### PR TITLE
Configure logo for docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -29,9 +29,11 @@ if (process.env.EXTRA_NAV_TEXT && process.env.EXTRA_NAV_LINK) {
   ];
 }
 
-let plausibleScript: [string, Record<string, string>][] = [];
+const head: [string, Record<string, string>][] = [
+  ["link", { rel: "icon", href: "/logtape.svg", }]
+];
 if (process.env.PLAUSIBLE_DOMAIN) {
-  plausibleScript = [
+  head.push(
     [
       "script",
       {
@@ -40,7 +42,7 @@ if (process.env.PLAUSIBLE_DOMAIN) {
         src: "https://plausible.io/js/script.outbound-links.js",
       },
     ],
-  ];
+  );
 }
 
 const MANUAL = {
@@ -104,7 +106,7 @@ export default defineConfig({
       pattern: "https://github.com/dahlia/logtape/edit/main/docs/:path",
     },
   },
-  head: plausibleScript,
+  head: head,
   markdown: {
     codeTransformers: [
       transformerTwoslash({


### PR DESCRIPTION
If it was your intention that the logtape docs shouldn't have a logo, please ignore this pull request 🙏🏻.

<img width="224" alt="image" src="https://github.com/user-attachments/assets/22889931-e0db-40f7-8596-256c2e0e780b" />
