### PR TITLE
Escape curly braces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Version 0.4.0
 
 To be released.
 
+- Curly braces can now be escaped with double curly braces
+
 
 Version 0.3.0
 -------------

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ logger.debug("Or you can use a function call: {value}.", () => {
 });
 ~~~~
 
+When using the function call, the way to log single curly braces `{`  is to
+double the brace `{{`:
+
+~~~~ typescript
+logger.debug("This logs {{single}} curly braces.");
+~~~~
+
 
 Categories
 ----------

--- a/logtape/logger.test.ts
+++ b/logtape/logger.test.ts
@@ -428,8 +428,16 @@ Deno.test("parseMessageTemplate()", () => {
     ["Hello, world!"],
   );
   assertEquals(
+    parseMessageTemplate("Hello, {{world}}!", { foo: 123 }),
+    ["Hello, {world}!"],
+  );
+  assertEquals(
     parseMessageTemplate("Hello, {foo}!", { foo: 123 }),
     ["Hello, ", 123, "!"],
+  );
+  assertEquals(
+    parseMessageTemplate("Hello, {{foo}}!", { foo: 123 }),
+    ["Hello, {foo}!"],
   );
   assertEquals(
     parseMessageTemplate("Hello, {bar}!", { foo: 123 }),

--- a/logtape/logger.test.ts
+++ b/logtape/logger.test.ts
@@ -455,6 +455,10 @@ Deno.test("parseMessageTemplate()", () => {
     parseMessageTemplate("Hello, {foo}, {bar}", { foo: 123, bar: 456 }),
     ["Hello, ", 123, ", ", 456, ""],
   );
+  assertEquals(
+    parseMessageTemplate("Hello, {{world!", { foo: 123 }),
+    ["Hello, {world!"],
+  );
 });
 
 Deno.test("renderMessage()", () => {


### PR DESCRIPTION
Addresses #1  - This commit allows using double curly braces to log `{{` single braces `{` in the function call syntax.

~~~~ typescript
logger.debug("This logs {{single}} curly braces.");

This logs {single} curly braces.
~~~~

