### PR TITLE
Fix bug allowing logtape to work under Node.js

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,9 @@ jobs:
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.x
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
     - run: deno task test --coverage=.cov --junit-path=.test-report.xml
     - uses: EnricoMi/publish-unit-test-result-action@v2
       if: runner.os == 'Linux' && always()
@@ -43,6 +46,9 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: dahlia/logtape
         file: .cov.lcov
+    - run: deno task dnt
+    - run: bun run ./test_runner.js
+      working-directory: ${{ github.workspace }}/npm/
     - run: deno task check
 
   publish:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 LogTape changelog
 =================
 
+Version 0.4.1
+-------------
+
+To be released.
+
+
 Version 0.4.0
 -------------
 

--- a/deno.json
+++ b/deno.json
@@ -25,6 +25,7 @@
     "test": "deno test --allow-read --allow-write",
     "coverage": "rm -rf coverage && deno task test --coverage && deno coverage --html coverage",
     "dnt": "deno run -A dnt.ts",
+    "test-all": "deno task test && deno task dnt && cd npm/ && bun run ./test_runner.js && cd ../",
     "hooks:install": "deno run --allow-read=deno.json,.git/hooks/ --allow-write=.git/hooks/ jsr:@hongminhee/deno-task-hooks",
     "hooks:pre-commit": "deno task check",
     "hooks:pre-push": "deno task test"

--- a/dnt.ts
+++ b/dnt.ts
@@ -29,6 +29,7 @@ await build({
   entryPoints: ["./logtape/mod.ts"],
   importMap: "./deno.json",
   mappings: {
+    "./logtape/filesink.jsr.ts": "./logtape/filesink.node.ts",
     "./logtape/filesink.deno.ts": "./logtape/filesink.node.ts",
   },
   shims: {

--- a/logtape/filesink.deno.ts
+++ b/logtape/filesink.deno.ts
@@ -24,8 +24,8 @@ export const denoDriver: RotatingFileSinkDriver<Deno.FsFile> = {
   closeSync(fd) {
     fd.close();
   },
-  statSync: Deno.statSync,
-  renameSync: Deno.renameSync,
+  statSync: globalThis?.Deno.statSync,
+  renameSync: globalThis?.Deno.renameSync,
 };
 
 /**

--- a/logtape/filesink.jsr.ts
+++ b/logtape/filesink.jsr.ts
@@ -1,0 +1,9 @@
+const filesink: Omit<typeof import("./filesink.deno.ts"), "denoDriver"> =
+  await ("Deno" in globalThis
+    ? import("./filesink.deno.ts")
+    : import("./filesink.node.ts"));
+
+export const getFileSink = filesink.getFileSink;
+export const getRotatingFileSink = filesink.getRotatingFileSink;
+
+// cSpell: ignore filesink

--- a/logtape/filesink.test.ts
+++ b/logtape/filesink.test.ts
@@ -26,7 +26,6 @@ Deno.test("getFileSink()", () => {
 
 Deno.test("getRotatingFileSink()", () => {
   const path = Deno.makeTempFileSync();
-  console.debug({ path });
   const sink: Sink & Disposable = getRotatingFileSink(path, {
     maxSize: 150,
   });

--- a/logtape/mod.ts
+++ b/logtape/mod.ts
@@ -7,6 +7,7 @@ export {
   type LoggerConfig,
   reset,
 } from "./config.ts";
+export { getFileSink, getRotatingFileSink } from "./filesink.jsr.ts";
 export {
   type Filter,
   type FilterLike,
@@ -32,13 +33,5 @@ export {
   type StreamSinkOptions,
   withFilter,
 } from "./sink.ts";
-
-const filesink: Omit<typeof import("./filesink.deno.ts"), "denoDriver"> =
-  await ("Deno" in globalThis
-    ? import("./filesink.deno.ts")
-    : import("./filesink.node.ts"));
-
-export const getFileSink = filesink.getFileSink;
-export const getRotatingFileSink = filesink.getRotatingFileSink;
 
 // cSpell: ignore filesink

--- a/logtape/mod.ts
+++ b/logtape/mod.ts
@@ -7,7 +7,6 @@ export {
   type LoggerConfig,
   reset,
 } from "./config.ts";
-export { getFileSink, getRotatingFileSink } from "./filesink.deno.ts";
 export {
   type Filter,
   type FilterLike,
@@ -33,5 +32,9 @@ export {
   type StreamSinkOptions,
   withFilter,
 } from "./sink.ts";
+export const { getFileSink, getRotatingFileSink } =
+  await ("Deno" in globalThis
+    ? import("./filesink.deno.ts")
+    : import("./filesink.node.ts"));
 
 // cSpell: ignore filesink

--- a/logtape/mod.ts
+++ b/logtape/mod.ts
@@ -32,9 +32,13 @@ export {
   type StreamSinkOptions,
   withFilter,
 } from "./sink.ts";
-export const { getFileSink, getRotatingFileSink } =
+
+const filesink: Omit<typeof import("./filesink.deno.ts"), "denoDriver"> =
   await ("Deno" in globalThis
     ? import("./filesink.deno.ts")
     : import("./filesink.node.ts"));
+
+export const getFileSink = filesink.getFileSink;
+export const getRotatingFileSink = filesink.getRotatingFileSink;
 
 // cSpell: ignore filesink


### PR DESCRIPTION
Fixes #3

This dynamic imports the filesink module based on if it is Deno or not, as well as safely access the Deno namespace for top level code that is evaluated when modules are loaded (which occurs when Cloudflare Workers create bundles).
