### PR TITLE
Relax Sentry client type in getSentrySink, preserve template metadata, and remove node:util import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,26 @@ To be released.
  -  Added `PrettyFormatterOptions.properties` option for displaying
     `LogRecord.properties` (structured data).  [[#69], [#70] by Matthias Feist]
 
+### @logtape/sentry
+
+ - Changed the type of the `getSentrySink()` function to accept any Sentry
+   client implementing the public capture APIs (was
+   `(client?: Client) => Sink`). Introduced a structural `SentryClientLike`
+   interface to avoid nominal type conflicts across differing `@sentry/core`
+   instances. [[#80] by Sora Morimoto]
+
+ - Fixed preservation of Sentry template metadata by returning a
+   `ParameterizedString` from the internal `getParameterizedString()` so that
+   `captureMessage` receives the templated form and breadcrumbs/formatting can
+   leverage `__sentry_template_*` metadata. [[#80] by Sora Morimoto]
+
+ - Fixed cross-runtime compatibility by removing an unnecessary `node:util`
+   type import referenced only by documentation, avoiding module resolution
+   issues outside Node.js. [[#80] by Sora Morimoto]
+
 [#69]: https://github.com/dahlia/logtape/issues/69
 [#70]: https://github.com/dahlia/logtape/pull/70
+[#80]: https://github.com/dahlia/logtape/pull/80
 
 
 Version 1.0.4

--- a/packages/sentry/src/mod.ts
+++ b/packages/sentry/src/mod.ts
@@ -27,7 +27,7 @@ function getParameterizedString(record: LogRecord): ParameterizedString {
   const paramStr = new String(result) as ParameterizedString;
   paramStr.__sentry_template_string__ = tplString;
   paramStr.__sentry_template_values__ = tplValues;
-  return result;
+  return paramStr;
 }
 
 /**

--- a/packages/sentry/src/mod.ts
+++ b/packages/sentry/src/mod.ts
@@ -6,8 +6,6 @@ import {
   type Scope,
   type SeverityLevel,
 } from "@sentry/core";
-// deno-lint-ignore no-unused-vars
-import type util from "node:util";
 
 function getParameterizedString(record: LogRecord): ParameterizedString {
   let result = "";

--- a/packages/sentry/src/mod.ts
+++ b/packages/sentry/src/mod.ts
@@ -1,5 +1,11 @@
 import type { LogRecord, Sink } from "@logtape/logtape";
-import { type Client, getClient, type ParameterizedString } from "@sentry/core";
+import {
+  type EventHint,
+  getClient,
+  type ParameterizedString,
+  type Scope,
+  type SeverityLevel,
+} from "@sentry/core";
 // deno-lint-ignore no-unused-vars
 import type util from "node:util";
 
@@ -25,8 +31,8 @@ function getParameterizedString(record: LogRecord): ParameterizedString {
 }
 
 /**
- * A platform-specific inspect function.  In Deno, this is {@link Deno.inspect},
- * and in Node.js/Bun it is {@link util.inspect}.  If neither is available, it
+ * A platform-specific inspect function. In Deno, this is {@link Deno.inspect},
+ * and in Node.js/Bun it is {@link util.inspect}. If neither is available, it
  * falls back to {@link JSON.stringify}.
  *
  * @param value The value to inspect.
@@ -47,13 +53,27 @@ const inspect: (value: unknown) => string =
     ? globalThis.util.inspect
     : JSON.stringify;
 
+interface SentryClientLike {
+  captureException: (
+    exception: unknown,
+    hint?: EventHint,
+    scope?: Scope,
+  ) => string;
+  captureMessage: (
+    message: ParameterizedString,
+    level?: SeverityLevel,
+    hint?: EventHint,
+    scope?: Scope,
+  ) => string;
+}
+
 /**
  * Gets a LogTape sink that sends logs to Sentry.
- * @param client The Sentry client.  If omitted, the global default client is
+ * @param client The Sentry client. If omitted, the global default client is
  *               used.
  * @returns A LogTape sink that sends logs to Sentry.
  */
-export function getSentrySink(client?: Client): Sink {
+export function getSentrySink(client?: SentryClientLike): Sink {
   return (record: LogRecord) => {
     const message = getParameterizedString(record);
     if (client == null) client = getClient();


### PR DESCRIPTION
### Why

Projects using `@sentry/aws-serverless` (and other SDKs returning `NodeClient`) hit nominal type incompatibilities with `@sentry/core`’s `Client`, especially across multiple installed versions. The sink only needs the public capture APIs, so coupling to `Client` is unnecessary and brittle.

### What changed

- Introduced a structural `SentryClientLike` interface (using `EventHint`, `Scope`, `SeverityLevel`, `ParameterizedString`) and updated `getSentrySink` to accept it, avoiding nominal conflicts while reflecting the public API shape.
- Ensured template metadata reaches Sentry by returning `ParameterizedString` from `getParameterizedString`, preserving `__sentry_template_*`.
- Removed the JSDoc-only `node:util` type import to keep cross-runtime compatibility.
- Updated `CHANGES.md` accordingly.

### Impact

- Broader compatibility with Sentry clients (including `NodeClient`) without relying on single-version deduplication.
- No runtime behaviour change; message formatting and breadcrumbs improve via preserved template metadata.
- Cross-runtime friendliness maintained (Deno/Node/Bun/browsers).

### Quality

- All checks pass: type-check, lint, format, and tests.