### PR TITLE
Fix lazy property snapshot timing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 2.0.7
 
 To be released.
 
+### @logtape/logtape
+
+ -  Fixed lazy properties so they are evaluated when a log record is emitted,
+    not later when a buffering sink flushes the record.  This makes
+    `lazy()` values stable for non-blocking console sinks and custom buffering
+    sinks.  [[#156], [#157]]
+
+[#156]: https://github.com/dahlia/logtape/issues/156
+[#157]: https://github.com/dahlia/logtape/pull/157
+
 
 Version 2.0.6
 -------------

--- a/packages/logtape/src/logger.test.ts
+++ b/packages/logtape/src/logger.test.ts
@@ -13,7 +13,7 @@ import {
   renderMessage,
 } from "./logger.ts";
 import type { LogRecord } from "./record.ts";
-import type { Sink } from "./sink.ts";
+import { getConsoleSink, type Sink } from "./sink.ts";
 
 function templateLiteral(tpl: TemplateStringsArray, ..._: unknown[]) {
   return tpl;
@@ -2309,6 +2309,295 @@ test("Logger.with() lazy getter throwing error propagates", () => {
     assert.strictEqual(errors.length, 1);
     assert.ok(errors[0] instanceof Error);
     assert.strictEqual((errors[0] as Error).message, "getter error");
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger.with() lazy values are snapshotted before buffered sinks read them", () => {
+  const logger = LoggerImpl.getLogger(["lazy-buffer-snapshot-test"]);
+  const records: LogRecord[] = [];
+  logger.parentSinks = "override";
+  logger.sinks.push((record) => records.push(record));
+
+  try {
+    let currentUser = "alice";
+    const ctx = logger.with({ user: lazy(() => currentUser) });
+
+    ctx.info("First {user}");
+    currentUser = "bob";
+    ctx.info("Second {user}");
+    currentUser = "carol";
+
+    assert.strictEqual(records.length, 2);
+    assert.deepStrictEqual(records[0].message, ["First ", "alice", ""]);
+    assert.strictEqual(records[0].properties.user, "alice");
+    assert.deepStrictEqual(records[1].message, ["Second ", "bob", ""]);
+    assert.strictEqual(records[1].properties.user, "bob");
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger.with() lazy values are snapshotted for non-blocking console sinks", () => {
+  const logger = LoggerImpl.getLogger(["lazy-non-blocking-console-test"]);
+  const logs: unknown[][] = [];
+  const fakeConsole = {
+    debug: (...args: unknown[]) => logs.push(args),
+    error: (...args: unknown[]) => logs.push(args),
+    info: (...args: unknown[]) => logs.push(args),
+    log: (...args: unknown[]) => logs.push(args),
+    trace: (...args: unknown[]) => logs.push(args),
+    warn: (...args: unknown[]) => logs.push(args),
+  } as unknown as Console;
+  const sink = getConsoleSink({
+    console: fakeConsole,
+    formatter: (record) => [
+      record.level,
+      record.category.join("."),
+      record.message.join(" "),
+      record.properties,
+    ],
+    nonBlocking: {
+      bufferSize: 100,
+      flushInterval: 5000,
+    },
+  });
+  logger.parentSinks = "override";
+  logger.sinks.push(sink);
+
+  try {
+    let currentUser = "alice";
+    const ctx = logger.with({ user: lazy(() => currentUser) });
+
+    ctx.info("First action");
+    currentUser = "bob";
+    ctx.info("Second action");
+    currentUser = "carol";
+
+    (sink as Sink & Disposable)[Symbol.dispose]();
+
+    assert.deepStrictEqual(logs, [
+      [
+        "info",
+        "lazy-non-blocking-console-test",
+        "First action",
+        { user: "alice" },
+      ],
+      [
+        "info",
+        "lazy-non-blocking-console-test",
+        "Second action",
+        { user: "bob" },
+      ],
+    ]);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger lazy values are resolved once for all sinks", () => {
+  const logger = LoggerImpl.getLogger(["lazy-single-evaluation-test"]);
+  const records1: LogRecord[] = [];
+  const records2: LogRecord[] = [];
+  logger.parentSinks = "override";
+  logger.sinks.push((record) => records1.push(record));
+  logger.sinks.push((record) => records2.push(record));
+
+  try {
+    let evaluations = 0;
+    const ctx = logger.with({
+      value: lazy(() => {
+        evaluations++;
+        return evaluations;
+      }),
+    });
+
+    ctx.info("Shared lazy value");
+
+    assert.strictEqual(evaluations, 1);
+    assert.strictEqual(records1[0].properties.value, 1);
+    assert.strictEqual(records2[0].properties.value, 1);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger does not resolve lazy values when level disables record", () => {
+  const logger = LoggerImpl.getLogger(["lazy-disabled-level-test"]);
+  logger.parentSinks = "override";
+  logger.lowestLevel = "warning";
+  logger.sinks.push(() => assert.fail("sink should not be called"));
+
+  try {
+    let evaluated = false;
+    const ctx = logger.with({
+      value: lazy(() => {
+        evaluated = true;
+        return "computed";
+      }),
+    });
+
+    ctx.info("Filtered by level");
+
+    assert.strictEqual(evaluated, false);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger does not resolve lazy values when filters reject record", () => {
+  const logger = LoggerImpl.getLogger(["lazy-filtered-test"]);
+  logger.parentSinks = "override";
+  logger.filters.push(() => false);
+  logger.sinks.push(() => assert.fail("sink should not be called"));
+
+  try {
+    let evaluated = false;
+    const ctx = logger.with({
+      value: lazy(() => {
+        evaluated = true;
+        return "computed";
+      }),
+    });
+
+    ctx.info("Filtered by predicate");
+
+    assert.strictEqual(evaluated, false);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger filters see resolved direct lazy properties", () => {
+  const logger = LoggerImpl.getLogger(["lazy-direct-filter-test"]);
+  const records: LogRecord[] = [];
+  logger.parentSinks = "override";
+  logger.filters.push((record) => record.properties.user === "alice");
+  logger.sinks.push((record) => records.push(record));
+
+  try {
+    let currentUser = "alice";
+
+    logger.info("Accepted {user}", { user: lazy(() => currentUser) });
+    currentUser = "bob";
+    logger.info("Rejected {user}", { user: lazy(() => currentUser) });
+
+    assert.strictEqual(records.length, 1);
+    assert.deepStrictEqual(records[0].message, ["Accepted ", "alice", ""]);
+    assert.strictEqual(records[0].properties.user, "alice");
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger filters see messages rendered with resolved direct lazy properties", () => {
+  const logger = LoggerImpl.getLogger(["lazy-direct-message-filter-test"]);
+  const records: LogRecord[] = [];
+  logger.parentSinks = "override";
+  logger.filters.push((record) => record.message.includes("alice"));
+  logger.sinks.push((record) => records.push(record));
+
+  try {
+    let currentUser = "alice";
+
+    logger.info("Accepted {user}", { user: lazy(() => currentUser) });
+    currentUser = "bob";
+    logger.info("Rejected {user}", { user: lazy(() => currentUser) });
+
+    assert.strictEqual(records.length, 1);
+    assert.deepStrictEqual(records[0].message, ["Accepted ", "alice", ""]);
+    assert.strictEqual(records[0].properties.user, "alice");
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger caches direct message rendering across filter and sink access", () => {
+  const logger = LoggerImpl.getLogger(["lazy-direct-message-cache-test"]);
+  const records: LogRecord[] = [];
+  let filteredMessage: readonly unknown[] | undefined;
+  logger.parentSinks = "override";
+  logger.filters.push((record) => {
+    filteredMessage = record.message;
+    assert.strictEqual(record.message, filteredMessage);
+    return true;
+  });
+  logger.sinks.push((record) => records.push(record));
+
+  try {
+    let currentUser = "alice";
+
+    logger.info("Cached {user}", { user: lazy(() => currentUser) });
+    currentUser = "bob";
+
+    assert.strictEqual(records.length, 1);
+    assert.strictEqual(records[0].message, filteredMessage);
+    assert.strictEqual(records[0].message, records[0].message);
+    assert.deepStrictEqual(records[0].message, ["Cached ", "alice", ""]);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger filters do not resolve direct lazy properties when not inspected", () => {
+  const logger = LoggerImpl.getLogger(["lazy-direct-uninspected-filter-test"]);
+  logger.parentSinks = "override";
+  logger.filters.push(() => false);
+  logger.sinks.push(() => assert.fail("sink should not be called"));
+
+  try {
+    let evaluated = false;
+
+    logger.info("Rejected", {
+      value: lazy(() => {
+        evaluated = true;
+        return "computed";
+      }),
+    });
+
+    assert.strictEqual(evaluated, false);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger does not resolve lazy values when no sinks are configured", () => {
+  const logger = LoggerImpl.getLogger(["lazy-no-sink-test"]);
+  logger.parentSinks = "override";
+
+  try {
+    let evaluated = false;
+    const ctx = logger.with({
+      value: lazy(() => {
+        evaluated = true;
+        return "computed";
+      }),
+    });
+
+    ctx.info("No destination");
+
+    assert.strictEqual(evaluated, false);
+  } finally {
+    logger.resetDescendants();
+  }
+});
+
+test("Logger resolves direct lazy properties before buffered sinks read them", () => {
+  const logger = LoggerImpl.getLogger(["lazy-direct-buffer-snapshot-test"]);
+  const records: LogRecord[] = [];
+  logger.parentSinks = "override";
+  logger.sinks.push((record) => records.push(record));
+
+  try {
+    let value = "initial";
+
+    logger.info("Direct {value}", { value: lazy(() => value) });
+    value = "updated";
+
+    assert.strictEqual(records.length, 1);
+    assert.deepStrictEqual(records[0].message, ["Direct ", "initial", ""]);
+    assert.strictEqual(records[0].properties.value, "initial");
   } finally {
     logger.resetDescendants();
   }

--- a/packages/logtape/src/logger.test.ts
+++ b/packages/logtape/src/logger.test.ts
@@ -6,6 +6,7 @@ import {
   getLogger,
   isLazy,
   lazy,
+  type Logger,
   LoggerCtx,
   LoggerImpl,
   type LogMethod,
@@ -2315,14 +2316,16 @@ test("Logger.with() lazy getter throwing error propagates", () => {
 });
 
 test("Logger.with() lazy values are snapshotted before buffered sinks read them", () => {
-  const logger = LoggerImpl.getLogger(["lazy-buffer-snapshot-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-buffer-snapshot-test",
+  ]);
   const records: LogRecord[] = [];
   logger.parentSinks = "override";
   logger.sinks.push((record) => records.push(record));
 
   try {
-    let currentUser = "alice";
-    const ctx = logger.with({ user: lazy(() => currentUser) });
+    let currentUser: string = "alice";
+    const ctx: Logger = logger.with({ user: lazy(() => currentUser) });
 
     ctx.info("First {user}");
     currentUser = "bob";
@@ -2340,9 +2343,11 @@ test("Logger.with() lazy values are snapshotted before buffered sinks read them"
 });
 
 test("Logger.with() lazy values are snapshotted for non-blocking console sinks", () => {
-  const logger = LoggerImpl.getLogger(["lazy-non-blocking-console-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-non-blocking-console-test",
+  ]);
   const logs: unknown[][] = [];
-  const fakeConsole = {
+  const fakeConsole: Console = {
     debug: (...args: unknown[]) => logs.push(args),
     error: (...args: unknown[]) => logs.push(args),
     info: (...args: unknown[]) => logs.push(args),
@@ -2350,7 +2355,7 @@ test("Logger.with() lazy values are snapshotted for non-blocking console sinks",
     trace: (...args: unknown[]) => logs.push(args),
     warn: (...args: unknown[]) => logs.push(args),
   } as unknown as Console;
-  const sink = getConsoleSink({
+  const sink: Sink | (Sink & Disposable) = getConsoleSink({
     console: fakeConsole,
     formatter: (record) => [
       record.level,
@@ -2367,8 +2372,8 @@ test("Logger.with() lazy values are snapshotted for non-blocking console sinks",
   logger.sinks.push(sink);
 
   try {
-    let currentUser = "alice";
-    const ctx = logger.with({ user: lazy(() => currentUser) });
+    let currentUser: string = "alice";
+    const ctx: Logger = logger.with({ user: lazy(() => currentUser) });
 
     ctx.info("First action");
     currentUser = "bob";
@@ -2397,7 +2402,9 @@ test("Logger.with() lazy values are snapshotted for non-blocking console sinks",
 });
 
 test("Logger lazy values are resolved once for all sinks", () => {
-  const logger = LoggerImpl.getLogger(["lazy-single-evaluation-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-single-evaluation-test",
+  ]);
   const records1: LogRecord[] = [];
   const records2: LogRecord[] = [];
   logger.parentSinks = "override";
@@ -2405,8 +2412,8 @@ test("Logger lazy values are resolved once for all sinks", () => {
   logger.sinks.push((record) => records2.push(record));
 
   try {
-    let evaluations = 0;
-    const ctx = logger.with({
+    let evaluations: number = 0;
+    const ctx: Logger = logger.with({
       value: lazy(() => {
         evaluations++;
         return evaluations;
@@ -2424,14 +2431,16 @@ test("Logger lazy values are resolved once for all sinks", () => {
 });
 
 test("Logger does not resolve lazy values when level disables record", () => {
-  const logger = LoggerImpl.getLogger(["lazy-disabled-level-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-disabled-level-test",
+  ]);
   logger.parentSinks = "override";
   logger.lowestLevel = "warning";
   logger.sinks.push(() => assert.fail("sink should not be called"));
 
   try {
-    let evaluated = false;
-    const ctx = logger.with({
+    let evaluated: boolean = false;
+    const ctx: Logger = logger.with({
       value: lazy(() => {
         evaluated = true;
         return "computed";
@@ -2447,14 +2456,14 @@ test("Logger does not resolve lazy values when level disables record", () => {
 });
 
 test("Logger does not resolve lazy values when filters reject record", () => {
-  const logger = LoggerImpl.getLogger(["lazy-filtered-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger(["lazy-filtered-test"]);
   logger.parentSinks = "override";
   logger.filters.push(() => false);
   logger.sinks.push(() => assert.fail("sink should not be called"));
 
   try {
-    let evaluated = false;
-    const ctx = logger.with({
+    let evaluated: boolean = false;
+    const ctx: Logger = logger.with({
       value: lazy(() => {
         evaluated = true;
         return "computed";
@@ -2470,14 +2479,16 @@ test("Logger does not resolve lazy values when filters reject record", () => {
 });
 
 test("Logger filters see resolved direct lazy properties", () => {
-  const logger = LoggerImpl.getLogger(["lazy-direct-filter-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-direct-filter-test",
+  ]);
   const records: LogRecord[] = [];
   logger.parentSinks = "override";
   logger.filters.push((record) => record.properties.user === "alice");
   logger.sinks.push((record) => records.push(record));
 
   try {
-    let currentUser = "alice";
+    let currentUser: string = "alice";
 
     logger.info("Accepted {user}", { user: lazy(() => currentUser) });
     currentUser = "bob";
@@ -2492,14 +2503,16 @@ test("Logger filters see resolved direct lazy properties", () => {
 });
 
 test("Logger filters see messages rendered with resolved direct lazy properties", () => {
-  const logger = LoggerImpl.getLogger(["lazy-direct-message-filter-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-direct-message-filter-test",
+  ]);
   const records: LogRecord[] = [];
   logger.parentSinks = "override";
   logger.filters.push((record) => record.message.includes("alice"));
   logger.sinks.push((record) => records.push(record));
 
   try {
-    let currentUser = "alice";
+    let currentUser: string = "alice";
 
     logger.info("Accepted {user}", { user: lazy(() => currentUser) });
     currentUser = "bob";
@@ -2514,7 +2527,9 @@ test("Logger filters see messages rendered with resolved direct lazy properties"
 });
 
 test("Logger caches direct message rendering across filter and sink access", () => {
-  const logger = LoggerImpl.getLogger(["lazy-direct-message-cache-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-direct-message-cache-test",
+  ]);
   const records: LogRecord[] = [];
   let filteredMessage: readonly unknown[] | undefined;
   logger.parentSinks = "override";
@@ -2526,7 +2541,7 @@ test("Logger caches direct message rendering across filter and sink access", () 
   logger.sinks.push((record) => records.push(record));
 
   try {
-    let currentUser = "alice";
+    let currentUser: string = "alice";
 
     logger.info("Cached {user}", { user: lazy(() => currentUser) });
     currentUser = "bob";
@@ -2541,13 +2556,15 @@ test("Logger caches direct message rendering across filter and sink access", () 
 });
 
 test("Logger filters do not resolve direct lazy properties when not inspected", () => {
-  const logger = LoggerImpl.getLogger(["lazy-direct-uninspected-filter-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-direct-uninspected-filter-test",
+  ]);
   logger.parentSinks = "override";
   logger.filters.push(() => false);
   logger.sinks.push(() => assert.fail("sink should not be called"));
 
   try {
-    let evaluated = false;
+    let evaluated: boolean = false;
 
     logger.info("Rejected", {
       value: lazy(() => {
@@ -2563,12 +2580,12 @@ test("Logger filters do not resolve direct lazy properties when not inspected", 
 });
 
 test("Logger does not resolve lazy values when no sinks are configured", () => {
-  const logger = LoggerImpl.getLogger(["lazy-no-sink-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger(["lazy-no-sink-test"]);
   logger.parentSinks = "override";
 
   try {
-    let evaluated = false;
-    const ctx = logger.with({
+    let evaluated: boolean = false;
+    const ctx: Logger = logger.with({
       value: lazy(() => {
         evaluated = true;
         return "computed";
@@ -2584,13 +2601,15 @@ test("Logger does not resolve lazy values when no sinks are configured", () => {
 });
 
 test("Logger resolves direct lazy properties before buffered sinks read them", () => {
-  const logger = LoggerImpl.getLogger(["lazy-direct-buffer-snapshot-test"]);
+  const logger: LoggerImpl = LoggerImpl.getLogger([
+    "lazy-direct-buffer-snapshot-test",
+  ]);
   const records: LogRecord[] = [];
   logger.parentSinks = "override";
   logger.sinks.push((record) => records.push(record));
 
   try {
-    let value = "initial";
+    let value: string = "initial";
 
     logger.info("Direct {value}", { value: lazy(() => value) });
     value = "updated";

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -80,6 +80,19 @@ function resolveProperties(
   return resolved;
 }
 
+function snapshotLogRecordProperties(record: LogRecord): LogRecord {
+  const properties = resolveProperties(record.properties);
+  const descriptors = Object.getOwnPropertyDescriptors(record) as
+    & PropertyDescriptorMap
+    & { properties?: PropertyDescriptor };
+  descriptors.properties = {
+    value: properties,
+    enumerable: true,
+    configurable: true,
+  };
+  return Object.defineProperties({}, descriptors) as LogRecord;
+}
+
 /**
  * A logger interface.  It provides methods to log messages at different
  * severity levels.
@@ -1413,10 +1426,22 @@ export class LoggerImpl implements Logger {
     ) {
       return;
     }
-    for (const sink of this.getSinks(record.level)) {
+    const sinks = [...this.getSinks(record.level)];
+    if (sinks.length < 1) return;
+    let snapshot: LogRecord | undefined;
+    let snapshotFailed = false;
+    for (const sink of sinks) {
       if (bypassSinks?.has(sink)) continue;
       try {
-        sink(record);
+        if (snapshot == null && !snapshotFailed) {
+          try {
+            snapshot = snapshotLogRecordProperties(record);
+          } catch {
+            snapshotFailed = true;
+            snapshot = record;
+          }
+        }
+        sink(snapshot ?? record);
       } catch (error) {
         const bypassSinks2 = new Set(bypassSinks);
         bypassSinks2.add(sink);
@@ -1438,21 +1463,25 @@ export class LoggerImpl implements Logger {
   ): void {
     const implicitContext = getImplicitContext();
     let cachedProps: Record<string, unknown> | undefined = undefined;
+    let cachedMessage: readonly unknown[] | undefined = undefined;
     const record: LogRecord = typeof properties === "function"
       ? {
         category: this.category,
         level,
         timestamp: Date.now(),
         get message() {
-          return parseMessageTemplate(rawMessage, this.properties);
+          if (cachedMessage == null) {
+            cachedMessage = parseMessageTemplate(rawMessage, this.properties);
+          }
+          return cachedMessage;
         },
         rawMessage,
         get properties() {
           if (cachedProps == null) {
-            cachedProps = {
+            cachedProps = resolveProperties({
               ...implicitContext,
               ...properties(),
-            };
+            });
           }
           return cachedProps;
         },
@@ -1461,12 +1490,22 @@ export class LoggerImpl implements Logger {
         category: this.category,
         level,
         timestamp: Date.now(),
-        message: parseMessageTemplate(rawMessage, {
-          ...implicitContext,
-          ...properties,
-        }),
+        get message() {
+          if (cachedMessage == null) {
+            cachedMessage = parseMessageTemplate(rawMessage, this.properties);
+          }
+          return cachedMessage;
+        },
         rawMessage,
-        properties: { ...implicitContext, ...properties },
+        get properties() {
+          if (cachedProps == null) {
+            cachedProps = resolveProperties({
+              ...implicitContext,
+              ...properties,
+            });
+          }
+          return cachedProps;
+        },
       };
     this.emit(record, bypassSinks);
   }

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -81,7 +81,9 @@ function resolveProperties(
 }
 
 function snapshotLogRecordProperties(record: LogRecord): LogRecord {
-  const properties = resolveProperties(record.properties);
+  const properties: Record<string, unknown> = resolveProperties(
+    record.properties,
+  );
   const descriptors = Object.getOwnPropertyDescriptors(record) as
     & PropertyDescriptorMap
     & { properties?: PropertyDescriptor };
@@ -1426,10 +1428,10 @@ export class LoggerImpl implements Logger {
     ) {
       return;
     }
-    const sinks = [...this.getSinks(record.level)];
+    const sinks: Sink[] = [...this.getSinks(record.level)];
     if (sinks.length < 1) return;
     let snapshot: LogRecord | undefined;
-    let snapshotFailed = false;
+    let snapshotFailed: boolean = false;
     for (const sink of sinks) {
       if (bypassSinks?.has(sink)) continue;
       try {
@@ -1461,7 +1463,7 @@ export class LoggerImpl implements Logger {
     properties: Record<string, unknown> | (() => Record<string, unknown>),
     bypassSinks?: Set<Sink>,
   ): void {
-    const implicitContext = getImplicitContext();
+    const implicitContext: Record<string, unknown> = getImplicitContext();
     let cachedProps: Record<string, unknown> | undefined = undefined;
     let cachedMessage: readonly unknown[] | undefined = undefined;
     const record: LogRecord = typeof properties === "function"


### PR DESCRIPTION
## What changed

This fixes a timing bug where `lazy()` properties could be evaluated when a buffering sink flushed a record, rather than when the log record was emitted.

The main change is in *packages/logtape/src/logger.ts*. Log records now resolve and cache lazy properties at the logger dispatch boundary once the record is actually going to a sink. This keeps lazy values stable for non-blocking console sinks, custom buffering sinks, and other sinks that read `record.properties` later.

The fix still preserves the lazy behavior for records that should not do any work: logs rejected by level checks, filters that do not inspect properties, and loggers with no sinks do not force lazy evaluation.

## Notes

Filters now see the same resolved properties and rendered message that sinks see. Direct lazy properties such as `{ user: lazy(() => currentUser) }` are resolved on demand and cached, so filters can safely inspect `record.properties` or `record.message` without seeing the `Lazy` wrapper.

Rendered messages are also cached to avoid repeated template parsing when formatters or filters read `record.message` more than once.

## Tests

Added focused regression coverage in *packages/logtape/src/logger.test.ts* for:

 -  custom buffering sinks reading records later
 -  `getConsoleSink({ nonBlocking: true })`
 -  filters that inspect direct lazy properties
 -  filters that inspect rendered messages
 -  filters that reject without inspecting lazy values
 -  disabled levels and loggers with no sinks
 -  shared lazy evaluation across multiple sinks
 -  cached message rendering across filter and sink access

Also updated *CHANGES.md*.

Verified with:

```bash
deno test --node-modules-dir=auto packages/logtape/src/logger.test.ts
deno test --node-modules-dir=auto packages/logtape/src/sink.test.ts
mise run check
```

Fixes <https://github.com/dahlia/logtape/issues/156>.
