### PR TITLE
Allow category deep nesting

### DIFF
--- a/logtape/category.ts
+++ b/logtape/category.ts
@@ -1,0 +1,3 @@
+export type CategoryList = Readonly<string[]>;
+
+export type Category = string | CategoryList;

--- a/logtape/category.ts
+++ b/logtape/category.ts
@@ -1,3 +1,14 @@
-export type CategoryList = Readonly<string[]>;
+export type CategoryList = readonly string[];
 
-export type Category = string | CategoryList;
+export type Category = string | readonly Category[];
+
+export function getCategoryList(category: Category): CategoryList {
+  return deepFlatten(category);
+}
+
+function deepFlatten(arr: Category): string[] {
+  if (typeof arr === "string") return [arr];
+  return arr.flatMap((item) => (
+    typeof item === "string" ? [item] : deepFlatten(item)
+  ));
+}

--- a/logtape/config.ts
+++ b/logtape/config.ts
@@ -1,3 +1,4 @@
+import type { Category } from "./category.ts";
 import { type FilterLike, toFilter } from "./filter.ts";
 import type { LogLevel } from "./level.ts";
 import { LoggerImpl } from "./logger.ts";
@@ -40,7 +41,7 @@ export interface LoggerConfig<
    * The category of the logger.  If a string, it is equivalent to an array
    * with one element.
    */
-  category: string | string[];
+  category: Category;
 
   /**
    * The sink identifiers to use.

--- a/logtape/formatter.ts
+++ b/logtape/formatter.ts
@@ -1,3 +1,4 @@
+import type { CategoryList } from "./category.ts";
 import type { LogLevel } from "./level.ts";
 import util from "./nodeUtil.ts";
 import type { LogRecord } from "./record.ts";
@@ -154,7 +155,7 @@ export interface TextFormatterOptions {
    * If this is a function, it will be called with the category array and
    * should return a string, which will be used for rendering the category.
    */
-  category?: string | ((category: readonly string[]) => string);
+  category?: string | ((category: CategoryList) => string);
 
   /**
    * The format of the embedded values.

--- a/logtape/logger.test.ts
+++ b/logtape/logger.test.ts
@@ -37,6 +37,10 @@ Deno.test("getLogger()", () => {
     getLogger(["foo", "bar"]),
     getLogger().getChild("foo").getChild("bar"),
   );
+  assertStrictEquals(
+    getLogger(["foo", ["bar", ["baz", ["qux"]]]]),
+    getLogger().getChild("foo").getChild("bar").getChild("baz").getChild("qux"),
+  );
 });
 
 Deno.test("Logger.getChild()", () => {

--- a/logtape/logger.ts
+++ b/logtape/logger.ts
@@ -1,4 +1,8 @@
-import type { Category, CategoryList } from "./category.ts";
+import {
+  type Category,
+  type CategoryList,
+  getCategoryList,
+} from "./category.ts";
 import type { Filter } from "./filter.ts";
 import type { LogLevel } from "./level.ts";
 import type { LogRecord } from "./record.ts";
@@ -422,7 +426,6 @@ export class LoggerImpl implements Logger {
       (globalThis as GlobalRootLoggerRegistry)[globalRootLoggerSymbol] =
         rootLogger;
     }
-    if (typeof category === "string") return rootLogger.getChild(category);
     if (category.length === 0) return rootLogger;
     return rootLogger.getChild(category);
   }
@@ -438,7 +441,8 @@ export class LoggerImpl implements Logger {
   getChild(
     subcategory: Category,
   ): LoggerImpl {
-    const name = typeof subcategory === "string" ? subcategory : subcategory[0];
+    const subcategoryList = getCategoryList(subcategory);
+    const name = subcategoryList[0];
     const childRef = this.children[name];
     let child: LoggerImpl | undefined = childRef instanceof LoggerImpl
       ? childRef
@@ -449,10 +453,10 @@ export class LoggerImpl implements Logger {
         ? new WeakRef(child)
         : child;
     }
-    if (typeof subcategory === "string" || subcategory.length === 1) {
+    if (subcategoryList.length === 1) {
       return child;
     }
-    return child.getChild(subcategory.slice(1));
+    return child.getChild(subcategoryList.slice(1));
   }
 
   /**

--- a/logtape/mod.ts
+++ b/logtape/mod.ts
@@ -1,3 +1,4 @@
+export { type Category, type CategoryList } from "./category.ts";
 export {
   type Config,
   ConfigError,

--- a/logtape/record.ts
+++ b/logtape/record.ts
@@ -1,3 +1,4 @@
+import type { CategoryList } from "./category.ts";
 import type { LogLevel } from "./level.ts";
 
 /**
@@ -7,7 +8,7 @@ export interface LogRecord {
   /**
    * The category of the logger that produced the log record.
    */
-  readonly category: readonly string[];
+  readonly category: CategoryList;
 
   /**
    * The log level.


### PR DESCRIPTION
This PR is based on #21 and has only last commit as difference

Here we can use like this

```ts
getLogger(['app', ['deep', ['nested', ['string', ['array']]]]])
```