### PR TITLE
Add agent skill for AI coding assistants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,11 +37,17 @@ To be released.
     `Logger.error()`, and `Logger.fatal()`, including contextual loggers
     created with `Logger.with()`.  [[#143], [#145]]
 
+ -  Added agent skill for AI coding assistants ([Agent Skills] standard).
+    The skill is bundled inside the npm package and teaches AI agents how to
+    use LogTape correctly.  [[#147]]
+
+[Agent Skills]: https://agentskills.io/
 [#137]: https://github.com/dahlia/logtape/issues/137
 [#138]: https://github.com/dahlia/logtape/pull/138
 [#140]: https://github.com/dahlia/logtape/issues/140
 [#143]: https://github.com/dahlia/logtape/issues/143
 [#145]: https://github.com/dahlia/logtape/pull/145
+[#147]: https://github.com/dahlia/logtape/issues/147
 
 ### @logtape/pretty
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -175,6 +175,7 @@ const MANUAL = {
     { text: "Using in libraries", link: "/manual/library" },
     { text: "Debugging", link: "/manual/debug" },
     { text: "Testing", link: "/manual/testing" },
+    { text: "LLM integration", link: "/manual/llm" },
   ],
 };
 

--- a/docs/manual/install.md
+++ b/docs/manual/install.md
@@ -66,3 +66,18 @@ bun add @logtape/logtape@dev
 
 [JSR]: https://jsr.io/@logtape/logtape
 [npm]: https://www.npmjs.com/package/@logtape/logtape
+
+
+Setting up for AI coding assistants
+-----------------------------------
+
+LogTape bundles an [Agent Skills] skill inside the npm package.  If you use
+AI coding assistants like [Claude Code], [GitHub Copilot], [Cursor], or
+[Windsurf], you can expose the skill so that they learn LogTape's best practices
+automatically.  See [*LLM integration*](./llm.md) for setup instructions.
+
+[Agent Skills]: https://agentskills.io/
+[Claude Code]: https://claude.com/claude-code
+[GitHub Copilot]: https://github.com/features/copilot
+[Cursor]: https://cursor.com/
+[Windsurf]: https://windsurf.com/

--- a/docs/manual/llm.md
+++ b/docs/manual/llm.md
@@ -77,7 +77,7 @@ skills and symlinks them into the appropriate agent directories.
 
 3.  Run `npm install` (or your package manager's equivalent).  This symlinks
     skills from *node\_modules* into the appropriate agent directories
-    (e.g., *.claude/skills/*, *.cursor/rules/*).
+    (e.g., *.claude/skills/*, *.cursor/skills/*).
 
 4.  Add the generated symlinks to your *.gitignore*:
 

--- a/docs/manual/llm.md
+++ b/docs/manual/llm.md
@@ -3,8 +3,8 @@ LLM integration
 
 LogTape ships with built-in support for AI coding assistants through the
 [Agent Skills] standard.  This means tools like [Claude Code], [GitHub Copilot],
-[Cursor], [Windsurf], and others can automatically learn how to use LogTape
-correctly when working on your project.
+[Cursor], [Windsurf], and [many others][Agent Skills] can automatically learn
+how to use LogTape correctly when working on your project.
 
 [Agent Skills]: https://agentskills.io/
 [Claude Code]: https://claude.com/claude-code
@@ -20,9 +20,11 @@ The bundled agent skill teaches AI assistants:
 
  -  How to get loggers with hierarchical categories
  -  The structured message syntax (named placeholders, not string interpolation)
- -  Configuration rules (`configure()` is app-only, must be `await`ed)
+ -  Configuration rules (`configure()` and `configureSync()`)
  -  The library author rule (never call `configure()` in library code)
- -  Context management with `with()` and `lazy()`
+ -  Context management with `with()`, `withContext()`, and `lazy()`
+ -  Sink and formatter setup
+ -  Adaptor integration for existing loggers (winston, Pino, log4js)
  -  Testing patterns
  -  Common mistakes to avoid
 
@@ -32,17 +34,36 @@ library for general-purpose LLM consumption.
 [llms.txt]: https://logtape.org/llms.txt
 
 
-Setting up with npm (recommended)
----------------------------------
+Setting up with skills-npm
+--------------------------
 
-The skill is bundled inside the `@logtape/logtape` npm package.  To expose it
-to your AI coding assistant, use [skills-npm]:
+[skills-npm] by Anthony Fu scans *node\_modules* for packages that declare
+skills and symlinks them into the appropriate agent directories.
 
 1.  Install *skills-npm* as a dev dependency:
 
-    ~~~~ bash
+    :::code-group
+
+    ~~~~ bash [npm]
     npm install -D skills-npm
     ~~~~
+
+
+    ~~~~ bash [pnpm]
+    pnpm add -D skills-npm
+    ~~~~
+
+
+    ~~~~ bash [Yarn]
+    yarn add -D skills-npm
+    ~~~~
+
+
+    ~~~~ bash [Bun]
+    bun add -D skills-npm
+    ~~~~
+
+    :::
 
 2.  Add a `prepare` script to your *package.json*:
 
@@ -58,7 +79,7 @@ to your AI coding assistant, use [skills-npm]:
     skills from *node\_modules* into the appropriate agent directories
     (e.g., *.claude/skills/*, *.cursor/rules/*).
 
-4.  Add `skills/npm-*` to your *.gitignore*:
+4.  Add the generated symlinks to your *.gitignore*:
 
     ~~~~ text
     skills/npm-*
@@ -68,6 +89,80 @@ After this one-time setup, the skill stays in sync with the installed version
 of LogTape.  Every `npm install` refreshes the symlinks automatically.
 
 [skills-npm]: https://github.com/antfu/skills-npm
+
+
+Setting up with npm-agentskills
+-------------------------------
+
+[npm-agentskills] by onmax is another tool that discovers agent skills from
+npm packages.  It offers a CLI and a Nuxt module.
+
+[npm-agentskills]: https://github.com/onmax/npm-agentskills
+
+### CLI usage
+
+~~~~ bash
+npx agents export --target claude
+~~~~
+
+You can also export to other agents:
+
+~~~~ bash
+npx agents export --target cursor
+npx agents export --target codex
+~~~~
+
+To see all discovered skills:
+
+~~~~ bash
+npx agents list
+~~~~
+
+### Automatic setup via postinstall
+
+Add to your *package.json*:
+
+~~~~ json
+{
+  "scripts": {
+    "postinstall": "agents export --target claude"
+  }
+}
+~~~~
+
+### Nuxt integration
+
+For Nuxt projects, add the module and skills are discovered automatically
+when running `nuxi prepare` or `nuxi dev`.
+
+
+Manual setup
+------------
+
+If you prefer not to use a discovery tool, you can set up the skill manually
+for your specific AI coding assistant.
+
+### Claude Code
+
+Copy or symlink the skill directory into your project:
+
+~~~~ bash
+mkdir -p .claude/skills
+cp -r node_modules/@logtape/logtape/skills/logtape .claude/skills/logtape
+~~~~
+
+### Cursor
+
+~~~~ bash
+mkdir -p .cursor/skills
+cp -r node_modules/@logtape/logtape/skills/logtape .cursor/skills/logtape
+~~~~
+
+### Other agents
+
+Most Agent Skills-compatible tools look for skills in a directory like
+*.\<agent\>/skills/* in your project root.  Consult your tool's documentation
+for the exact path.
 
 
 Setting up for Deno
@@ -94,11 +189,11 @@ field:
 }
 ~~~~
 
-When *skills-npm* runs, it reads this field from every package in
-*node\_modules* and creates symlinks so that agent tools can discover and load
-the skills.  The skill's `description` field in its frontmatter tells the agent
-*when* to activate it, so it loads automatically whenever the agent is working
-on logging-related code.
+When a discovery tool like *skills-npm* or *npm-agentskills* runs, it reads
+this field from every package in *node\_modules* and copies or symlinks the
+skill directories so that agent tools can discover and load them.  The skill's
+`description` field in its frontmatter tells the agent *when* to activate it,
+so it loads automatically whenever the agent is working on logging-related code.
 
 > [!NOTE]
 > The `agents` field is purely metadata.  It does not add any runtime

--- a/docs/manual/llm.md
+++ b/docs/manual/llm.md
@@ -1,0 +1,119 @@
+LLM integration
+===============
+
+LogTape ships with built-in support for AI coding assistants through the
+[Agent Skills] standard.  This means tools like [Claude Code], [GitHub Copilot],
+[Cursor], [Windsurf], and others can automatically learn how to use LogTape
+correctly when working on your project.
+
+[Agent Skills]: https://agentskills.io/
+[Claude Code]: https://claude.com/claude-code
+[GitHub Copilot]: https://github.com/features/copilot
+[Cursor]: https://cursor.com/
+[Windsurf]: https://windsurf.com/
+
+
+What the skill provides
+-----------------------
+
+The bundled agent skill teaches AI assistants:
+
+ -  How to get loggers with hierarchical categories
+ -  The structured message syntax (named placeholders, not string interpolation)
+ -  Configuration rules (`configure()` is app-only, must be `await`ed)
+ -  The library author rule (never call `configure()` in library code)
+ -  Context management with `with()` and `lazy()`
+ -  Testing patterns
+ -  Common mistakes to avoid
+
+This complements the [llms.txt] file, which provides a broad overview of the
+library for general-purpose LLM consumption.
+
+[llms.txt]: https://logtape.org/llms.txt
+
+
+Setting up with npm (recommended)
+---------------------------------
+
+The skill is bundled inside the `@logtape/logtape` npm package.  To expose it
+to your AI coding assistant, use [skills-npm]:
+
+1.  Install *skills-npm* as a dev dependency:
+
+    ~~~~ bash
+    npm install -D skills-npm
+    ~~~~
+
+2.  Add a `prepare` script to your *package.json*:
+
+    ~~~~ json
+    {
+      "scripts": {
+        "prepare": "skills-npm"
+      }
+    }
+    ~~~~
+
+3.  Run `npm install` (or your package manager's equivalent).  This symlinks
+    skills from *node\_modules* into the appropriate agent directories
+    (e.g., *.claude/skills/*, *.cursor/rules/*).
+
+4.  Add `skills/npm-*` to your *.gitignore*:
+
+    ~~~~ text
+    skills/npm-*
+    ~~~~
+
+After this one-time setup, the skill stays in sync with the installed version
+of LogTape.  Every `npm install` refreshes the symlinks automatically.
+
+[skills-npm]: https://github.com/antfu/skills-npm
+
+
+Setting up for Deno
+-------------------
+
+For Deno users who install LogTape from JSR, the skill file is accessible
+directly from the repository.  You can reference it by URL or copy it into
+your project's skill directory manually.
+
+
+How it works
+------------
+
+The `@logtape/logtape` *package.json* declares the skill using the `agents`
+field:
+
+~~~~ json
+{
+  "agents": {
+    "skills": [
+      { "name": "logtape", "path": "./skills/logtape" }
+    ]
+  }
+}
+~~~~
+
+When *skills-npm* runs, it reads this field from every package in
+*node\_modules* and creates symlinks so that agent tools can discover and load
+the skills.  The skill's `description` field in its frontmatter tells the agent
+*when* to activate it, so it loads automatically whenever the agent is working
+on logging-related code.
+
+> [!NOTE]
+> The `agents` field is purely metadata.  It does not add any runtime
+> dependencies or affect how LogTape works.
+
+
+Also available: llms.txt
+------------------------
+
+LogTape's documentation site also generates an [llms.txt] file following the
+[llms.txt standard].  This file provides a comprehensive overview of the entire
+library and is useful for general-purpose LLM tools that support the standard.
+
+While the agent skill focuses on *how to write code* with LogTape (practical
+rules and common mistakes), *llms.txt* focuses on *what LogTape is* (API
+surface, concepts, and documentation links).
+
+[llms.txt standard]: https://llmstxt.org/

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -66,8 +66,14 @@
   },
   "sideEffects": false,
   "files": [
-    "dist/"
+    "dist/",
+    "skills/"
   ],
+  "agents": {
+    "skills": [
+      { "name": "logtape", "path": "./skills/logtape" }
+    ]
+  },
   "devDependencies": {
     "@alinea/suite": "catalog:",
     "@std/assert": "catalog:",

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -388,6 +388,70 @@ See <https://logtape.org/manual/sinks> and
 <https://logtape.org/manual/formatters> for details.
 
 
+Data redaction
+--------------
+
+Use `@logtape/redaction` to prevent sensitive data from reaching log output.
+
+### Pattern-based redaction (scans formatted text)
+
+Wrap a formatter with `redactByPattern()` to catch data like emails, credit
+card numbers, or JWTs anywhere in the log output:
+
+~~~~ typescript
+import { defaultConsoleFormatter, getConsoleSink } from "@logtape/logtape";
+import {
+  EMAIL_ADDRESS_PATTERN,
+  JWT_PATTERN,
+  redactByPattern,
+} from "@logtape/redaction";
+
+const sink = getConsoleSink({
+  formatter: redactByPattern(defaultConsoleFormatter, [
+    EMAIL_ADDRESS_PATTERN,
+    JWT_PATTERN,
+  ]),
+});
+~~~~
+
+Built-in patterns: `EMAIL_ADDRESS_PATTERN`, `CREDIT_CARD_NUMBER_PATTERN`,
+`JWT_PATTERN`, `US_SSN_PATTERN`, `KR_RRN_PATTERN`.
+
+### Field-based redaction (removes/replaces properties by name)
+
+Wrap a sink with `redactByField()` to strip sensitive fields from structured
+log data before it reaches the sink:
+
+~~~~ typescript
+import { getConsoleSink } from "@logtape/logtape";
+import { redactByField } from "@logtape/redaction";
+
+// Uses DEFAULT_REDACT_FIELDS (password, secret, token, etc.)
+const sink = redactByField(getConsoleSink());
+
+// Or customize with replacement instead of removal
+const sink2 = redactByField(getConsoleSink(), {
+  fieldPatterns: [/password/i, /secret/i, /api[-_]?key/i],
+  action: () => "[REDACTED]",
+});
+~~~~
+
+### Combining both for maximum security
+
+~~~~ typescript
+const sink = redactByField(
+  getConsoleSink({
+    formatter: redactByPattern(defaultConsoleFormatter, [
+      EMAIL_ADDRESS_PATTERN,
+      JWT_PATTERN,
+    ]),
+  }),
+);
+~~~~
+
+See <https://logtape.org/manual/redaction> for details.
+
+
 Adaptors for existing loggers
 -----------------------------
 

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: logtape
+description: >
+  Use this skill when writing any code that uses LogTape for logging in
+  JavaScript or TypeScript.  Covers getting loggers, the structured message
+  syntax, configuration, library author rules, context, lazy evaluation,
+  testing, and common mistakes to avoid.  Trigger whenever the user is
+  adding logging to a project, debugging log output, or integrating LogTape
+  with a framework.
+license: MIT
+---
+
+LogTape skill for AI coding assistants
+======================================
+
+LogTape is a zero-dependency, library-first logging framework for JavaScript
+and TypeScript that works across Deno, Node.js, Bun, browsers, and edge
+functions.
+
+Full documentation: <https://logtape.org/>
+
+
+Getting a logger
+----------------
+
+Always use `getLogger()` with an **array** category to enable hierarchical
+filtering.  The hierarchy works like a path: a parent category's configuration
+applies to all children.
+
+~~~~ typescript
+import { getLogger } from "@logtape/logtape";
+
+// Good: array form enables hierarchical filtering
+const logger = getLogger(["my-app", "users", "auth"]);
+
+// Acceptable shorthand for a single-segment category
+const rootLogger = getLogger("my-app");
+~~~~
+
+Choose category segments that reflect your module structure so that operators
+can selectively enable/disable logging per subsystem.
+
+See <https://logtape.org/manual/categories> for details.
+
+
+Structured messages
+-------------------
+
+Use **named placeholders** with a properties object.  This keeps messages
+parseable and properties searchable:
+
+~~~~ typescript
+// Correct: structured message with named placeholders
+logger.info("User {userId} logged in from {ip}", { userId, ip });
+
+// Correct: structured data without a message
+logger.info({ userId, ip, action: "login" });
+~~~~
+
+Template literal syntax is available for quick debug logging but does **not**
+produce structured data:
+
+~~~~ typescript
+// Template literal: convenient but not structured
+logger.debug`User ${userId} logged in`;
+~~~~
+
+See <https://logtape.org/manual/struct> for full structured logging details.
+
+
+Severity levels
+---------------
+
+LogTape provides six levels, from most to least verbose:
+
+| Level     | Use for                                               |
+| --------- | ----------------------------------------------------- |
+| `trace`   | Very fine-grained diagnostic output                   |
+| `debug`   | Developer-facing diagnostic messages                  |
+| `info`    | Normal operational events (startup, shutdown, etc.)   |
+| `warning` | Unexpected but recoverable situations                 |
+| `error`   | Errors that affect a single operation                 |
+| `fatal`   | Unrecoverable errors that require process termination |
+
+Use the lowest appropriate level.  Reserve `error`/`fatal` for actual failures;
+avoid using them for expected conditions like validation errors.
+
+See <https://logtape.org/manual/levels> for details.
+
+
+Configuration
+-------------
+
+`configure()` is **application-only**.  It must be `await`ed and called
+**exactly once** at startup (e.g., in your entry point):
+
+~~~~ typescript
+import { configure, getConsoleSink } from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: "my-app",
+      lowestLevel: "debug",
+      sinks: ["console"],
+    },
+  ],
+});
+~~~~
+
+Key rules:
+
+ -  Always `await` the call; it returns a `Promise`.
+ -  Call it once.  Calling it again without `await reset()` first throws.
+ -  For tests, call `await reset()` in teardown to allow reconfiguration.
+
+See <https://logtape.org/manual/config> for all options.
+
+
+Library author rule
+-------------------
+
+**Never call `configure()` in library code.**  Libraries should only call
+`getLogger()` and log messages.  The application that depends on your library
+decides how (or whether) to configure sinks and levels.
+
+~~~~ typescript
+// my-lib/src/client.ts — library code
+import { getLogger } from "@logtape/logtape";
+
+// Good: just get a logger, don't configure
+const logger = getLogger(["my-lib", "client"]);
+
+export function fetchData(url: string) {
+  logger.debug("Fetching {url}", { url });
+  // ...
+}
+~~~~
+
+See <https://logtape.org/manual/library> for the full guide.
+
+
+Context with `with()` and lazy evaluation
+-----------------------------------------
+
+### Adding context
+
+Use `logger.with()` to create a child logger that attaches properties to every
+subsequent log call:
+
+~~~~ typescript
+const reqLogger = logger.with({ requestId, userId });
+reqLogger.info("Processing order {orderId}", { orderId });
+// Log record will contain requestId, userId, AND orderId
+~~~~
+
+### Lazy evaluation
+
+Wrap expensive computations with `lazy()` so they only run when the level is
+enabled:
+
+~~~~ typescript
+import { getLogger, lazy } from "@logtape/logtape";
+
+const logger = getLogger(["my-app"]);
+logger.debug("System state: {state}", {
+  state: lazy(() => JSON.stringify(getExpensiveState())),
+});
+~~~~
+
+For structured data, pass a callback as the second argument:
+
+~~~~ typescript
+logger.debug("Diagnostics", () => ({
+  heap: process.memoryUsage().heapUsed,
+  uptime: process.uptime(),
+}));
+~~~~
+
+See <https://logtape.org/manual/lazy> and
+<https://logtape.org/manual/contexts> for details.
+
+
+Logging errors
+--------------
+
+Pass `Error` objects directly to `error()` or `fatal()`.  You can attach
+extra properties as a second argument:
+
+~~~~ typescript
+try {
+  await riskyOperation();
+} catch (error) {
+  logger.error(error, { operation: "riskyOperation", userId });
+}
+~~~~
+
+
+Testing
+-------
+
+For tests, configure a buffer sink and assert on collected records:
+
+~~~~ typescript
+import { configure, getLogger, reset, type LogRecord } from "@logtape/logtape";
+
+const buffer: LogRecord[] = [];
+
+await configure({
+  sinks: { buffer: buffer.push.bind(buffer) },
+  loggers: [{ category: "test", sinks: ["buffer"] }],
+});
+
+const logger = getLogger(["test"]);
+logger.info("hello");
+
+// Assert
+assert(buffer.length === 1);
+assert(buffer[0].level === "info");
+
+await reset();
+~~~~
+
+Always call `await reset()` in test teardown so that each test can call
+`configure()` independently.
+
+See <https://logtape.org/manual/testing> for more patterns.
+
+
+Available packages
+------------------
+
+### Sink packages
+
+| Package                     | Description            |
+| --------------------------- | ---------------------- |
+| `@logtape/file`             | File and rotating file |
+| `@logtape/otel`             | OpenTelemetry          |
+| `@logtape/sentry`           | Sentry                 |
+| `@logtape/syslog`           | Syslog                 |
+| `@logtape/cloudwatch-logs`  | AWS CloudWatch Logs    |
+| `@logtape/windows-eventlog` | Windows Event Log      |
+
+### Framework integrations
+
+| Package                | Description               |
+| ---------------------- | ------------------------- |
+| `@logtape/express`     | Express HTTP logging      |
+| `@logtape/fastify`     | Fastify HTTP logging      |
+| `@logtape/hono`        | Hono HTTP logging         |
+| `@logtape/koa`         | Koa HTTP logging          |
+| `@logtape/elysia`      | Elysia HTTP logging       |
+| `@logtape/drizzle-orm` | Drizzle ORM query logging |
+
+### Formatters
+
+| Package              | Description              |
+| -------------------- | ------------------------ |
+| `@logtape/pretty`    | Pretty console formatter |
+| `@logtape/redaction` | Sensitive data redaction |
+
+### Adaptors (for existing loggers)
+
+| Package                    | Description           |
+| -------------------------- | --------------------- |
+| `@logtape/adaptor-pino`    | Pino compatibility    |
+| `@logtape/adaptor-winston` | Winston compatibility |
+| `@logtape/adaptor-log4js`  | log4js compatibility  |
+
+
+Common mistakes
+---------------
+
+### Using template literals for structured data
+
+~~~~ typescript
+// WRONG: template literals don't produce structured data
+logger.info`User ${userId} performed ${action}`;
+
+// CORRECT: use placeholders for structured, searchable logs
+logger.info("User {userId} performed {action}", { userId, action });
+~~~~
+
+### String concatenation
+
+~~~~ typescript
+// WRONG: loses structure, always evaluates
+logger.info("User " + userId + " logged in from " + ip);
+
+// CORRECT
+logger.info("User {userId} logged in from {ip}", { userId, ip });
+~~~~
+
+### Calling `configure()` in library code
+
+~~~~ typescript
+// WRONG: library must never configure LogTape
+import { configure } from "@logtape/logtape";
+await configure({ /* ... */ });  // Don't do this in a library!
+
+// CORRECT: just use getLogger()
+import { getLogger } from "@logtape/logtape";
+const logger = getLogger(["my-lib"]);
+~~~~
+
+### Forgetting to `await configure()`
+
+~~~~ typescript
+// WRONG: configure() returns a Promise; without await, logging may
+// not work when you expect it to
+configure({ /* ... */ });
+
+// CORRECT
+await configure({ /* ... */ });
+~~~~
+
+### Using `console.log` alongside LogTape
+
+~~~~ typescript
+// WRONG: bypasses LogTape's filtering, formatting, and routing
+console.log("User logged in:", userId);
+
+// CORRECT: use the logger so the message goes through configured sinks
+logger.info("User {userId} logged in", { userId });
+~~~~
+
+### Flat categories
+
+~~~~ typescript
+// WRONG: single flat string prevents granular filtering
+const logger = getLogger("myapp");
+
+// CORRECT: hierarchical array enables per-module control
+const logger = getLogger(["myapp", "auth", "oauth"]);
+~~~~
+
+
+Best practices summary
+----------------------
+
+ -  One `configure()` call at startup, always `await`ed
+ -  Hierarchical array categories (e.g., `["app", "module", "sub"]`)
+ -  Structured messages with named placeholders, not string interpolation
+ -  `lazy()` or callback for expensive computations
+ -  `logger.with()` for request-scoped context
+ -  `error`/`fatal` only for real failures
+ -  Libraries: never `configure()`, just `getLogger()`
+ -  Tests: `reset()` in teardown, buffer sink for assertions

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -40,6 +40,14 @@ const rootLogger = getLogger("my-app");
 Choose category segments that reflect your module structure so that operators
 can selectively enable/disable logging per subsystem.
 
+Use `logger.getChild("sub")` to derive a child logger without repeating the
+full category:
+
+~~~~ typescript
+const dbLogger = logger.getChild("database");
+// category = ["my-app", "users", "auth", "database"]
+~~~~
+
 See <https://logtape.org/manual/categories> for details.
 
 
@@ -55,6 +63,9 @@ logger.info("User {userId} logged in from {ip}", { userId, ip });
 
 // Correct: structured data without a message
 logger.info({ userId, ip, action: "login" });
+
+// Nested property access (since 1.2.0)
+logger.info("Name: {user.name}", { user: { name: "Alice" } });
 ~~~~
 
 Template literal syntax is available for quick debug logging but does **not**
@@ -91,6 +102,8 @@ See <https://logtape.org/manual/levels> for details.
 Configuration
 -------------
 
+### Async configuration (most common)
+
 `configure()` is **application-only**.  It must be `await`ed and called
 **exactly once** at startup (e.g., in your entry point):
 
@@ -111,11 +124,48 @@ await configure({
 });
 ~~~~
 
-Key rules:
+### Synchronous configuration
 
- -  Always `await` the call; it returns a `Promise`.
- -  Call it once.  Calling it again without `await reset()` first throws.
- -  For tests, call `await reset()` in teardown to allow reconfiguration.
+Use `configureSync()` when you cannot use `await` (e.g., top-level in CommonJS,
+or in a synchronous startup path):
+
+~~~~ typescript
+import { configureSync, getConsoleSink } from "@logtape/logtape";
+
+configureSync({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: "my-app",
+      lowestLevel: "debug",
+      sinks: ["console"],
+    },
+  ],
+});
+~~~~
+
+> **Limitation:** `configureSync()` cannot use `AsyncDisposable` sinks such as
+> `getStreamSink()` or sinks created with `fromAsyncSink()`.
+
+### Key rules
+
+ -  `configure()` returns a `Promise`; always `await` it.
+ -  `configureSync()` returns `void`; do not `await` it.
+ -  Call either one **once**.  Calling again without resetting first throws
+    `ConfigError`.
+ -  Do **not** mix async and sync: if you used `configure()`, reset with
+    `await reset()`; if you used `configureSync()`, reset with `resetSync()`.
+ -  For tests, call `await reset()` (or `resetSync()`) in teardown.
+
+### Framework-specific patterns
+
+ -  **React**: configure **before** `createRoot()`.
+ -  **Vue**: configure **before** `app.mount()`.
+ -  **Next.js**: use *instrumentation.js* (server) or
+    *instrumentation-client.js* (client).
+ -  **SvelteKit**: configure in *hooks.server.ts*.
 
 See <https://logtape.org/manual/config> for all options.
 
@@ -123,9 +173,9 @@ See <https://logtape.org/manual/config> for all options.
 Library author rule
 -------------------
 
-**Never call `configure()` in library code.**  Libraries should only call
-`getLogger()` and log messages.  The application that depends on your library
-decides how (or whether) to configure sinks and levels.
+**Never call `configure()` or `configureSync()` in library code.**  Libraries
+should only call `getLogger()` and log messages.  The application that depends
+on your library decides how (or whether) to configure sinks and levels.
 
 ~~~~ typescript
 // my-lib/src/client.ts — library code
@@ -140,13 +190,30 @@ export function fetchData(url: string) {
 }
 ~~~~
 
+If your library wraps other LogTape-using libraries, use `withCategoryPrefix()`
+to nest their logs under your category:
+
+~~~~ typescript
+import { withCategoryPrefix } from "@logtape/logtape";
+
+export function myOperation() {
+  return withCategoryPrefix(["my-lib"], () => {
+    // Logs from inner libraries appear as ["my-lib", ...their-category]
+    innerLib.doWork();
+  });
+}
+~~~~
+
+> **Note:** `withCategoryPrefix()` requires `contextLocalStorage` to be
+> configured by the application.
+
 See <https://logtape.org/manual/library> for the full guide.
 
 
 Context with `with()` and lazy evaluation
 -----------------------------------------
 
-### Adding context
+### Adding explicit context
 
 Use `logger.with()` to create a child logger that attaches properties to every
 subsequent log call:
@@ -156,6 +223,31 @@ const reqLogger = logger.with({ requestId, userId });
 reqLogger.info("Processing order {orderId}", { orderId });
 // Log record will contain requestId, userId, AND orderId
 ~~~~
+
+### Implicit context (request tracing)
+
+Use `withContext()` to propagate context across an entire call stack without
+threading loggers manually.  Requires `contextLocalStorage` in configuration:
+
+~~~~ typescript
+import { configure, getConsoleSink, withContext } from "@logtape/logtape";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+await configure({
+  sinks: { console: getConsoleSink() },
+  loggers: [{ category: "app", sinks: ["console"] }],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+function handleRequest(req: Request) {
+  withContext({ requestId: crypto.randomUUID() }, () => {
+    // All logs inside this callback automatically include requestId
+    processRequest(req);
+  });
+}
+~~~~
+
+> **Note:** Implicit contexts are not available in browsers yet.
 
 ### Lazy evaluation
 
@@ -180,6 +272,23 @@ logger.debug("Diagnostics", () => ({
 }));
 ~~~~
 
+For **async** lazy evaluation, pass an async callback and `await` the result:
+
+~~~~ typescript
+await logger.info("User details", async () => ({
+  user: await fetchUserDetails(),
+}));
+~~~~
+
+For multiple expensive log calls, use `isEnabledFor()`:
+
+~~~~ typescript
+if (logger.isEnabledFor("debug")) {
+  const snapshot = await captureExpensiveSnapshot();
+  logger.debug("Snapshot: {data}", { data: snapshot });
+}
+~~~~
+
 See <https://logtape.org/manual/lazy> and
 <https://logtape.org/manual/contexts> for details.
 
@@ -197,6 +306,107 @@ try {
   logger.error(error, { operation: "riskyOperation", userId });
 }
 ~~~~
+
+
+Sinks and formatters
+--------------------
+
+### Built-in sinks
+
+~~~~ typescript
+import {
+  configure,
+  getConsoleSink,
+  getStreamSink,
+} from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+    stderr: getStreamSink(Writable.toWeb(process.stderr)),
+  },
+  loggers: [{ category: "app", sinks: ["console"] }],
+});
+~~~~
+
+### Sink filters
+
+Use `withFilter()` to route different levels to different sinks:
+
+~~~~ typescript
+import { configure, getConsoleSink, withFilter } from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    errorsOnly: withFilter(getConsoleSink(), "error"),
+    allLevels: getConsoleSink(),
+  },
+  loggers: [
+    { category: "app", sinks: ["allLevels", "errorsOnly"] },
+  ],
+});
+~~~~
+
+### Formatters
+
+~~~~ typescript
+import {
+  configure,
+  getAnsiColorFormatter,
+  getConsoleSink,
+  getJsonLinesFormatter,
+} from "@logtape/logtape";
+
+// Pretty ANSI-colored output for development
+getConsoleSink({ formatter: getAnsiColorFormatter() });
+
+// JSON Lines for production / log aggregation
+getConsoleSink({ formatter: getJsonLinesFormatter() });
+~~~~
+
+For even nicer development output, use `@logtape/pretty`:
+
+~~~~ typescript
+import { getPrettyFormatter } from "@logtape/pretty";
+
+getConsoleSink({ formatter: getPrettyFormatter() });
+~~~~
+
+### Disposal
+
+Non-blocking sinks and stream sinks hold resources.  In **edge functions** or
+short-lived processes, explicitly dispose before exit:
+
+~~~~ typescript
+import { dispose } from "@logtape/logtape";
+
+// At shutdown
+await dispose();
+~~~~
+
+See <https://logtape.org/manual/sinks> and
+<https://logtape.org/manual/formatters> for details.
+
+
+Adaptors for existing loggers
+-----------------------------
+
+If the project already uses winston, Pino, or log4js, use an adaptor instead
+of `configure()`:
+
+~~~~ typescript
+import { install } from "@logtape/adaptor-winston";
+import winston from "winston";
+
+const winstonLogger = winston.createLogger({ /* ... */ });
+install(winstonLogger);
+// All LogTape logs now route through winston
+~~~~
+
+Available: `@logtape/adaptor-winston`, `@logtape/adaptor-pino`,
+`@logtape/adaptor-log4js`.
+
+See <https://logtape.org/manual/adaptors> for details.
 
 
 Testing
@@ -224,8 +434,18 @@ assert(buffer[0].level === "info");
 await reset();
 ~~~~
 
-Always call `await reset()` in test teardown so that each test can call
-`configure()` independently.
+If using `configureSync()`, reset with `resetSync()`:
+
+~~~~ typescript
+import { configureSync, resetSync } from "@logtape/logtape";
+
+configureSync({ /* ... */ });
+// ... test ...
+resetSync();
+~~~~
+
+Always call `reset()` / `resetSync()` in test teardown so that each test can
+configure independently.
 
 See <https://logtape.org/manual/testing> for more patterns.
 
@@ -315,6 +535,25 @@ configure({ /* ... */ });
 
 // CORRECT
 await configure({ /* ... */ });
+
+// Or use the synchronous variant if you can't await
+configureSync({ /* ... */ });
+~~~~
+
+### Mixing async/sync configure and reset
+
+~~~~ typescript
+// WRONG: mismatched pair causes errors
+await configure({ /* ... */ });
+resetSync();  // Can't sync-reset an async config!
+
+// CORRECT: match configure and reset variants
+await configure({ /* ... */ });
+await reset();
+
+// Or:
+configureSync({ /* ... */ });
+resetSync();
 ~~~~
 
 ### Using `console.log` alongside LogTape
@@ -337,15 +576,31 @@ const logger = getLogger("myapp");
 const logger = getLogger(["myapp", "auth", "oauth"]);
 ~~~~
 
+### Logging sensitive data without redaction
+
+~~~~ typescript
+// WRONG: password ends up in log files
+logger.info("Login attempt for {email} with {password}", { email, password });
+
+// CORRECT: never log secrets; use @logtape/redaction if needed
+logger.info("Login attempt for {email}", { email });
+~~~~
+
 
 Best practices summary
 ----------------------
 
- -  One `configure()` call at startup, always `await`ed
+ -  One `configure()` or `configureSync()` call at startup
+ -  Always `await configure()`; never `await configureSync()`
+ -  Match reset variant to configure variant
  -  Hierarchical array categories (e.g., `["app", "module", "sub"]`)
  -  Structured messages with named placeholders, not string interpolation
  -  `lazy()` or callback for expensive computations
  -  `logger.with()` for request-scoped context
+ -  `withContext()` + `AsyncLocalStorage` for implicit context propagation
  -  `error`/`fatal` only for real failures
- -  Libraries: never `configure()`, just `getLogger()`
- -  Tests: `reset()` in teardown, buffer sink for assertions
+ -  Libraries: never configure, just `getLogger()`
+ -  Tests: `reset()` / `resetSync()` in teardown, buffer sink for assertions
+ -  Never log sensitive data (passwords, tokens, PII)
+ -  Use `dispose()` / `disposeSync()` in edge functions or short-lived
+    processes

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -48,7 +48,7 @@ const dbLogger = logger.getChild("database");
 // category = ["my-app", "users", "auth", "database"]
 ~~~~
 
-See <https://logtape.org/manual/categories> for details.
+See <https://logtape.org/manual/categories.md> for details.
 
 
 Structured messages
@@ -76,7 +76,7 @@ produce structured data:
 logger.debug`User ${userId} logged in`;
 ~~~~
 
-See <https://logtape.org/manual/struct> for full structured logging details.
+See <https://logtape.org/manual/struct.md> for full structured logging details.
 
 
 Severity levels
@@ -96,7 +96,7 @@ LogTape provides six levels, from most to least verbose:
 Use the lowest appropriate level.  Reserve `error`/`fatal` for actual failures;
 avoid using them for expected conditions like validation errors.
 
-See <https://logtape.org/manual/levels> for details.
+See <https://logtape.org/manual/levels.md> for details.
 
 
 Configuration
@@ -167,7 +167,7 @@ configureSync({
     *instrumentation-client.js* (client).
  -  **SvelteKit**: configure in *hooks.server.ts*.
 
-See <https://logtape.org/manual/config> for all options.
+See <https://logtape.org/manual/config.md> for all options.
 
 
 Library author rule
@@ -207,7 +207,7 @@ export function myOperation() {
 > **Note:** `withCategoryPrefix()` requires `contextLocalStorage` to be
 > configured by the application.
 
-See <https://logtape.org/manual/library> for the full guide.
+See <https://logtape.org/manual/library.md> for the full guide.
 
 
 Context with `with()` and lazy evaluation
@@ -289,8 +289,8 @@ if (logger.isEnabledFor("debug")) {
 }
 ~~~~
 
-See <https://logtape.org/manual/lazy> and
-<https://logtape.org/manual/contexts> for details.
+See <https://logtape.org/manual/lazy.md> and
+<https://logtape.org/manual/contexts.md> for details.
 
 
 Logging errors
@@ -384,8 +384,8 @@ import { dispose } from "@logtape/logtape";
 await dispose();
 ~~~~
 
-See <https://logtape.org/manual/sinks> and
-<https://logtape.org/manual/formatters> for details.
+See <https://logtape.org/manual/sinks.md> and
+<https://logtape.org/manual/formatters.md> for details.
 
 
 Data redaction
@@ -449,7 +449,7 @@ const sink = redactByField(
 );
 ~~~~
 
-See <https://logtape.org/manual/redaction> for details.
+See <https://logtape.org/manual/redaction.md> for details.
 
 
 Adaptors for existing loggers
@@ -470,7 +470,7 @@ install(winstonLogger);
 Available: `@logtape/adaptor-winston`, `@logtape/adaptor-pino`,
 `@logtape/adaptor-log4js`.
 
-See <https://logtape.org/manual/adaptors> for details.
+See <https://logtape.org/manual/adaptors.md> for details.
 
 
 Testing
@@ -511,7 +511,7 @@ resetSync();
 Always call `reset()` / `resetSync()` in test teardown so that each test can
 configure independently.
 
-See <https://logtape.org/manual/testing> for more patterns.
+See <https://logtape.org/manual/testing.md> for more patterns.
 
 
 Available packages


### PR DESCRIPTION
## Summary

- Add a bundled [Agent Skills](https://agentskills.io/) skill to `@logtape/logtape` that teaches AI coding assistants (Claude Code, GitHub Copilot, Cursor, Windsurf, etc.) how to use LogTape correctly
- Add an *LLM integration* documentation page with setup instructions for skills-npm, npm-agentskills, and manual installation
- Declare the skill in `package.json` via the `agents` field for automatic discovery

## What the skill covers

- Getting loggers with hierarchical array categories
- Structured messages with named placeholders (not template literals or string concat)
- `configure()` and `configureSync()` with pairing rules for `reset()`/`resetSync()`
- Framework-specific patterns (React, Vue, Next.js, SvelteKit)
- Library author rule: never call `configure()` in library code
- Explicit context (`with()`), implicit context (`withContext()` + `AsyncLocalStorage`), and `withCategoryPrefix()`
- Lazy evaluation (`lazy()`, async callbacks, `isEnabledFor()`)
- Sinks, formatters, sink filters (`withFilter()`), and disposal
- Data redaction (`redactByPattern()`, `redactByField()`)
- Adaptors for existing loggers (winston, Pino, log4js)
- Testing with buffer sinks
- Complete package reference table
- Common mistakes section with negative examples

## Changed files

| File | Description |
| --- | --- |
| `packages/logtape/skills/logtape/SKILL.md` | The agent skill (~670 lines) |
| `packages/logtape/package.json` | `agents` field + `skills/` in `files` |
| `docs/manual/llm.md` | LLM integration guide |
| `docs/manual/install.md` | Link to LLM integration page |
| `docs/.vitepress/config.mts` | Add page to sidebar |
| `CHANGES.md` | Changelog entry |

Closes #147