### PR TITLE
Built-in logfmt formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,8 @@ To be released.
  -  `getAnsiColorFormatter()` now supports timezone control through the
     inherited `timeZone` option from `TextFormatterOptions`.  [[#140]]
 
- -  Added built-in logfmt formatter for readable structured logs.  [[#159]]
+ -  Added built-in logfmt formatter for readable structured logs.
+    [[#159], [#162]]
 
      -  Added `logfmtFormatter` constant.
      -  Added `getLogfmtFormatter()` function.
@@ -56,6 +57,7 @@ To be released.
 [#145]: https://github.com/dahlia/logtape/pull/145
 [#147]: https://github.com/dahlia/logtape/issues/147
 [#159]: https://github.com/dahlia/logtape/issues/159
+[#162]: https://github.com/dahlia/logtape/pull/162
 
 ### @logtape/pretty
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,13 @@ To be released.
  -  `getAnsiColorFormatter()` now supports timezone control through the
     inherited `timeZone` option from `TextFormatterOptions`.  [[#140]]
 
+ -  Added built-in logfmt formatter for readable structured logs.  [[#159]]
+
+     -  Added `logfmtFormatter` constant.
+     -  Added `getLogfmtFormatter()` function.
+     -  Added `LogfmtFormatterOptions` interface.
+     -  Added `#logfmt` configuration shorthand.
+
  -  Added `Logger.warn(error, properties)`, `Logger.warning(error, properties)`,
     `Logger.error(error, properties)`, and `Logger.fatal(error, properties)`
     overloads for attaching extra structured properties while preserving
@@ -48,6 +55,7 @@ To be released.
 [#143]: https://github.com/dahlia/logtape/issues/143
 [#145]: https://github.com/dahlia/logtape/pull/145
 [#147]: https://github.com/dahlia/logtape/issues/147
+[#159]: https://github.com/dahlia/logtape/issues/159
 
 ### @logtape/pretty
 

--- a/docs/manual/config.md
+++ b/docs/manual/config.md
@@ -560,6 +560,7 @@ be called with the remaining configuration options as its argument.
 | `#text`      | `@logtape/logtape#getTextFormatter`      |
 | `#ansiColor` | `@logtape/logtape#getAnsiColorFormatter` |
 | `#jsonLines` | `@logtape/logtape#getJsonLinesFormatter` |
+| `#logfmt`    | `@logtape/logtape#getLogfmtFormatter`    |
 
 #### Formatters
 

--- a/docs/manual/formatters.md
+++ b/docs/manual/formatters.md
@@ -80,7 +80,7 @@ while staying readable in terminals and plain log streams.
 
 It formats log records like this:
 
-~~~~
+~~~~ logfmt
 time=2023-11-14T22:13:20.000Z level=info logger=my.logger msg="Hello, world!" key=value
 ~~~~
 

--- a/docs/manual/formatters.md
+++ b/docs/manual/formatters.md
@@ -15,7 +15,7 @@ Of course, you can write your own sinks that take a text formatter.
 Built-in text formatters
 ------------------------
 
-LogTape provides three built-in text formatters:
+LogTape provides the following built-in text formatters:
 
 ### Default text formatter
 
@@ -69,6 +69,26 @@ It formats log records like this:
 ~~~~
 
 [JSON Lines]: https://jsonlines.org/
+
+### logfmt formatter
+
+*This API is available since LogTape 2.1.0.*
+
+`logfmtFormatter` formats log records as [logfmt], a sequence of
+space-delimited key-value pairs.  It keeps structured properties easy to parse
+while staying readable in terminals and plain log streams.
+
+It formats log records like this:
+
+~~~~
+time=2023-11-14T22:13:20.000Z level=info logger=my.logger msg="Hello, world!" key=value
+~~~~
+
+Values containing whitespace, `=`, `"`, `\`, control characters, or empty
+strings are quoted.  Quoted values escape tabs, newlines, carriage returns,
+quotes, and backslashes.
+
+[logfmt]: https://brandur.org/logfmt
 
 ### Pretty formatter
 
@@ -437,6 +457,55 @@ The properties format. This can be one of the following:
     `properties` key).
 
 The default is `"nest:properties"`.
+
+### logfmt formatter
+
+*This API is available since LogTape 2.1.0.*
+
+You can customize the logfmt formatter by calling
+the `getLogfmtFormatter()` function with a `LogfmtFormatterOptions` object.
+Customizable options include:
+
+#### `~LogfmtFormatterOptions.categorySeparator`
+
+The separator between category names.  For example, if the separator is `"."`,
+the category `["a", "b", "c"]` will be formatted as `"a.b.c"`.
+
+The default separator is `"."`.
+
+If this is a function, it will be called with the category array and should
+return a string, which will be used for rendering the category.
+
+#### `~LogfmtFormatterOptions.message`
+
+The message format.  This can be one of the following:
+
+ -  `"template"`: The raw message template is used as the message.
+ -  `"rendered"`: The message is rendered with the values.
+
+The default is `"rendered"`.
+
+#### `~LogfmtFormatterOptions.properties`
+
+The properties format.  This can be one of the following:
+
+ -  `"flatten"`: The properties are flattened into logfmt key-value pairs.
+ -  `"prepend:<prefix>"`: The properties are prepended with the given prefix
+    (e.g., `"prepend:ctx_"` will prepend `ctx_` to each property key).
+
+The default is `"flatten"`.
+
+#### `~LogfmtFormatterOptions.timeZone`
+
+The timezone used for timestamp rendering.  Behaves the same as
+[`timeZone`](#textformatteroptions-timezone) in the default text formatter.
+
+#### `~LogfmtFormatterOptions.lineEnding`
+
+The line ending style for formatted output.  This can be `"lf"` for Unix-style
+line endings (`\n`) or `"crlf"` for Windows-style line endings (`\r\n`).
+
+The default is `"lf"`.
 
 ### Pretty formatter
 

--- a/docs/manual/formatters.md
+++ b/docs/manual/formatters.md
@@ -89,10 +89,10 @@ strings are quoted.  Quoted values escape tabs, newlines, carriage returns,
 quotes, and backslashes.
 
 Property keys that contain whitespace, `=`, `"`, `%`, control characters, or
-the Unicode replacement character are percent-escaped so that the output stays
-parseable.  For example, the key `user id` is emitted as `user%20id`.
-Logfmt parsers generally expose these escaped key names literally rather than
-decoding them.
+the Unicode replacement character are percent-escaped as UTF-8 bytes so that
+the output stays parseable.  For example, the key `user id` is emitted as
+`user%20id`.  Logfmt parsers generally expose these escaped key names
+literally rather than decoding them.
 
 [logfmt]: https://brandur.org/logfmt
 

--- a/docs/manual/formatters.md
+++ b/docs/manual/formatters.md
@@ -88,6 +88,12 @@ Values containing whitespace, `=`, `"`, `\`, control characters, or empty
 strings are quoted.  Quoted values escape tabs, newlines, carriage returns,
 quotes, and backslashes.
 
+Property keys that contain whitespace, `=`, `"`, `%`, control characters, or
+the Unicode replacement character are percent-escaped so that the output stays
+parseable.  For example, the key `user id` is emitted as `user%20id`.
+Logfmt parsers generally expose these escaped key names literally rather than
+decoding them.
+
 [logfmt]: https://brandur.org/logfmt
 
 ### Pretty formatter

--- a/packages/config/src/shorthands.test.ts
+++ b/packages/config/src/shorthands.test.ts
@@ -52,6 +52,10 @@ test("mergeShorthands()", () => {
     merged.formatters?.text,
     DEFAULT_SHORTHANDS.formatters?.text,
   );
+  assert.strictEqual(
+    DEFAULT_SHORTHANDS.formatters?.logfmt,
+    "@logtape/logtape#getLogfmtFormatter",
+  );
 });
 
 test("mergeShorthands() lets custom shorthands override defaults", () => {

--- a/packages/config/src/shorthands.ts
+++ b/packages/config/src/shorthands.ts
@@ -14,6 +14,7 @@ export const DEFAULT_SHORTHANDS: ShorthandRegistry = {
     text: "@logtape/logtape#getTextFormatter",
     ansiColor: "@logtape/logtape#getAnsiColorFormatter",
     jsonLines: "@logtape/logtape#getJsonLinesFormatter",
+    logfmt: "@logtape/logtape#getLogfmtFormatter",
   },
 };
 

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -355,6 +355,7 @@ import {
   getAnsiColorFormatter,
   getConsoleSink,
   getJsonLinesFormatter,
+  getLogfmtFormatter,
 } from "@logtape/logtape";
 
 // Pretty ANSI-colored output for development
@@ -362,6 +363,9 @@ getConsoleSink({ formatter: getAnsiColorFormatter() });
 
 // JSON Lines for production / log aggregation
 getConsoleSink({ formatter: getJsonLinesFormatter() });
+
+// logfmt for readable structured logs
+getConsoleSink({ formatter: getLogfmtFormatter() });
 ~~~~
 
 For even nicer development output, use `@logtape/pretty`:

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -845,6 +845,26 @@ test("getLogfmtFormatter()", () => {
   );
 });
 
+test("getLogfmtFormatter() preserves tagged template literal segments", () => {
+  function rawMessage(tpl: TemplateStringsArray, ..._: unknown[]) {
+    return tpl;
+  }
+
+  const logRecord: LogRecord = {
+    level: "info",
+    category: ["template"],
+    message: ["a ", 1, " b ", 2, " c"],
+    rawMessage: rawMessage`a ${1} b ${2} c`,
+    timestamp: 1700000000000,
+    properties: {},
+  };
+
+  assert.deepStrictEqual(
+    getLogfmtFormatter({ message: "template" })(logRecord),
+    'time=2023-11-14T22:13:20.000Z level=info logger=template msg="a {} b {} c"\n',
+  );
+});
+
 test("getLogfmtFormatter() escapes values", () => {
   const logRecord: LogRecord = {
     level: "warning",

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -930,11 +930,11 @@ test("getLogfmtFormatter() escapes invalid property keys", () => {
   const parsed = parseLogfmt(output);
 
   assert.deepStrictEqual(parsed.userid, "valid");
-  assert.deepStrictEqual(parsed["user%0020id"], "space");
-  assert.deepStrictEqual(parsed["user%003Did"], "equals");
-  assert.deepStrictEqual(parsed["user%0022id"], "quote");
-  assert.deepStrictEqual(parsed["%0009"], "tab");
-  assert.deepStrictEqual(parsed["user%002520id"], "percent");
+  assert.deepStrictEqual(parsed["user%20id"], "space");
+  assert.deepStrictEqual(parsed["user%3Did"], "equals");
+  assert.deepStrictEqual(parsed["user%22id"], "quote");
+  assert.deepStrictEqual(parsed["%09"], "tab");
+  assert.deepStrictEqual(parsed["user%2520id"], "percent");
 });
 
 test("getLogfmtFormatter() renders BigInt message values", () => {

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -960,6 +960,7 @@ test("getLogfmtFormatter() escapes invalid property keys", () => {
       'user"id': "quote",
       "\t": "tab",
       "user%20id": "percent",
+      "bad\uFFFdkey": "replacement",
       userid: "valid",
     },
   });
@@ -971,6 +972,7 @@ test("getLogfmtFormatter() escapes invalid property keys", () => {
   assert.deepStrictEqual(parsed["user%22id"], "quote");
   assert.deepStrictEqual(parsed["%09"], "tab");
   assert.deepStrictEqual(parsed["user%2520id"], "percent");
+  assert.deepStrictEqual(parsed["bad%EF%BF%BDkey"], "replacement");
 });
 
 test("getLogfmtFormatter() renders BigInt message values", () => {

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -930,11 +930,11 @@ test("getLogfmtFormatter() escapes invalid property keys", () => {
   const parsed = parseLogfmt(output);
 
   assert.deepStrictEqual(parsed.userid, "valid");
-  assert.deepStrictEqual(parsed["user%20id"], "space");
-  assert.deepStrictEqual(parsed["user%3Did"], "equals");
-  assert.deepStrictEqual(parsed["user%22id"], "quote");
-  assert.deepStrictEqual(parsed["%09"], "tab");
-  assert.deepStrictEqual(parsed["user%2520id"], "percent");
+  assert.deepStrictEqual(parsed["user%0020id"], "space");
+  assert.deepStrictEqual(parsed["user%003Did"], "equals");
+  assert.deepStrictEqual(parsed["user%0022id"], "quote");
+  assert.deepStrictEqual(parsed["%0009"], "tab");
+  assert.deepStrictEqual(parsed["user%002520id"], "percent");
 });
 
 test("getLogfmtFormatter() renders BigInt message values", () => {

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -900,6 +900,7 @@ test("getLogfmtFormatter() serializes structured properties", () => {
       error: new Error("boom"),
       nested: { count: 2, labels: ["a", "b"] },
       nil: null,
+      createdAt: new Date("2023-11-14T22:13:20.000Z"),
     },
   };
 
@@ -919,6 +920,7 @@ test("getLogfmtFormatter() serializes structured properties", () => {
   assert.deepStrictEqual(parsedError.name, "Error");
   assert.deepStrictEqual(parsedError.message, "boom");
   assert.deepStrictEqual(parsed.nil, "null");
+  assert.deepStrictEqual(parsed.createdAt, "2023-11-14T22:13:20.000Z");
 });
 
 test("getLogfmtFormatter() coerces browser inspect fallback output", async () => {

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -1089,46 +1089,84 @@ test("getAnsiColorFormatter() with lineEnding option", () => {
 
 function parseLogfmt(line: string): Record<string, string> {
   const result: Record<string, string> = {};
-  let index = 0;
-  const source = line.trimEnd();
-  while (index < source.length) {
-    let key = "";
-    while (index < source.length && source[index] !== "=") {
-      key += source[index];
-      index++;
-    }
-    index++;
+  const source: string = line.trimEnd();
+  let index: number = 0;
 
-    let value = "";
-    if (source[index] === '"') {
-      index++;
-      while (index < source.length && source[index] !== '"') {
-        if (source[index] === "\\") {
-          index++;
-          const escaped = source[index];
-          if (escaped === "n") value += "\n";
-          else if (escaped === "r") value += "\r";
-          else if (escaped === "t") value += "\t";
-          else if (escaped === "u") {
-            value += String.fromCharCode(
-              Number.parseInt(source.slice(index + 1, index + 5), 16),
-            );
-            index += 4;
-          } else value += escaped;
-        } else {
-          value += source[index];
-        }
-        index++;
-      }
-      index++;
-    } else {
-      while (index < source.length && source[index] !== " ") {
-        value += source[index];
-        index++;
-      }
-    }
-    result[key] = value;
+  while (index < source.length) {
+    const keyEnd: number = source.indexOf("=", index);
+    const key: string = source.slice(index, keyEnd);
+    const parsed: ParsedLogfmtValue = source[keyEnd + 1] === '"'
+      ? parseQuotedLogfmtValue(source, keyEnd + 2)
+      : parseBareLogfmtValue(source, keyEnd + 1);
+
+    result[key] = parsed.value;
+    index = parsed.nextIndex;
     if (source[index] === " ") index++;
   }
   return result;
+}
+
+interface ParsedLogfmtValue {
+  readonly value: string;
+  readonly nextIndex: number;
+}
+
+function parseBareLogfmtValue(
+  source: string,
+  startIndex: number,
+): ParsedLogfmtValue {
+  const valueEnd: number = source.indexOf(" ", startIndex);
+  const nextIndex: number = valueEnd < 0 ? source.length : valueEnd;
+  return {
+    value: source.slice(startIndex, nextIndex),
+    nextIndex,
+  };
+}
+
+function parseQuotedLogfmtValue(
+  source: string,
+  startIndex: number,
+): ParsedLogfmtValue {
+  let value: string = "";
+  let index: number = startIndex;
+
+  while (index < source.length && source[index] !== '"') {
+    if (source[index] === "\\") {
+      const parsed: ParsedLogfmtValue = parseLogfmtEscape(source, index + 1);
+      value += parsed.value;
+      index = parsed.nextIndex;
+    } else {
+      value += source[index];
+      index++;
+    }
+  }
+
+  return {
+    value,
+    nextIndex: index + 1,
+  };
+}
+
+function parseLogfmtEscape(
+  source: string,
+  escapeIndex: number,
+): ParsedLogfmtValue {
+  const escaped: string = source[escapeIndex];
+  switch (escaped) {
+    case "n":
+      return { value: "\n", nextIndex: escapeIndex + 1 };
+    case "r":
+      return { value: "\r", nextIndex: escapeIndex + 1 };
+    case "t":
+      return { value: "\t", nextIndex: escapeIndex + 1 };
+    case "u":
+      return {
+        value: String.fromCharCode(
+          Number.parseInt(source.slice(escapeIndex + 1, escapeIndex + 5), 16),
+        ),
+        nextIndex: escapeIndex + 5,
+      };
+    default:
+      return { value: escaped, nextIndex: escapeIndex + 1 };
+  }
 }

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -915,7 +915,7 @@ test("getLogfmtFormatter() serializes structured properties", () => {
   assert.deepStrictEqual(parsed.nil, "null");
 });
 
-test("getLogfmtFormatter() rejects invalid property keys", () => {
+test("getLogfmtFormatter() escapes invalid property keys", () => {
   const output = getLogfmtFormatter()({
     ...info,
     properties: {
@@ -923,16 +923,18 @@ test("getLogfmtFormatter() rejects invalid property keys", () => {
       "user=id": "equals",
       'user"id': "quote",
       "\t": "tab",
+      "user%20id": "percent",
       userid: "valid",
     },
   });
   const parsed = parseLogfmt(output);
 
   assert.deepStrictEqual(parsed.userid, "valid");
-  assert.deepStrictEqual(output.includes("space"), false);
-  assert.deepStrictEqual(output.includes("equals"), false);
-  assert.deepStrictEqual(output.includes("quote"), false);
-  assert.deepStrictEqual(output.includes("tab"), false);
+  assert.deepStrictEqual(parsed["user%20id"], "space");
+  assert.deepStrictEqual(parsed["user%3Did"], "equals");
+  assert.deepStrictEqual(parsed["user%22id"], "quote");
+  assert.deepStrictEqual(parsed["%09"], "tab");
+  assert.deepStrictEqual(parsed["user%2520id"], "percent");
 });
 
 test("getLogfmtFormatter() renders BigInt message values", () => {

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -915,6 +915,42 @@ test("getLogfmtFormatter() serializes structured properties", () => {
   assert.deepStrictEqual(parsed.nil, "null");
 });
 
+test("getLogfmtFormatter() coerces browser inspect fallback output", async () => {
+  const globals = globalThis as { document?: object };
+  const previousDocument = globals.document;
+  globals.document = {};
+
+  try {
+    const { getLogfmtFormatter: getBrowserLogfmtFormatter } = await import(
+      "./formatter.ts?browser-inspect-fallback"
+    );
+    const formatter = getBrowserLogfmtFormatter();
+    const actual = formatter({
+      level: "info",
+      category: ["browser"],
+      message: ["ok"],
+      rawMessage: "ok",
+      timestamp: 1700000000000,
+      properties: {
+        omitted: {
+          toJSON() {
+            return undefined;
+          },
+        },
+      },
+    });
+
+    assert.deepStrictEqual(
+      actual,
+      "time=2023-11-14T22:13:20.000Z level=info logger=browser " +
+        "msg=ok omitted=undefined\n",
+    );
+  } finally {
+    if (previousDocument == null) delete globals.document;
+    else globals.document = previousDocument;
+  }
+});
+
 test("getLogfmtFormatter() escapes invalid property keys", () => {
   const output = getLogfmtFormatter()({
     ...info,

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -9,7 +9,9 @@ import {
   type FormattedValues,
   getAnsiColorFormatter,
   getJsonLinesFormatter,
+  getLogfmtFormatter,
   getTextFormatter,
+  logfmtFormatter,
 } from "./formatter.ts";
 import type { LogLevel } from "./level.ts";
 import type { LogRecord } from "./record.ts";
@@ -812,6 +814,145 @@ test("getJsonLinesFormatter() emits parseable JSON lines", () => {
   );
 });
 
+test("getLogfmtFormatter()", () => {
+  const logRecord: LogRecord = {
+    level: "info",
+    category: ["my-app", "auth"],
+    message: ["User ", "alice", " logged in"],
+    rawMessage: "User {user} logged in",
+    timestamp: 1700000000000,
+    properties: { userId: "12345", duration: "45ms", cached: false },
+  };
+
+  assert.deepStrictEqual(
+    getLogfmtFormatter()(logRecord),
+    'time=2023-11-14T22:13:20.000Z level=info logger=my-app.auth msg="User alice logged in" userId=12345 duration=45ms cached=false\n',
+  );
+
+  assert.deepStrictEqual(
+    logfmtFormatter(logRecord),
+    'time=2023-11-14T22:13:20.000Z level=info logger=my-app.auth msg="User alice logged in" userId=12345 duration=45ms cached=false\n',
+  );
+
+  assert.deepStrictEqual(
+    getLogfmtFormatter({
+      categorySeparator: "/",
+      message: "template",
+      properties: "prepend:prop_",
+      timeZone: "Asia/Seoul",
+    })(logRecord),
+    'time=2023-11-15T07:13:20.000+09:00 level=info logger=my-app/auth msg="User {user} logged in" prop_userId=12345 prop_duration=45ms prop_cached=false\n',
+  );
+});
+
+test("getLogfmtFormatter() escapes values", () => {
+  const logRecord: LogRecord = {
+    level: "warning",
+    category: ["my app"],
+    message: ['bad chars: = " \\ \n \t'],
+    rawMessage: 'bad chars: = " \\ \n \t',
+    timestamp: 1700000000000,
+    properties: {
+      empty: "",
+      nullString: "null",
+      quote: 'a "quote"',
+      path: String.raw`C:\tmp\app.log`,
+      multiline: "first\nsecond",
+    },
+  };
+
+  assert.deepStrictEqual(
+    getLogfmtFormatter()(logRecord),
+    'time=2023-11-14T22:13:20.000Z level=warning logger="my app" msg="bad chars: = \\" \\\\ \\n \\t" empty="" nullString="null" quote="a \\"quote\\"" path="C:\\\\tmp\\\\app.log" multiline="first\\nsecond"\n',
+  );
+});
+
+test("getLogfmtFormatter() serializes structured properties", () => {
+  const recordWithError: LogRecord = {
+    ...info,
+    properties: {
+      error: new Error("boom"),
+      nested: { count: 2, labels: ["a", "b"] },
+      nil: null,
+    },
+  };
+
+  const output = getLogfmtFormatter()(recordWithError);
+  const parsed = parseLogfmt(output);
+
+  assert.deepStrictEqual(parsed.time, "2023-11-14T22:13:20.000Z");
+  assert.deepStrictEqual(parsed.level, "info");
+  assert.deepStrictEqual(parsed.logger, "my-app.junk");
+  assert.deepStrictEqual(parsed.msg, "Hello, 123 & 456!");
+  assert.deepStrictEqual(JSON.parse(parsed.nested), {
+    count: 2,
+    labels: ["a", "b"],
+  });
+
+  const parsedError = JSON.parse(parsed.error);
+  assert.deepStrictEqual(parsedError.name, "Error");
+  assert.deepStrictEqual(parsedError.message, "boom");
+  assert.deepStrictEqual(parsed.nil, "null");
+});
+
+test("getLogfmtFormatter() renders BigInt message values", () => {
+  const logRecord: LogRecord = {
+    level: "debug",
+    category: ["counter"],
+    message: ["Count is ", 123n],
+    rawMessage: "Count is {count}",
+    timestamp: 1700000000000,
+    properties: {},
+  };
+
+  assert.deepStrictEqual(
+    getLogfmtFormatter()(logRecord),
+    'time=2023-11-14T22:13:20.000Z level=debug logger=counter msg="Count is 123"\n',
+  );
+});
+
+test("getLogfmtFormatter() validates properties option", () => {
+  assert.throws(
+    () => getLogfmtFormatter({ properties: "prepend:" }),
+    TypeError,
+    'Invalid properties option: "prepend:". It must be of the form "prepend:<prefix>" where <prefix> is a non-empty string.',
+  );
+});
+
+test("getLogfmtFormatter() emits parseable logfmt lines", () => {
+  fc.assert(
+    fc.property(
+      logLevelArb,
+      fc.array(fc.string()),
+      fc.string(),
+      fc.dictionary(
+        fc.stringMatching(/^[A-Za-z_][A-Za-z0-9_.-]*$/),
+        fc.jsonValue(),
+      ),
+      fc.integer({ min: 0, max: 8_640_000_000_000_000 }),
+      (level, category, message, properties, timestamp) => {
+        const record: LogRecord = {
+          level,
+          category,
+          message: [message],
+          rawMessage: message,
+          timestamp,
+          properties,
+        };
+
+        const line = getLogfmtFormatter()(record);
+        const parsed = parseLogfmt(line);
+
+        assert.strictEqual(line.endsWith("\n"), true);
+        assert.deepStrictEqual(parsed.time, new Date(timestamp).toISOString());
+        assert.deepStrictEqual(parsed.level, level);
+        assert.deepStrictEqual(parsed.logger, category.join("."));
+        assert.deepStrictEqual(parsed.msg, message);
+      },
+    ),
+  );
+});
+
 test("getTextFormatter() with lineEnding option", () => {
   assert.deepStrictEqual(
     getTextFormatter({ lineEnding: "crlf" })(info),
@@ -844,6 +985,17 @@ test("getJsonLinesFormatter() with lineEnding option", () => {
   assert.deepStrictEqual(defaultOutput.endsWith("\r\n"), false);
 });
 
+test("getLogfmtFormatter() with lineEnding option", () => {
+  assert.deepStrictEqual(
+    getLogfmtFormatter({ lineEnding: "crlf" })(info).endsWith("\r\n"),
+    true,
+  );
+  assert.deepStrictEqual(
+    getLogfmtFormatter({ lineEnding: "lf" })(info).endsWith("\r\n"),
+    false,
+  );
+});
+
 test("getAnsiColorFormatter() with lineEnding option", () => {
   assert.deepStrictEqual(
     getAnsiColorFormatter({ lineEnding: "crlf" })(info).endsWith("\r\n"),
@@ -854,3 +1006,49 @@ test("getAnsiColorFormatter() with lineEnding option", () => {
     false,
   );
 });
+
+function parseLogfmt(line: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  let index = 0;
+  const source = line.trimEnd();
+  while (index < source.length) {
+    let key = "";
+    while (index < source.length && source[index] !== "=") {
+      key += source[index];
+      index++;
+    }
+    index++;
+
+    let value = "";
+    if (source[index] === '"') {
+      index++;
+      while (index < source.length && source[index] !== '"') {
+        if (source[index] === "\\") {
+          index++;
+          const escaped = source[index];
+          if (escaped === "n") value += "\n";
+          else if (escaped === "r") value += "\r";
+          else if (escaped === "t") value += "\t";
+          else if (escaped === "u") {
+            value += String.fromCharCode(
+              Number.parseInt(source.slice(index + 1, index + 5), 16),
+            );
+            index += 4;
+          } else value += escaped;
+        } else {
+          value += source[index];
+        }
+        index++;
+      }
+      index++;
+    } else {
+      while (index < source.length && source[index] !== " ") {
+        value += source[index];
+        index++;
+      }
+    }
+    result[key] = value;
+    if (source[index] === " ") index++;
+  }
+  return result;
+}

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -875,6 +875,12 @@ test("getLogfmtFormatter() escapes values", () => {
     properties: {
       empty: "",
       nullString: "null",
+      undefinedString: "undefined",
+      trueString: "true",
+      falseString: "false",
+      actualUndefined: undefined,
+      actualTrue: true,
+      actualFalse: false,
       quote: 'a "quote"',
       path: String.raw`C:\tmp\app.log`,
       multiline: "first\nsecond",
@@ -883,7 +889,7 @@ test("getLogfmtFormatter() escapes values", () => {
 
   assert.deepStrictEqual(
     getLogfmtFormatter()(logRecord),
-    'time=2023-11-14T22:13:20.000Z level=warning logger="my app" msg="bad chars: = \\" \\\\ \\n \\t" empty="" nullString="null" quote="a \\"quote\\"" path="C:\\\\tmp\\\\app.log" multiline="first\\nsecond"\n',
+    'time=2023-11-14T22:13:20.000Z level=warning logger="my app" msg="bad chars: = \\" \\\\ \\n \\t" empty="" nullString="null" undefinedString="undefined" trueString="true" falseString="false" actualUndefined=undefined actualTrue=true actualFalse=false quote="a \\"quote\\"" path="C:\\\\tmp\\\\app.log" multiline="first\\nsecond"\n',
   );
 });
 

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -1094,6 +1094,7 @@ function parseLogfmt(line: string): Record<string, string> {
 
   while (index < source.length) {
     const keyEnd: number = source.indexOf("=", index);
+    if (keyEnd < 0) break;
     const key: string = source.slice(index, keyEnd);
     const parsed: ParsedLogfmtValue = source[keyEnd + 1] === '"'
       ? parseQuotedLogfmtValue(source, keyEnd + 2)

--- a/packages/logtape/src/formatter.test.ts
+++ b/packages/logtape/src/formatter.test.ts
@@ -915,6 +915,26 @@ test("getLogfmtFormatter() serializes structured properties", () => {
   assert.deepStrictEqual(parsed.nil, "null");
 });
 
+test("getLogfmtFormatter() rejects invalid property keys", () => {
+  const output = getLogfmtFormatter()({
+    ...info,
+    properties: {
+      "user id": "space",
+      "user=id": "equals",
+      'user"id': "quote",
+      "\t": "tab",
+      userid: "valid",
+    },
+  });
+  const parsed = parseLogfmt(output);
+
+  assert.deepStrictEqual(parsed.userid, "valid");
+  assert.deepStrictEqual(output.includes("space"), false);
+  assert.deepStrictEqual(output.includes("equals"), false);
+  assert.deepStrictEqual(output.includes("quote"), false);
+  assert.deepStrictEqual(output.includes("tab"), false);
+});
+
 test("getLogfmtFormatter() renders BigInt message values", () => {
   const logRecord: LogRecord = {
     level: "debug",

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -33,7 +33,7 @@ const levelAbbreviations: Record<LogLevel, string> = {
  *                If `colors` is `true`, the output will be ANSI-colored.
  * @returns The string representation of the value.
  */
-const inspectValue: (
+const platformInspect: (
   value: unknown,
   options?: { colors?: boolean },
 ) => unknown =
@@ -74,7 +74,7 @@ const inspectValue: (
 const inspect: (value: unknown, options?: { colors?: boolean }) => string = (
   value: unknown,
   options?: { colors?: boolean },
-): string => String(inspectValue(value, options));
+): string => String(platformInspect(value, options));
 
 const utf8Encoder = new TextEncoder();
 
@@ -1203,16 +1203,6 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
   const msgLen = record.message.length;
   if (msgLen === 1) return record.message[0] as string;
 
-  if (msgLen <= 6) {
-    let msg: string = "";
-    for (let i = 0; i < msgLen; i++) {
-      msg += (i % 2 === 0)
-        ? record.message[i] as string
-        : stringifyLogfmtValue(record.message[i]);
-    }
-    return msg;
-  }
-
   const parts: string[] = new Array(msgLen);
   for (let i = 0; i < msgLen; i++) {
     parts[i] = (i % 2 === 0)
@@ -1287,26 +1277,35 @@ function quoteLogfmtValue(value: string, quoteNull: boolean): string {
 
   for (const char of value) {
     const code: number = char.codePointAt(0)!;
-    if (
-      code <= 0x20 || code === 0x7f || code === 0xfffd ||
-      char === "=" || char === '"' || char === "\\"
-    ) {
-      needsQuote = true;
-    }
-
-    if (char === "\t") quoted += "\\t";
-    else if (char === "\n") quoted += "\\n";
-    else if (char === "\r") quoted += "\\r";
-    else if (char === '"') quoted += '\\"';
-    else if (char === "\\") quoted += "\\\\";
-    else if (code <= 0x1f || code === 0x7f) {
-      quoted += `\\u${code.toString(16).padStart(4, "0")}`;
-    } else {
-      quoted += char;
-    }
+    if (shouldQuoteLogfmtValueChar(char, code)) needsQuote = true;
+    quoted += escapeLogfmtValueChar(char, code);
   }
 
   return needsQuote ? `"${quoted}"` : value;
+}
+
+function shouldQuoteLogfmtValueChar(char: string, code: number): boolean {
+  return code <= 0x20 || code === 0x7f || code === 0xfffd ||
+    char === "=" || char === '"' || char === "\\";
+}
+
+function escapeLogfmtValueChar(char: string, code: number): string {
+  switch (char) {
+    case "\t":
+      return "\\t";
+    case "\n":
+      return "\\n";
+    case "\r":
+      return "\\r";
+    case '"':
+      return '\\"';
+    case "\\":
+      return "\\\\";
+    default:
+      return code <= 0x1f || code === 0x7f
+        ? `\\u${code.toString(16).padStart(4, "0")}`
+        : char;
+  }
 }
 
 function formatLogfmtValue(value: unknown): string {

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1213,19 +1213,33 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
 }
 
 function filterLogfmtKey(key: string): string | null {
-  let result = "";
+  if (key === "") return null;
+
+  let needsEscape: boolean = false;
   for (const char of key) {
-    const code = char.codePointAt(0)!;
-    if (
-      code <= 0x20 || code === 0x7f || code === 0xfffd ||
-      char === "=" || char === '"' || char === "%"
-    ) {
+    const code: number = char.codePointAt(0)!;
+    if (shouldEscapeLogfmtKeyChar(char, code)) {
+      needsEscape = true;
+      break;
+    }
+  }
+  if (!needsEscape) return key;
+
+  let result: string = "";
+  for (const char of key) {
+    const code: number = char.codePointAt(0)!;
+    if (shouldEscapeLogfmtKeyChar(char, code)) {
       result += `%${code.toString(16).toUpperCase().padStart(2, "0")}`;
     } else {
       result += char;
     }
   }
-  return result === "" ? null : result;
+  return result;
+}
+
+function shouldEscapeLogfmtKeyChar(char: string, code: number): boolean {
+  return code <= 0x20 || code === 0x7f || code === 0xfffd ||
+    char === "=" || char === '"' || char === "%";
 }
 
 function stringifyLogfmtValue(value: unknown): string {
@@ -1246,15 +1260,15 @@ function stringifyLogfmtValue(value: unknown): string {
     // Fall back to inspect below.
   }
 
-  return inspect(value, { colors: false });
+  return String(inspect(value, { colors: false }));
 }
 
 function quoteLogfmtValue(value: string, quoteNull: boolean): string {
-  let needsQuote = value === "" || quoteNull && value === "null";
-  let quoted = "";
+  let needsQuote: boolean = value === "" || quoteNull && value === "null";
+  let quoted: string = "";
 
   for (const char of value) {
-    const code = char.codePointAt(0)!;
+    const code: number = char.codePointAt(0)!;
     if (
       code <= 0x20 || code === 0x7f || code === 0xfffd ||
       char === "=" || char === '"' || char === "\\"
@@ -1267,7 +1281,7 @@ function quoteLogfmtValue(value: string, quoteNull: boolean): string {
     else if (char === "\r") quoted += "\\r";
     else if (char === '"') quoted += '\\"';
     else if (char === "\\") quoted += "\\\\";
-    else if (code != null && (code <= 0x1f || code === 0x7f)) {
+    else if (code <= 0x1f || code === 0x7f) {
       quoted += `\\u${code.toString(16).padStart(4, "0")}`;
     } else {
       quoted += char;

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1123,6 +1123,254 @@ export function getJsonLinesFormatter(
 export const jsonLinesFormatter: TextFormatter = getJsonLinesFormatter();
 
 /**
+ * Options for the {@link getLogfmtFormatter} function.
+ * @since 2.1.0
+ */
+export interface LogfmtFormatterOptions {
+  /**
+   * The separator between category names.  For example, if the separator is
+   * `"."`, the category `["a", "b", "c"]` will be formatted as `"a.b.c"`.
+   * If this is a function, it will be called with the category array and
+   * should return a string, which will be used for rendering the category.
+   *
+   * @default `"."`
+   */
+  readonly categorySeparator?:
+    | string
+    | ((category: readonly string[]) => string);
+
+  /**
+   * The message format.  This can be one of the following:
+   *
+   * - `"template"`: The raw message template is used as the message.
+   * - `"rendered"`: The message is rendered with the values.
+   *
+   * @default `"rendered"`
+   */
+  readonly message?: "template" | "rendered";
+
+  /**
+   * The properties format.  This can be one of the following:
+   *
+   * - `"flatten"`: The properties are flattened into logfmt key-value pairs.
+   * - `"prepend:<prefix>"`: The properties are prepended with the given prefix
+   *   (e.g., `"prepend:ctx_"` will prepend `ctx_` to each property key).
+   *
+   * @default `"flatten"`
+   */
+  readonly properties?: "flatten" | `prepend:${string}`;
+
+  /**
+   * The timezone used for timestamp rendering.
+   *
+   * - `undefined` (default): UTC
+   * - `null`: System local timezone
+   * - IANA timezone name such as `"America/Bogota"` or `"Asia/Seoul"`
+   * - Fixed UTC offset string such as `"+09:00"` or `"-05:00"`
+   *
+   * @since 2.1.0
+   */
+  readonly timeZone?: string | null;
+
+  /**
+   * Line ending style for formatted output.
+   *
+   * - `"lf"`: Unix-style line endings (`\n`)
+   * - `"crlf"`: Windows-style line endings (`\r\n`)
+   *
+   * @default "lf"
+   * @since 2.1.0
+   */
+  readonly lineEnding?: "lf" | "crlf";
+}
+
+function renderStructuredMessage(record: LogRecord, template: boolean): string {
+  if (template) {
+    if (typeof record.rawMessage === "string") return record.rawMessage;
+    let msg = "";
+    for (let i = 0; i < record.rawMessage.length; i++) {
+      msg += i % 2 < 1 ? record.rawMessage[i] : "{}";
+    }
+    return msg;
+  }
+
+  const msgLen = record.message.length;
+  if (msgLen === 1) return record.message[0] as string;
+
+  let msg = "";
+  for (let i = 0; i < msgLen; i++) {
+    msg += (i % 2 < 1)
+      ? record.message[i]
+      : stringifyLogfmtValue(record.message[i]);
+  }
+  return msg;
+}
+
+function filterLogfmtKey(key: string): string | null {
+  let result = "";
+  for (const char of key) {
+    const code = char.codePointAt(0);
+    if (
+      code == null || code <= 0x20 || code === 0x7f || code === 0xfffd ||
+      char === "=" || char === '"'
+    ) {
+      continue;
+    }
+    result += char;
+  }
+  return result === "" ? null : result;
+}
+
+function stringifyLogfmtValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null) return "null";
+  if (
+    typeof value === "number" || typeof value === "boolean" ||
+    typeof value === "bigint" || typeof value === "undefined" ||
+    typeof value === "symbol" || typeof value === "function"
+  ) {
+    return String(value);
+  }
+
+  try {
+    const json = JSON.stringify(value, jsonReplacer);
+    if (typeof json === "string") return json;
+  } catch {
+    // Fall back to inspect below.
+  }
+
+  return inspect(value, { colors: false });
+}
+
+function quoteLogfmtValue(value: string, quoteNull: boolean): string {
+  let needsQuote = value === "" || quoteNull && value === "null";
+  let quoted = "";
+
+  for (const char of value) {
+    const code = char.codePointAt(0);
+    if (
+      code == null || code <= 0x20 || code === 0x7f || code === 0xfffd ||
+      char === "=" || char === '"' || char === "\\"
+    ) {
+      needsQuote = true;
+    }
+
+    if (char === "\t") quoted += "\\t";
+    else if (char === "\n") quoted += "\\n";
+    else if (char === "\r") quoted += "\\r";
+    else if (char === '"') quoted += '\\"';
+    else if (char === "\\") quoted += "\\\\";
+    else if (code != null && (code <= 0x1f || code === 0x7f)) {
+      quoted += `\\u${code.toString(16).padStart(4, "0")}`;
+    } else {
+      quoted += char;
+    }
+  }
+
+  return needsQuote ? `"${quoted}"` : value;
+}
+
+function formatLogfmtValue(value: unknown): string {
+  const stringified = stringifyLogfmtValue(value);
+  return quoteLogfmtValue(stringified, typeof value === "string");
+}
+
+function pushLogfmtPair(
+  pairs: string[],
+  key: string,
+  value: unknown,
+): void {
+  const filteredKey = filterLogfmtKey(key);
+  if (filteredKey == null) return;
+  pairs.push(`${filteredKey}=${formatLogfmtValue(value)}`);
+}
+
+/**
+ * Get a [logfmt] formatter with the specified options.  The log records
+ * will be rendered as space-delimited key-value pairs, one record per line.
+ * It looks like this:
+ *
+ * ```text
+ * time=2023-11-14T22:13:20.000Z level=info logger=my.logger msg="Hello, world!" key=value
+ * ```
+ *
+ * [logfmt]: https://brandur.org/logfmt
+ * @param options The options for the logfmt formatter.
+ * @returns The logfmt formatter.
+ * @since 2.1.0
+ */
+export function getLogfmtFormatter(
+  options: LogfmtFormatterOptions = {},
+): TextFormatter {
+  const lineEnding = getLineEndingValue(options.lineEnding);
+  const timestampRenderer = createTimestampFormatter(
+    "rfc3339",
+    resolveTimeZone(options.timeZone),
+  );
+  const isTemplateMessage = options.message === "template";
+  const propertiesOption = options.properties ?? "flatten";
+
+  let joinCategory: (category: readonly string[]) => string;
+  if (typeof options.categorySeparator === "function") {
+    joinCategory = options.categorySeparator;
+  } else {
+    const separator = options.categorySeparator ?? ".";
+    joinCategory = (category: readonly string[]): string =>
+      category.join(separator);
+  }
+
+  let propertyPrefix = "";
+  if (propertiesOption === "flatten") {
+    propertyPrefix = "";
+  } else if (propertiesOption.startsWith("prepend:")) {
+    propertyPrefix = propertiesOption.substring(8);
+    if (propertyPrefix === "") {
+      throw new TypeError(
+        `Invalid properties option: ${
+          JSON.stringify(propertiesOption)
+        }. It must be of the form "prepend:<prefix>" where <prefix> is a non-empty string.`,
+      );
+    }
+  } else {
+    throw new TypeError(
+      `Invalid properties option: ${
+        JSON.stringify(propertiesOption)
+      }. It must be "flatten" or "prepend:<prefix>".`,
+    );
+  }
+
+  return (record: LogRecord): string => {
+    const pairs: string[] = [];
+    pushLogfmtPair(pairs, "time", timestampRenderer(record.timestamp));
+    pushLogfmtPair(pairs, "level", record.level);
+    pushLogfmtPair(pairs, "logger", joinCategory(record.category));
+    pushLogfmtPair(
+      pairs,
+      "msg",
+      renderStructuredMessage(
+        record,
+        isTemplateMessage,
+      ),
+    );
+
+    for (const [key, value] of Object.entries(record.properties)) {
+      pushLogfmtPair(pairs, `${propertyPrefix}${key}`, value);
+    }
+
+    return `${pairs.join(" ")}${lineEnding}`;
+  };
+}
+
+/**
+ * The default [logfmt] formatter.  This formatter formats log records as
+ * space-delimited key-value pairs, one record per line.
+ *
+ * [logfmt]: https://brandur.org/logfmt
+ * @since 2.1.0
+ */
+export const logfmtFormatter: TextFormatter = getLogfmtFormatter();
+
+/**
  * A console formatter is a function that accepts a log record and returns
  * an array of arguments to pass to {@link console.log}.
  *

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1197,7 +1197,7 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
     let msg = "";
     for (let i = 0; i < msgLen; i++) {
       msg += (i % 2 === 0)
-        ? record.message[i]
+        ? record.message[i] as string
         : stringifyLogfmtValue(record.message[i]);
     }
     return msg;
@@ -1218,11 +1218,14 @@ function filterLogfmtKey(key: string): string | null {
     const code = char.codePointAt(0);
     if (
       code == null || code <= 0x20 || code === 0x7f || code === 0xfffd ||
-      char === "=" || char === '"'
+      char === "=" || char === '"' || char === "%"
     ) {
-      return null;
+      result += `%${
+        (code ?? 0xfffd).toString(16).toUpperCase().padStart(2, "0")
+      }`;
+    } else {
+      result += char;
     }
-    result += char;
   }
   return result === "" ? null : result;
 }

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1412,8 +1412,14 @@ export function getLogfmtFormatter(
       ),
     );
 
-    for (const [key, value] of Object.entries(record.properties)) {
-      pushLogfmtPair(pairs, `${propertyPrefix}${key}`, value);
+    for (const key in record.properties) {
+      if (Object.prototype.hasOwnProperty.call(record.properties, key)) {
+        pushLogfmtPair(
+          pairs,
+          `${propertyPrefix}${key}`,
+          record.properties[key],
+        );
+      }
     }
 
     return `${pairs.join(" ")}${lineEnding}`;

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1196,7 +1196,7 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
   if (msgLen <= 6) {
     let msg = "";
     for (let i = 0; i < msgLen; i++) {
-      msg += (i % 2 < 1)
+      msg += (i % 2 === 0)
         ? record.message[i]
         : stringifyLogfmtValue(record.message[i]);
     }
@@ -1205,7 +1205,7 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
 
   const parts: string[] = new Array(msgLen);
   for (let i = 0; i < msgLen; i++) {
-    parts[i] = (i % 2 < 1)
+    parts[i] = (i % 2 === 0)
       ? record.message[i] as string
       : stringifyLogfmtValue(record.message[i]);
   }

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1221,7 +1221,7 @@ function filterLogfmtKey(key: string): string | null {
       char === "=" || char === '"' || char === "%"
     ) {
       result += `%${
-        (code ?? 0xfffd).toString(16).toUpperCase().padStart(2, "0")
+        (code ?? 0xfffd).toString(16).toUpperCase().padStart(4, "0")
       }`;
     } else {
       result += char;
@@ -1311,6 +1311,7 @@ function pushLogfmtPair(
 export function getLogfmtFormatter(
   options: LogfmtFormatterOptions = {},
 ): TextFormatter {
+  const prependPrefix = "prepend:";
   const lineEnding: string = getLineEndingValue(options.lineEnding);
   const timestampRenderer: (ts: number) => string | null =
     createTimestampFormatter(
@@ -1332,8 +1333,8 @@ export function getLogfmtFormatter(
   let propertyPrefix = "";
   if (propertiesOption === "flatten") {
     propertyPrefix = "";
-  } else if (propertiesOption.startsWith("prepend:")) {
-    propertyPrefix = propertiesOption.substring(8);
+  } else if (propertiesOption.startsWith(prependPrefix)) {
+    propertyPrefix = propertiesOption.substring(prependPrefix.length);
     if (propertyPrefix === "") {
       throw new TypeError(
         `Invalid properties option: ${

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -36,7 +36,7 @@ const levelAbbreviations: Record<LogLevel, string> = {
 const platformInspect: (
   value: unknown,
   options?: { colors?: boolean },
-) => unknown =
+) => string | undefined =
   // @ts-ignore: Browser detection
   // dnt-shim-ignore
   typeof document !== "undefined" ||

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1193,13 +1193,23 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
   const msgLen = record.message.length;
   if (msgLen === 1) return record.message[0] as string;
 
-  let msg = "";
+  if (msgLen <= 6) {
+    let msg = "";
+    for (let i = 0; i < msgLen; i++) {
+      msg += (i % 2 < 1)
+        ? record.message[i]
+        : stringifyLogfmtValue(record.message[i]);
+    }
+    return msg;
+  }
+
+  const parts: string[] = new Array(msgLen);
   for (let i = 0; i < msgLen; i++) {
-    msg += (i % 2 < 1)
-      ? record.message[i]
+    parts[i] = (i % 2 < 1)
+      ? record.message[i] as string
       : stringifyLogfmtValue(record.message[i]);
   }
-  return msg;
+  return parts.join("");
 }
 
 function filterLogfmtKey(key: string): string | null {

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1308,11 +1308,12 @@ function pushLogfmtPair(
 export function getLogfmtFormatter(
   options: LogfmtFormatterOptions = {},
 ): TextFormatter {
-  const lineEnding = getLineEndingValue(options.lineEnding);
-  const timestampRenderer = createTimestampFormatter(
-    "rfc3339",
-    resolveTimeZone(options.timeZone),
-  );
+  const lineEnding: string = getLineEndingValue(options.lineEnding);
+  const timestampRenderer: (ts: number) => string | null =
+    createTimestampFormatter(
+      "rfc3339",
+      resolveTimeZone(options.timeZone),
+    );
   const isTemplateMessage = options.message === "template";
   const propertiesOption = options.properties ?? "flatten";
 

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1187,11 +1187,7 @@ export interface LogfmtFormatterOptions {
 function renderStructuredMessage(record: LogRecord, template: boolean): string {
   if (template) {
     if (typeof record.rawMessage === "string") return record.rawMessage;
-    let msg = "";
-    for (let i = 0; i < record.rawMessage.length; i++) {
-      msg += i % 2 < 1 ? record.rawMessage[i] : "{}";
-    }
-    return msg;
+    return record.rawMessage.join("{}");
   }
 
   const msgLen = record.message.length;

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1260,12 +1260,19 @@ function stringifyLogfmtValue(value: unknown): string {
 
   try {
     const json: string | undefined = JSON.stringify(value, jsonReplacer);
-    if (typeof json === "string") return json;
+    if (typeof json === "string") return unwrapJsonStringLiteral(json);
   } catch {
     // Fall back to inspect below.
   }
 
   return inspect(value, { colors: false });
+}
+
+function unwrapJsonStringLiteral(json: string): string {
+  if (json.startsWith('"') && json.endsWith('"')) {
+    return JSON.parse(json) as string;
+  }
+  return json;
 }
 
 function quoteLogfmtValue(value: string, isString: boolean): string {

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -78,6 +78,35 @@ const inspect: (value: unknown, options?: { colors?: boolean }) => string = (
 
 const utf8Encoder = new TextEncoder();
 
+function renderMessageParts(
+  msgParts: readonly unknown[],
+  valueRenderer: (value: unknown) => string,
+): string {
+  const msgLen: number = msgParts.length;
+
+  if (msgLen === 1) {
+    return msgParts[0] as string;
+  }
+
+  if (msgLen <= 6) {
+    let message: string = "";
+    for (let i = 0; i < msgLen; i++) {
+      message += (i % 2 === 0)
+        ? msgParts[i] as string
+        : valueRenderer(msgParts[i]);
+    }
+    return message;
+  }
+
+  const parts: string[] = new Array(msgLen);
+  for (let i = 0; i < msgLen; i++) {
+    parts[i] = (i % 2 === 0)
+      ? msgParts[i] as string
+      : valueRenderer(msgParts[i]);
+  }
+  return parts.join("");
+}
+
 /**
  * The formatted values for a log record.
  * @since 0.6.0
@@ -636,30 +665,7 @@ export function getTextFormatter(
       `${timestamp ? `${timestamp} ` : ""}[${level}] ${category}: ${message}`);
 
   return (record: LogRecord): string => {
-    // Optimized message building
-    const msgParts = record.message;
-    const msgLen = msgParts.length;
-
-    let message: string;
-    if (msgLen === 1) {
-      // Fast path for simple messages with no interpolation
-      message = msgParts[0] as string;
-    } else if (msgLen <= 6) {
-      // Fast path for small messages - direct concatenation
-      message = "";
-      for (let i = 0; i < msgLen; i++) {
-        message += (i % 2 === 0) ? msgParts[i] : valueRenderer(msgParts[i]);
-      }
-    } else {
-      // Optimized path for larger messages - array join
-      const parts: string[] = new Array(msgLen);
-      for (let i = 0; i < msgLen; i++) {
-        parts[i] = (i % 2 === 0)
-          ? msgParts[i] as string
-          : valueRenderer(msgParts[i]);
-      }
-      message = parts.join("");
-    }
+    const message: string = renderMessageParts(record.message, valueRenderer);
 
     const timestamp = timestampRenderer(record.timestamp);
     const level = levelRenderer(record.level);
@@ -1200,16 +1206,7 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
     return record.rawMessage.join("{}");
   }
 
-  const msgLen = record.message.length;
-  if (msgLen === 1) return record.message[0] as string;
-
-  const parts: string[] = new Array(msgLen);
-  for (let i = 0; i < msgLen; i++) {
-    parts[i] = (i % 2 === 0)
-      ? record.message[i] as string
-      : stringifyLogfmtValue(record.message[i]);
-  }
-  return parts.join("");
+  return renderMessageParts(record.message, stringifyLogfmtValue);
 }
 
 function filterLogfmtKey(key: string): string | null {

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1215,14 +1215,12 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
 function filterLogfmtKey(key: string): string | null {
   let result = "";
   for (const char of key) {
-    const code = char.codePointAt(0);
+    const code = char.codePointAt(0)!;
     if (
-      code == null || code <= 0x20 || code === 0x7f || code === 0xfffd ||
+      code <= 0x20 || code === 0x7f || code === 0xfffd ||
       char === "=" || char === '"' || char === "%"
     ) {
-      result += `%${
-        (code ?? 0xfffd).toString(16).toUpperCase().padStart(4, "0")
-      }`;
+      result += `%${code.toString(16).toUpperCase().padStart(2, "0")}`;
     } else {
       result += char;
     }
@@ -1256,9 +1254,9 @@ function quoteLogfmtValue(value: string, quoteNull: boolean): string {
   let quoted = "";
 
   for (const char of value) {
-    const code = char.codePointAt(0);
+    const code = char.codePointAt(0)!;
     if (
-      code == null || code <= 0x20 || code === 0x7f || code === 0xfffd ||
+      code <= 0x20 || code === 0x7f || code === 0xfffd ||
       char === "=" || char === '"' || char === "\\"
     ) {
       needsQuote = true;

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -76,6 +76,8 @@ const inspect: (value: unknown, options?: { colors?: boolean }) => string = (
   options?: { colors?: boolean },
 ): string => String(inspectValue(value, options));
 
+const utf8Encoder = new TextEncoder();
+
 /**
  * The formatted values for a log record.
  * @since 0.6.0
@@ -1237,7 +1239,7 @@ function filterLogfmtKey(key: string): string | null {
   for (const char of key) {
     const code: number = char.codePointAt(0)!;
     if (shouldEscapeLogfmtKeyChar(char, code)) {
-      result += `%${code.toString(16).toUpperCase().padStart(2, "0")}`;
+      result += encodeLogfmtKeyChar(char);
     } else {
       result += char;
     }
@@ -1248,6 +1250,14 @@ function filterLogfmtKey(key: string): string | null {
 function shouldEscapeLogfmtKeyChar(char: string, code: number): boolean {
   return code <= 0x20 || code === 0x7f || code === 0xfffd ||
     char === "=" || char === '"' || char === "%";
+}
+
+function encodeLogfmtKeyChar(char: string): string {
+  let result: string = "";
+  for (const byte of utf8Encoder.encode(char)) {
+    result += `%${byte.toString(16).toUpperCase().padStart(2, "0")}`;
+  }
+  return result;
 }
 
 function stringifyLogfmtValue(value: unknown): string {

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1220,7 +1220,7 @@ function filterLogfmtKey(key: string): string | null {
       code == null || code <= 0x20 || code === 0x7f || code === 0xfffd ||
       char === "=" || char === '"'
     ) {
-      continue;
+      return null;
     }
     result += char;
   }

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -1268,17 +1268,30 @@ function stringifyLogfmtValue(value: unknown): string {
   return inspect(value, { colors: false });
 }
 
-function quoteLogfmtValue(value: string, quoteNull: boolean): string {
-  let needsQuote: boolean = value === "" || quoteNull && value === "null";
-  let quoted: string = "";
+function quoteLogfmtValue(value: string, isString: boolean): string {
+  let needsQuote: boolean = value === "" ||
+    isString && shouldQuoteStringLiteral(value);
 
   for (const char of value) {
     const code: number = char.codePointAt(0)!;
-    if (shouldQuoteLogfmtValueChar(char, code)) needsQuote = true;
+    if (shouldQuoteLogfmtValueChar(char, code)) {
+      needsQuote = true;
+      break;
+    }
+  }
+  if (!needsQuote) return value;
+
+  let quoted: string = "";
+  for (const char of value) {
+    const code: number = char.codePointAt(0)!;
     quoted += escapeLogfmtValueChar(char, code);
   }
+  return `"${quoted}"`;
+}
 
-  return needsQuote ? `"${quoted}"` : value;
+function shouldQuoteStringLiteral(value: string): boolean {
+  return value === "null" || value === "undefined" || value === "true" ||
+    value === "false";
 }
 
 function shouldQuoteLogfmtValueChar(char: string, code: number): boolean {

--- a/packages/logtape/src/formatter.ts
+++ b/packages/logtape/src/formatter.ts
@@ -33,7 +33,10 @@ const levelAbbreviations: Record<LogLevel, string> = {
  *                If `colors` is `true`, the output will be ANSI-colored.
  * @returns The string representation of the value.
  */
-const inspect: (value: unknown, options?: { colors?: boolean }) => string =
+const inspectValue: (
+  value: unknown,
+  options?: { colors?: boolean },
+) => unknown =
   // @ts-ignore: Browser detection
   // dnt-shim-ignore
   typeof document !== "undefined" ||
@@ -67,6 +70,11 @@ const inspect: (value: unknown, options?: { colors?: boolean }) => string =
         ...opts,
       })
     : (v) => JSON.stringify(v);
+
+const inspect: (value: unknown, options?: { colors?: boolean }) => string = (
+  value: unknown,
+  options?: { colors?: boolean },
+): string => String(inspectValue(value, options));
 
 /**
  * The formatted values for a log record.
@@ -1194,7 +1202,7 @@ function renderStructuredMessage(record: LogRecord, template: boolean): string {
   if (msgLen === 1) return record.message[0] as string;
 
   if (msgLen <= 6) {
-    let msg = "";
+    let msg: string = "";
     for (let i = 0; i < msgLen; i++) {
       msg += (i % 2 === 0)
         ? record.message[i] as string
@@ -1254,13 +1262,13 @@ function stringifyLogfmtValue(value: unknown): string {
   }
 
   try {
-    const json = JSON.stringify(value, jsonReplacer);
+    const json: string | undefined = JSON.stringify(value, jsonReplacer);
     if (typeof json === "string") return json;
   } catch {
     // Fall back to inspect below.
   }
 
-  return String(inspect(value, { colors: false }));
+  return inspect(value, { colors: false });
 }
 
 function quoteLogfmtValue(value: string, quoteNull: boolean): string {
@@ -1323,15 +1331,16 @@ function pushLogfmtPair(
 export function getLogfmtFormatter(
   options: LogfmtFormatterOptions = {},
 ): TextFormatter {
-  const prependPrefix = "prepend:";
+  const prependPrefix: string = "prepend:";
   const lineEnding: string = getLineEndingValue(options.lineEnding);
   const timestampRenderer: (ts: number) => string | null =
     createTimestampFormatter(
       "rfc3339",
       resolveTimeZone(options.timeZone),
     );
-  const isTemplateMessage = options.message === "template";
-  const propertiesOption = options.properties ?? "flatten";
+  const isTemplateMessage: boolean = options.message === "template";
+  const propertiesOption: "flatten" | `prepend:${string}` =
+    options.properties ?? "flatten";
 
   let joinCategory: (category: readonly string[]) => string;
   if (typeof options.categorySeparator === "function") {
@@ -1342,16 +1351,17 @@ export function getLogfmtFormatter(
       category.join(separator);
   }
 
-  let propertyPrefix = "";
+  let propertyPrefix: string = "";
   if (propertiesOption === "flatten") {
     propertyPrefix = "";
   } else if (propertiesOption.startsWith(prependPrefix)) {
     propertyPrefix = propertiesOption.substring(prependPrefix.length);
     if (propertyPrefix === "") {
       throw new TypeError(
-        `Invalid properties option: ${
-          JSON.stringify(propertiesOption)
-        }. It must be of the form "prepend:<prefix>" where <prefix> is a non-empty string.`,
+        "Invalid properties option: " + JSON.stringify(propertiesOption) +
+          ". " +
+          'It must be of the form "prepend:<prefix>" where <prefix> is a ' +
+          "non-empty string.",
       );
     }
   } else {

--- a/packages/logtape/src/mod.ts
+++ b/packages/logtape/src/mod.ts
@@ -32,9 +32,12 @@ export {
   type FormattedValues,
   getAnsiColorFormatter,
   getJsonLinesFormatter,
+  getLogfmtFormatter,
   getTextFormatter,
   jsonLinesFormatter,
   type JsonLinesFormatterOptions,
+  logfmtFormatter,
+  type LogfmtFormatterOptions,
   type TextFormatter,
   type TextFormatterOptions,
 } from "./formatter.ts";


### PR DESCRIPTION
## Summary

This PR adds a built-in logfmt formatter to *@logtape/logtape* for readable structured logs. The new formatter emits one log record per line as key-value pairs such as `time=2023-11-14T22:13:20.000Z level=info logger=my.logger msg="Hello, world!" key=value`.

The formatter is exposed as `logfmtFormatter` and `getLogfmtFormatter()`, with options for category joining, rendered vs. template messages, property prefixing, timezone-aware timestamps, and line endings. It also adds the `#logfmt` configuration shorthand.

Closes https://github.com/dahlia/logtape/issues/159

## Changes

- Added `LogfmtFormatterOptions`, `getLogfmtFormatter()`, and `logfmtFormatter` in *packages/logtape/src/formatter.ts*.
- Re-exported the new formatter API from *packages/logtape/src/mod.ts*.
- Added the `#logfmt` shorthand in *packages/config/src/shorthands.ts*.
- Added formatter and shorthand tests in *packages/logtape/src/formatter.test.ts* and *packages/config/src/shorthands.test.ts*.
- Documented the formatter in *docs/manual/formatters.md*, *docs/manual/config.md*, *CHANGES.md*, and *packages/logtape/skills/logtape/SKILL.md*.

## Notes

The logfmt formatter quotes and escapes values containing whitespace, `=`, `"`, `\`, control characters, or empty strings. Structured object and error properties are serialized before logfmt escaping.

This PR also fixes the logfmt formatter’s `message: "template"` behavior for tagged template literals so all literal segments are preserved. The equivalent JSON Lines formatter issue is tracked separately in https://github.com/dahlia/logtape/issues/161 and is not changed here.

## Testing

- `deno test packages/logtape/src/formatter.test.ts packages/config/src/shorthands.test.ts`
- `deno test packages/logtape/src/formatter.test.ts`
- `mise run check`
- `mise run test`