### PR TITLE
Fix: prevent auto meta‑logger message when meta logger is already con…

### DIFF
--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -327,8 +327,9 @@ function configureInternal<
   const meta = LoggerImpl.getLogger(["logtape", "meta"]);
   if (!metaConfigured) {
     meta.sinks.push(getConsoleSink());
-  }
-
+    return;
+  } 
+  
   meta.info(
     "LogTape loggers are configured.  Note that LogTape itself uses the meta " +
       "logger, which has category {metaLoggerCategory}.  The meta logger " +


### PR DESCRIPTION
This PR fixes an issue where LogTape prints the meta‑logger auto‑configuration message even when the user has explicitly configured the meta logger: https://github.com/dahlia/logtape/issues/141