### PR TITLE
bugfix: don't use process.on if not available

### DIFF
--- a/logtape/config.ts
+++ b/logtape/config.ts
@@ -304,7 +304,10 @@ function configureInternal<
   if ("process" in globalThis && !("Deno" in globalThis)) {
     // @ts-ignore: It's fine to use process in Node
     // deno-lint-ignore no-process-global
-    process.on("exit", allowAsync ? dispose : disposeSync);
+    if (process.on) {
+      // deno-lint-ignore no-process-global
+      process.on("exit", allowAsync ? dispose : disposeSync);
+    }
   } else {
     // @ts-ignore: It's fine to addEventListener() on the browser/Deno
     addEventListener("unload", allowAsync ? dispose : disposeSync);


### PR DESCRIPTION
Fixes #64 and also on Vercel edge functions