### PR TITLE
Use Hono Context in formatter callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,15 @@ To be released.
  -  Added `timeZone` support to `getPrettyFormatter()` for timestamp rendering,
     aligned with `@logtape/logtape` formatter semantics.  [[#140]]
 
+### @logtape/hono
+
+ -  Changed the `HonoContext` interface to extend Hono's `Context` so custom
+    formatter and skip callbacks receive the real runtime context.  Custom
+    formatters can now read context variables via APIs like `c.get()`.
+    [[#150] by Hamza Zia]
+
+[#150]: https://github.com/dahlia/logtape/pull/150
+
 
 Version 2.0.5
 -------------

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -98,6 +98,20 @@ app.use(honoLogger({
 }));
 ~~~~
 
+The formatter callback receives the real Hono `Context`, so you can also read
+context variables when your app uses them:
+
+~~~~ typescript
+app.use(honoLogger({
+  format: (c, responseTime) => ({
+    requestId: c.get("requestId"),
+    method: c.req.method,
+    path: c.req.path,
+    duration: responseTime,
+  }),
+}));
+~~~~
+
 
 Structured logging output
 -------------------------

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -12,6 +12,7 @@ export type { LogLevel } from "@logtape/logtape";
  * needed.
  * @since 1.3.0
  */
+// deno-lint-ignore no-explicit-any
 export interface HonoContext extends Context<any, any, any> {}
 
 /**

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -1,27 +1,18 @@
 import { getLogger, type LogLevel } from "@logtape/logtape";
 import { createMiddleware } from "hono/factory";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 
 export type { LogLevel } from "@logtape/logtape";
 
 /**
- * Minimal Hono Context interface for compatibility across Hono versions.
+ * Hono context type exposed to custom formatters and skip callbacks.
+ *
+ * This matches the actual runtime object passed to the middleware, so custom
+ * formatters can access context variables via methods like `c.get()` when
+ * needed.
  * @since 1.3.0
  */
-export interface HonoContext {
-  req: {
-    method: string;
-    url: string;
-    path: string;
-    header(name: string): string | undefined;
-  };
-  res: {
-    status: number;
-    headers: {
-      get(name: string): string | null;
-    };
-  };
-}
+export type HonoContext = Context<any, any, any>;
 
 /**
  * Predefined log format names compatible with Morgan.

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -5,14 +5,14 @@ import type { Context, MiddlewareHandler } from "hono";
 export type { LogLevel } from "@logtape/logtape";
 
 /**
- * Hono context type exposed to custom formatters and skip callbacks.
+ * Hono context interface exposed to custom formatters and skip callbacks.
  *
  * This matches the actual runtime object passed to the middleware, so custom
  * formatters can access context variables via methods like `c.get()` when
  * needed.
  * @since 1.3.0
  */
-export type HonoContext = Context<any, any, any>;
+export interface HonoContext extends Context<any, any, any> {}
 
 /**
  * Predefined log format names compatible with Morgan.


### PR DESCRIPTION
This updates `@logtape/hono` to expose the real Hono `Context` type to custom formatter and skip callbacks instead of a reduced hand-rolled subset.

That matches the runtime object the middleware already receives and lets apps access context variables through APIs like `c.get()` inside custom formatters.

Checks run:
- `pnpm --filter @logtape/hono build`
- `deno check packages/hono/src/mod.ts`
- `deno check` on a custom formatter example that calls `c.get("requestId")`