### PR TITLE
Implement syslog level mappings in formatter

### DIFF
--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -368,6 +368,14 @@ const levelRenderersCache = {
     error: "e",
     fatal: "f",
   } as const,
+  syslog: {
+    trace: "<7>",
+    debug: "<7>",
+    info: "<6>",
+    warning: "<4>",
+    error: "<3>",
+    fatal: "<0>",
+  } as const,
 } as const;
 
 /**
@@ -435,6 +443,8 @@ export function getTextFormatter(
       return (level: LogLevel): string => levelRenderersCache.L[level];
     } else if (levelOption === "l") {
       return (level: LogLevel): string => levelRenderersCache.l[level];
+    } else if (levelOption === "syslog") {
+      return (level: LogLevel): string => levelRenderersCache.syslog[level];
     } else {
       return levelOption;
     }

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -374,7 +374,7 @@ const levelRenderersCache = {
     info: "<6>",
     warning: "<4>",
     error: "<3>",
-    fatal: "<0>",
+    fatal: "<1>",
   } as const,
 } as const;
 


### PR DESCRIPTION
Added syslog level mappings for trace, debug, info, warning, error, and fatal.

These are documented here: https://www.freedesktop.org/software/systemd/man/latest/sd-daemon.html#

And they are can be used in Systemd via [this](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#SyslogLevelPrefix=) parameter.