### PR TITLE
LogTape should not buffer console logs in benchmarks

### DIFF
--- a/benchmarks/console.ts
+++ b/benchmarks/console.ts
@@ -17,6 +17,7 @@ function mocklog(which: "stdout" | "console.info") {
   let unmock: () => void;
   if (which === "stdout") {
     const origWrite = process.stdout.write.bind(process.stdout);
+    // deno-lint-ignore no-explicit-any
     process.stdout.write = (chunk: any, cb: any) => {
       invokations++;
       return origWrite(chunk, cb);
@@ -26,6 +27,7 @@ function mocklog(which: "stdout" | "console.info") {
     };
   } else {
     const origInfo = globalThis.console.info.bind(globalThis.console);
+    // deno-lint-ignore no-explicit-any
     globalThis.console.info = (...args: any[]) => {
       invokations++;
       return origInfo(...args);
@@ -47,7 +49,7 @@ function mocklog(which: "stdout" | "console.info") {
         throw new Error(
           `${
             iterations - invokations
-          } invokations missing, out of ${iterations} iterations.`
+          } invokations missing, out of ${iterations} iterations.`,
         );
       }
     },

--- a/benchmarks/console.ts
+++ b/benchmarks/console.ts
@@ -19,7 +19,7 @@ function mocklog(which: "stdout" | "console.info") {
     const origWrite = process.stdout.write.bind(process.stdout);
     process.stdout.write = (chunk: any, cb: any) => {
       invokations++;
-      return origWrite(chunk);
+      return origWrite(chunk, cb);
     };
     unmock = () => {
       process.stdout.write = origWrite;

--- a/benchmarks/console.ts
+++ b/benchmarks/console.ts
@@ -14,7 +14,7 @@ summary(() => {
   bench("LogTape", async function* () {
     await logtape.configure({
       sinks: {
-        console: logtape.getConsoleSink({ nonBlocking: true }),
+        console: logtape.getConsoleSink({ nonBlocking: false }),
       },
       loggers: [
         { category: [], sinks: ["console"] },

--- a/benchmarks/console.ts
+++ b/benchmarks/console.ts
@@ -135,9 +135,9 @@ summary(() => {
 
 let reportOutput = "";
 await run({
-  // print(s) {
-  //   reportOutput += `${s}\n`;
-  // },
+  print(s) {
+    reportOutput += `${s}\n`;
+  },
 });
 
 process.on("exit", () => {

--- a/benchmarks/console.ts
+++ b/benchmarks/console.ts
@@ -55,31 +55,6 @@ function mocklog(which: "stdout" | "console.info") {
   };
 }
 
-function counter() {
-  let iterations = 0;
-  let invokations = 0;
-  return {
-    iter(cb: () => void) {
-      return () => {
-        iterations++;
-        cb();
-      };
-    },
-    invok() {
-      invokations++;
-    },
-    check() {
-      if (iterations > invokations) {
-        throw new Error(
-          `${
-            iterations - invokations
-          } invokations missing, out of ${iterations} iterations.`
-        );
-      }
-    },
-  };
-}
-
 summary(() => {
   bench("LogTape", async function* () {
     const { count, unmock, check } = mocklog("console.info");
@@ -160,9 +135,9 @@ summary(() => {
 
 let reportOutput = "";
 await run({
-  print(s) {
-    reportOutput += `${s}\n`;
-  },
+  // print(s) {
+  //   reportOutput += `${s}\n`;
+  // },
 });
 
 process.on("exit", () => {

--- a/benchmarks/console.ts
+++ b/benchmarks/console.ts
@@ -10,45 +10,121 @@ import { pino } from "pino";
 import signale from "signale";
 import winston from "winston";
 
+function mocklog(which: "stdout" | "console.info") {
+  let iterations = 0;
+  let invokations = 0;
+
+  let unmock: () => void;
+  if (which === "stdout") {
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: any, cb: any) => {
+      invokations++;
+      return origWrite(chunk);
+    };
+    unmock = () => {
+      process.stdout.write = origWrite;
+    };
+  } else {
+    const origInfo = globalThis.console.info.bind(globalThis.console);
+    globalThis.console.info = (...args: any[]) => {
+      invokations++;
+      return origInfo(...args);
+    };
+    unmock = () => {
+      globalThis.console.info = origInfo;
+    };
+  }
+
+  return {
+    count(cb: () => void) {
+      return () => {
+        iterations++;
+        cb();
+      };
+    },
+    check() {
+      if (iterations > invokations) {
+        throw new Error(
+          `${
+            iterations - invokations
+          } invokations missing, out of ${iterations} iterations.`
+        );
+      }
+    },
+    unmock,
+  };
+}
+
+function counter() {
+  let iterations = 0;
+  let invokations = 0;
+  return {
+    iter(cb: () => void) {
+      return () => {
+        iterations++;
+        cb();
+      };
+    },
+    invok() {
+      invokations++;
+    },
+    check() {
+      if (iterations > invokations) {
+        throw new Error(
+          `${
+            iterations - invokations
+          } invokations missing, out of ${iterations} iterations.`
+        );
+      }
+    },
+  };
+}
+
 summary(() => {
   bench("LogTape", async function* () {
+    const { count, unmock, check } = mocklog("console.info");
     await logtape.configure({
-      sinks: {
-        console: logtape.getConsoleSink({ nonBlocking: false }),
-      },
-      loggers: [
-        { category: [], sinks: ["console"] },
-      ],
+      sinks: { console: logtape.getConsoleSink({ nonBlocking: false }) },
+      loggers: [{ category: [], sinks: ["console"] }],
       reset: true,
     });
     const logger = logtape.getLogger();
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
     await logtape.reset();
   });
 
   bench("winston", function* () {
+    const { count, unmock, check } = mocklog("stdout");
     const logger = winston.createLogger({
-      transports: [
-        new winston.transports.Console(),
-      ],
+      transports: [new winston.transports.Console()],
     });
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
   });
 
   bench("pino", function* () {
+    const { count, unmock, check } = mocklog("stdout");
     const logger = pino();
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
   });
 
   bench("bunyan", function* () {
+    const { count, unmock, check } = mocklog("stdout");
     const logger = bunyan.createLogger({
       name: "benchmarks",
-      stream: process.stdout,
     });
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
   });
 
   bench("log4js", function* () {
+    const { count, unmock, check } = mocklog("stdout");
     log4js.configure({
       appenders: {
         console: { type: "console" },
@@ -58,19 +134,27 @@ summary(() => {
       },
     });
     const logger = log4js.getLogger();
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
   });
 
   bench("Signale", function* () {
+    const { count, unmock, check } = mocklog("stdout");
     const logger = new signale.Signale();
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
   });
 
   bench("Hive Logger", function* () {
+    const { count, unmock, check } = mocklog("console.info");
     const logger = new hiveLogger.Logger({
       writers: [new hiveLogger.ConsoleLogWriter()],
     });
-    yield () => logger.info("Test log message.");
+    yield count(() => logger.info("Test log message."));
+    unmock();
+    check();
   });
 });
 


### PR DESCRIPTION
Making the benchmark more[^1] fair since other loggers don't buffer but write synchrnously. 

Also I didn't update the results since we're running on different machines. How would you like me to proceed?

[^1]: "more" because some other loggers like pino and bunyan write to stdout which is faster than console.logs