### PR TITLE
New config for the "pretty" formatter to always render structure data

### DIFF
--- a/pretty/formatter.test.ts
+++ b/pretty/formatter.test.ts
@@ -1,9 +1,9 @@
 import { suite } from "@alinea/suite";
+import type { LogRecord } from "@logtape/logtape";
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
 import { assertMatch } from "@std/assert/match";
 import { assertStringIncludes } from "@std/assert/string-includes";
-import type { LogRecord } from "@logtape/logtape";
 import {
   type CategoryColorMap,
   getPrettyFormatter,
@@ -17,6 +17,7 @@ function createLogRecord(
   category: string[],
   message: LogRecord["message"],
   timestamp: number = Date.now(),
+  properties: Record<string, unknown> = {}
 ): LogRecord {
   // Convert message array to template strings format for rawMessage
   const rawMessage = typeof message === "string"
@@ -28,7 +29,7 @@ function createLogRecord(
     category,
     message,
     rawMessage,
-    properties: {},
+    properties,
     timestamp,
   };
 }
@@ -801,4 +802,20 @@ test("getPrettyFormatter() with multiline interpolated values (no align)", () =>
       );
     }
   }
+});
+
+test("renderStructuredValues set to true", () => {
+  const formatter = getPrettyFormatter({
+    renderStructuredValues: true,
+    inspectOptions: { colors: false }
+  });
+
+  const record = createLogRecord("info", ["test"], ['FooBar'], Date.now(), { foo: 'bar', bar: 'baz' });
+  const result = formatter(record);
+
+  // Should contain multiple lines due to wrapping
+  const lines = result.split("\n");
+  assert(lines.length == 3); // Normal log line + formatted properties + newline
+  assert(lines[1].trim() === "{ foo: 'bar', bar: 'baz' }");
+
 });

--- a/pretty/formatter.ts
+++ b/pretty/formatter.ts
@@ -568,6 +568,22 @@ export interface PrettyFormatterOptions
   };
 
   /**
+   * Configuration to always render structured data.
+   *
+   * If set to true, any structured data that is logged will
+   * always be rendered. This can be very verbose. Make sure
+   * to configure `inspectOptions` properly for your usecase.
+   *
+   * @example
+   * ```typescript
+   * renderStructuredValues: true
+   * ```
+   *
+   * @default `false`
+   */
+  readonly renderStructuredValues?: boolean;
+
+  /**
    * Enable word wrapping for long messages.
    *
    * When enabled, long messages will be wrapped at the specified width,
@@ -662,6 +678,7 @@ export function getPrettyFormatter(
     colors: useColors = true,
     align = true,
     inspectOptions = {},
+    renderStructuredValues = false,
     wordWrap = true,
   } = options;
 
@@ -875,6 +892,7 @@ export function getPrettyFormatter(
     let formattedCategory = categoryStr;
     let formattedMessage = message;
     let formattedTimestamp = "";
+    let formattedStructuredValues = "";
 
     if (useColors) {
       // Apply level color and style
@@ -907,6 +925,13 @@ export function getPrettyFormatter(
       }
     }
 
+    if (renderStructuredValues) {
+      formattedStructuredValues = inspect(record.properties, {
+        colors: useColors,
+        ...inspectOptions,
+      });
+    }
+
     // Build the final output with alignment
     if (align) {
       // Calculate padding accounting for ANSI escape sequences
@@ -936,6 +961,11 @@ export function getPrettyFormatter(
         );
       }
 
+      if (renderStructuredValues) {
+        const paddedStructuredValues = formattedStructuredValues.padStart(categoryWidth + categoryColorLength + levelWidth);
+        return result + "\n" + paddedStructuredValues + "\n";
+      }
+
       return result + "\n";
     } else {
       let result =
@@ -948,6 +978,10 @@ export function getPrettyFormatter(
           wordWrapEnabled ? wordWrapWidth : Infinity,
           message,
         );
+      }
+
+      if (renderStructuredValues) {
+        return result + "\n" + formattedStructuredValues + "\n";
       }
 
       return result + "\n";


### PR DESCRIPTION
see discussion here: https://github.com/dahlia/logtape/issues/69 