### PR TITLE
Allow Filter to Pass on Any True Result

### DIFF
--- a/logtape/logger.ts
+++ b/logtape/logger.ts
@@ -489,10 +489,10 @@ export class LoggerImpl implements Logger {
   }
 
   filter(record: LogRecord): boolean {
-    for (const filter of this.filters) {
-      if (!filter(record)) return false;
-    }
     if (this.filters.length < 1) return this.parent?.filter(record) ?? true;
+    else {
+      return this.filters.map((filter) => filter(record)).some((result) => result);
+    }
     return true;
   }
 


### PR DESCRIPTION
This PR changes current filter behavior.

Currently, filters reject a record at the first filter rejection.

From the docs on filters:
```
A filter is a function that filters log messages. A filter takes a log record and returns a boolean value. If the filter returns true, the log record is passed to the sinks; otherwise, the log record is discarded.
```

The change to the filter behavior is that now records will be passed if any filter statement passes.

This was generated by my desire to utilize a filter to pass a message regardless of configured log level.

Although this PR feels like an anti-pattern, figured I would commit back in the case this may be something others are looking for.

Example config I am interested in:

```
filters: {
    metrics(record) {
      console.log("metric")
      return record.properties.metric !== undefined
    }
},
loggers: [
  {
    category: ["production"],
    level: "warning",
    sinks: ["console"],
    filters: ["metrics"]
  },
]
```