### PR TITLE
Throttling filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,11 @@ To be released.
      -  Added `LogfmtFormatterOptions` interface.
      -  Added `#logfmt` configuration shorthand.
 
+ -  Added `getThrottlingFilter()` for suppressing repeated log records during
+    bursts.  It supports fixed or sliding windows, custom throttling keys,
+    record timestamp-based windows, LRU key limits, and optional summary
+    logging when suppressed records are reported.  [[#158], [#163]]
+
  -  Added `Logger.warn(error, properties)`, `Logger.warning(error, properties)`,
     `Logger.error(error, properties)`, and `Logger.fatal(error, properties)`
     overloads for attaching extra structured properties while preserving
@@ -56,8 +61,10 @@ To be released.
 [#143]: https://github.com/dahlia/logtape/issues/143
 [#145]: https://github.com/dahlia/logtape/pull/145
 [#147]: https://github.com/dahlia/logtape/issues/147
+[#158]: https://github.com/dahlia/logtape/issues/158
 [#159]: https://github.com/dahlia/logtape/issues/159
 [#162]: https://github.com/dahlia/logtape/pull/162
+[#163]: https://github.com/dahlia/logtape/pull/163
 
 ### @logtape/pretty
 

--- a/docs/manual/filters.md
+++ b/docs/manual/filters.md
@@ -131,6 +131,146 @@ await configure({
 ~~~~
 
 
+Throttling filter
+-----------------
+
+*This API is available since LogTape 2.1.0.*
+
+LogTape provides a built-in throttling filter for suppressing repeated log
+records during bursts.  The filter tracks records by category, level, and raw
+message template by default, so records with different substitution values are
+treated as the same pattern:
+
+~~~~ typescript twoslash
+// @noErrors: 2345
+import { configure, getThrottlingFilter } from "@logtape/logtape";
+
+await configure({
+  filters: {
+    throttle: getThrottlingFilter({
+      limit: 5,
+      windowMs: 10_000,
+    }),
+  },
+  loggers: [
+    {
+      category: ["my-app"],
+      sinks: ["console"],
+      filters: ["throttle"],
+    }
+  ],
+});
+~~~~
+
+The default `mode` is `"fixed"`.  A fixed window starts when the first record
+for a key arrives, allows up to `limit` records during `windowMs`, and
+suppresses the rest until the window closes.  Use `"sliding"` to count records
+accepted during the most recent `windowMs` instead:
+
+~~~~ typescript twoslash
+import { getThrottlingFilter } from "@logtape/logtape";
+
+const throttle = getThrottlingFilter({
+  limit: 5,
+  windowMs: 10_000,
+  mode: "sliding",
+});
+~~~~
+
+By default, the filter uses `Date.now()` for window calculations.  Set
+`timeSource` to `"record"` to use each record's `timestamp` instead, or pass
+`clock` when you need a custom clock:
+
+~~~~ typescript twoslash
+import { getThrottlingFilter } from "@logtape/logtape";
+
+const throttle = getThrottlingFilter({
+  limit: 5,
+  windowMs: 10_000,
+  timeSource: "record",
+});
+~~~~
+
+Use `key` to define what counts as the same record.  The following filter
+throttles per tenant regardless of message template:
+
+~~~~ typescript twoslash
+import { getThrottlingFilter } from "@logtape/logtape";
+
+const throttle = getThrottlingFilter({
+  limit: 20,
+  windowMs: 60_000,
+  key(record) {
+    return String(record.properties.tenantId);
+  },
+});
+~~~~
+
+The filter keeps up to 1,000 keys by default and evicts the least recently used
+key when the cap is reached.  Use `maxKeys` to change the cap, or `null` to
+disable it:
+
+~~~~ typescript twoslash
+import { getThrottlingFilter } from "@logtape/logtape";
+
+const throttle = getThrottlingFilter({
+  limit: 5,
+  windowMs: 10_000,
+  maxKeys: 10_000,
+});
+~~~~
+
+You can emit a summary when suppressed records are reported.  Summary logging
+is a side effect of the filter: it happens when suppression ends, when a
+suppressed key is evicted, or when the filter is disposed.  Prefer a dedicated
+summary logger so the summary is easy to route separately from application log
+traffic:
+
+~~~~ typescript twoslash
+// @noErrors: 2345
+import {
+  configure,
+  getConsoleSink,
+  getLogger,
+  getThrottlingFilter,
+} from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  filters: {
+    throttle: getThrottlingFilter({
+      limit: 5,
+      windowMs: 10_000,
+      summary: {
+        logger: getLogger(["my-app", "log-throttle"]),
+        level: "warning",
+        message: "Last log message was suppressed {suppressed} times.",
+      },
+    }),
+  },
+  loggers: [
+    {
+      category: ["my-app"],
+      sinks: ["console"],
+      filters: ["throttle"],
+    },
+    {
+      category: ["my-app", "log-throttle"],
+      sinks: ["console"],
+    },
+  ],
+});
+~~~~
+
+Summary records receive structured properties including `key`, `suppressed`,
+`allowed`, `reason`, `startTime`, `endTime`, `firstRecord`, and `lastRecord`.
+The filter lets summary records pass through reentrantly while it is emitting
+them, but using a separate summary logger still avoids surprising category
+inheritance and routing.
+
+
 Sink filter
 -----------
 

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -760,6 +760,59 @@ test("disposeSync() disposes sync filters before sync sinks", () => {
   }
 });
 
+test("disposeSync() disposes remaining resources after sync errors", () => {
+  const events: string[] = [];
+  const filterError = new Error("filter disposal failed");
+  const sinkError = new Error("sink disposal failed");
+  const filterA: Filter & Disposable = () => true;
+  filterA[Symbol.dispose] = () => {
+    events.push("filter a");
+    throw filterError;
+  };
+  const filterB: Filter & Disposable = () => true;
+  filterB[Symbol.dispose] = () => events.push("filter b");
+  const sinkA: Sink & Disposable = () => {};
+  sinkA[Symbol.dispose] = () => {
+    events.push("sink a");
+    throw sinkError;
+  };
+  const sinkB: Sink & Disposable = () => {};
+  sinkB[Symbol.dispose] = () => events.push("sink b");
+
+  try {
+    configureSync({
+      sinks: { sinkA, sinkB },
+      filters: { filterA, filterB },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["sinkA", "sinkB"],
+          filters: ["filterA", "filterB"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    assert.throws(
+      () => resetSync(),
+      (error) => {
+        assert.ok(error instanceof AggregateError);
+        assert.deepStrictEqual(error.errors, [filterError, sinkError]);
+        return true;
+      },
+    );
+
+    assert.deepStrictEqual(events, [
+      "filter a",
+      "filter b",
+      "sink a",
+      "sink b",
+    ]);
+  } finally {
+    resetSync();
+  }
+});
+
 test("disposeSync() deduplicates shared sync sink and filter", () => {
   const events: string[] = [];
   const shared: Sink & Filter & Disposable = () => true;

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -615,6 +615,79 @@ test("configureSync()", async () => {
   }
 });
 
+test("dispose() disposes filters before sinks", async () => {
+  const events: string[] = [];
+  const syncSink: Sink & Disposable = () => {};
+  syncSink[Symbol.dispose] = () => events.push("sync sink");
+  const asyncSink: Sink & AsyncDisposable = () => {};
+  asyncSink[Symbol.asyncDispose] = () => {
+    events.push("async sink");
+    return Promise.resolve();
+  };
+  const syncFilter: Filter & Disposable = () => true;
+  syncFilter[Symbol.dispose] = () => events.push("sync filter");
+  const asyncFilter: Filter & AsyncDisposable = () => true;
+  asyncFilter[Symbol.asyncDispose] = () => {
+    events.push("async filter");
+    return Promise.resolve();
+  };
+
+  try {
+    await configure({
+      sinks: { asyncSink, syncSink },
+      filters: { asyncFilter, syncFilter },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["asyncSink", "syncSink"],
+          filters: ["asyncFilter", "syncFilter"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    await reset();
+
+    assert.deepStrictEqual(events, [
+      "sync filter",
+      "async filter",
+      "sync sink",
+      "async sink",
+    ]);
+  } finally {
+    await reset();
+  }
+});
+
+test("disposeSync() disposes sync filters before sync sinks", () => {
+  const events: string[] = [];
+  const sink: Sink & Disposable = () => {};
+  sink[Symbol.dispose] = () => events.push("sink");
+  const filter: Filter & Disposable = () => true;
+  filter[Symbol.dispose] = () => events.push("filter");
+
+  try {
+    configureSync({
+      sinks: { sink },
+      filters: { filter },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["sink"],
+          filters: ["filter"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    resetSync();
+
+    assert.deepStrictEqual(events, ["filter", "sink"]);
+  } finally {
+    resetSync();
+  }
+});
+
 test(
   "configureSync() does not require addEventListener() in Edge runtimes",
   { skip: hasAddEventListener },

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -701,6 +701,36 @@ test("dispose() disposes sinks after async filter rejection", async () => {
   }
 });
 
+test("dispose() deduplicates shared async sink and filter", async () => {
+  const events: string[] = [];
+  const shared: Sink & Filter & AsyncDisposable = () => true;
+  shared[Symbol.asyncDispose] = () => {
+    events.push("shared");
+    return Promise.resolve();
+  };
+
+  try {
+    await configure({
+      sinks: { shared },
+      filters: { shared },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["shared"],
+          filters: ["shared"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    await reset();
+
+    assert.deepStrictEqual(events, ["shared"]);
+  } finally {
+    await reset();
+  }
+});
+
 test("disposeSync() disposes sync filters before sync sinks", () => {
   const events: string[] = [];
   const sink: Sink & Disposable = () => {};
@@ -725,6 +755,33 @@ test("disposeSync() disposes sync filters before sync sinks", () => {
     resetSync();
 
     assert.deepStrictEqual(events, ["filter", "sink"]);
+  } finally {
+    resetSync();
+  }
+});
+
+test("disposeSync() deduplicates shared sync sink and filter", () => {
+  const events: string[] = [];
+  const shared: Sink & Filter & Disposable = () => true;
+  shared[Symbol.dispose] = () => events.push("shared");
+
+  try {
+    configureSync({
+      sinks: { shared },
+      filters: { shared },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["shared"],
+          filters: ["shared"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    resetSync();
+
+    assert.deepStrictEqual(events, ["shared"]);
   } finally {
     resetSync();
   }

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -659,6 +659,48 @@ test("dispose() disposes filters before sinks", async () => {
   }
 });
 
+test("dispose() disposes sinks after async filter rejection", async () => {
+  const events: string[] = [];
+  const error = new Error("filter disposal failed");
+  const syncSink: Sink & Disposable = () => {};
+  syncSink[Symbol.dispose] = () => events.push("sync sink");
+  const asyncSink: Sink & AsyncDisposable = () => {};
+  asyncSink[Symbol.asyncDispose] = () => {
+    events.push("async sink");
+    return Promise.resolve();
+  };
+  const asyncFilter: Filter & AsyncDisposable = () => true;
+  asyncFilter[Symbol.asyncDispose] = () => {
+    events.push("async filter");
+    return Promise.reject(error);
+  };
+
+  try {
+    await configure({
+      sinks: { asyncSink, syncSink },
+      filters: { asyncFilter },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["asyncSink", "syncSink"],
+          filters: ["asyncFilter"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    await assert.rejects(reset(), error);
+
+    assert.deepStrictEqual(events, [
+      "async filter",
+      "sync sink",
+      "async sink",
+    ]);
+  } finally {
+    await reset();
+  }
+});
+
 test("disposeSync() disposes sync filters before sync sinks", () => {
   const events: string[] = [];
   const sink: Sink & Disposable = () => {};

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -701,6 +701,65 @@ test("dispose() disposes sinks after async filter rejection", async () => {
   }
 });
 
+test("dispose() disposes remaining async resources after sync errors", async () => {
+  const events: string[] = [];
+  const filterError = new Error("filter disposal failed");
+  const sinkError = new Error("sink disposal failed");
+  const filterA: Filter & AsyncDisposable = () => true;
+  filterA[Symbol.asyncDispose] = () => {
+    events.push("filter a");
+    throw filterError;
+  };
+  const filterB: Filter & AsyncDisposable = () => true;
+  filterB[Symbol.asyncDispose] = () => {
+    events.push("filter b");
+    return Promise.resolve();
+  };
+  const sinkA: Sink & AsyncDisposable = () => {};
+  sinkA[Symbol.asyncDispose] = () => {
+    events.push("sink a");
+    throw sinkError;
+  };
+  const sinkB: Sink & AsyncDisposable = () => {};
+  sinkB[Symbol.asyncDispose] = () => {
+    events.push("sink b");
+    return Promise.resolve();
+  };
+
+  try {
+    await configure({
+      sinks: { sinkA, sinkB },
+      filters: { filterA, filterB },
+      loggers: [
+        {
+          category: "my-app",
+          sinks: ["sinkA", "sinkB"],
+          filters: ["filterA", "filterB"],
+        },
+      ],
+    });
+    events.length = 0;
+
+    await assert.rejects(
+      reset(),
+      (error) => {
+        assert.ok(error instanceof AggregateError);
+        assert.deepStrictEqual(error.errors, [filterError, sinkError]);
+        return true;
+      },
+    );
+
+    assert.deepStrictEqual(events, [
+      "filter a",
+      "filter b",
+      "sink a",
+      "sink b",
+    ]);
+  } finally {
+    await reset();
+  }
+});
+
 test("dispose() deduplicates shared async sink and filter", async () => {
   const events: string[] = [];
   const shared: Sink & Filter & AsyncDisposable = () => true;

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -339,8 +339,12 @@ function configureInternal<
           "Async disposables cannot be used with configureSync().",
         );
       }
+      asyncSinkDisposables.delete(filter as AsyncDisposable);
     }
-    if (Symbol.dispose in filter) filterDisposables.add(filter as Disposable);
+    if (Symbol.dispose in filter) {
+      filterDisposables.add(filter as Disposable);
+      sinkDisposables.delete(filter as Disposable);
+    }
   }
 
   registerDisposeHook(allowAsync);

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -475,19 +475,29 @@ function disposeSyncDisposables(disposables: Set<Disposable>): void {
 }
 
 async function disposeAsyncFilters(): Promise<void> {
-  const promises: PromiseLike<void>[] = [];
-  for (const disposable of asyncFilterDisposables) {
-    promises.push(disposable[Symbol.asyncDispose]());
-    asyncFilterDisposables.delete(disposable);
-  }
-  await settleDisposePromises(promises);
+  await disposeAsyncDisposables(asyncFilterDisposables);
 }
 
 async function disposeAsyncSinks(): Promise<void> {
+  await disposeAsyncDisposables(asyncSinkDisposables);
+}
+
+async function disposeAsyncDisposables(
+  disposables: Set<AsyncDisposable>,
+): Promise<void> {
   const promises: PromiseLike<void>[] = [];
-  for (const disposable of asyncSinkDisposables) {
-    promises.push(disposable[Symbol.asyncDispose]());
-    asyncSinkDisposables.delete(disposable);
+  try {
+    for (const disposable of disposables) {
+      try {
+        promises.push(Promise.resolve(disposable[Symbol.asyncDispose]()));
+      } catch (error) {
+        promises.push(Promise.reject(error));
+      } finally {
+        disposables.delete(disposable);
+      }
+    }
+  } finally {
+    disposables.clear();
   }
   await settleDisposePromises(promises);
 }

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -400,10 +400,28 @@ function resetInternal(): void {
  * Dispose of the disposables.
  */
 export async function dispose(): Promise<void> {
-  disposeSyncFilters();
-  await disposeAsyncFilters();
-  disposeSyncSinks();
-  await disposeAsyncSinks();
+  const errors: unknown[] = [];
+  try {
+    disposeSyncFilters();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await disposeAsyncFilters();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    disposeSyncSinks();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await disposeAsyncSinks();
+  } catch (error) {
+    errors.push(error);
+  }
+  throwDisposeErrors(errors);
 }
 
 /**
@@ -432,7 +450,7 @@ async function disposeAsyncFilters(): Promise<void> {
     promises.push(disposable[Symbol.asyncDispose]());
     asyncFilterDisposables.delete(disposable);
   }
-  await Promise.all(promises);
+  await settleDisposePromises(promises);
 }
 
 async function disposeAsyncSinks(): Promise<void> {
@@ -441,7 +459,29 @@ async function disposeAsyncSinks(): Promise<void> {
     promises.push(disposable[Symbol.asyncDispose]());
     asyncSinkDisposables.delete(disposable);
   }
-  await Promise.all(promises);
+  await settleDisposePromises(promises);
+}
+
+async function settleDisposePromises(
+  promises: readonly PromiseLike<void>[],
+): Promise<void> {
+  const results = await Promise.allSettled(promises);
+  throwDisposeErrors(
+    results
+      .filter((result): result is PromiseRejectedResult =>
+        result.status === "rejected"
+      )
+      .map((result) => result.reason),
+  );
+}
+
+function throwDisposeErrors(errors: readonly unknown[]): void {
+  if (errors.length < 1) return;
+  if (errors.length === 1) throw errors[0];
+  throw new AggregateError(
+    errors,
+    "Multiple errors occurred while disposing LogTape resources.",
+  );
 }
 
 /**

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -91,14 +91,24 @@ let currentConfig: Config<string, string> | null = null;
 const strongRefs: Set<LoggerImpl> = new Set();
 
 /**
- * Disposables to dispose when resetting the configuration.
+ * Sync filter disposables to dispose when resetting the configuration.
  */
-const disposables: Set<Disposable> = new Set();
+const filterDisposables: Set<Disposable> = new Set();
 
 /**
- * Async disposables to dispose when resetting the configuration.
+ * Sync sink disposables to dispose when resetting the configuration.
  */
-const asyncDisposables: Set<AsyncDisposable> = new Set();
+const sinkDisposables: Set<Disposable> = new Set();
+
+/**
+ * Async filter disposables to dispose when resetting the configuration.
+ */
+const asyncFilterDisposables: Set<AsyncDisposable> = new Set();
+
+/**
+ * Async sink disposables to dispose when resetting the configuration.
+ */
+const asyncSinkDisposables: Set<AsyncDisposable> = new Set();
 
 /**
  * Check if a config is for the meta logger.
@@ -243,7 +253,7 @@ export function configureSync<TSinkId extends string, TFilterId extends string>(
       "Already configured; if you want to reset, turn on the reset flag.",
     );
   }
-  if (asyncDisposables.size > 0) {
+  if (asyncFilterDisposables.size > 0 || asyncSinkDisposables.size > 0) {
     throw new ConfigError(
       "Previously configured async disposables are still active. " +
         "Use configure() instead or explicitly dispose them using dispose().",
@@ -310,27 +320,27 @@ function configureInternal<
 
   for (const sink of Object.values<Sink>(config.sinks)) {
     if (Symbol.asyncDispose in sink) {
-      if (allowAsync) asyncDisposables.add(sink as AsyncDisposable);
+      if (allowAsync) asyncSinkDisposables.add(sink as AsyncDisposable);
       else {
         throw new ConfigError(
           "Async disposables cannot be used with configureSync().",
         );
       }
     }
-    if (Symbol.dispose in sink) disposables.add(sink as Disposable);
+    if (Symbol.dispose in sink) sinkDisposables.add(sink as Disposable);
   }
 
   for (const filter of Object.values<FilterLike>(config.filters ?? {})) {
     if (filter == null || typeof filter === "string") continue;
     if (Symbol.asyncDispose in filter) {
-      if (allowAsync) asyncDisposables.add(filter as AsyncDisposable);
+      if (allowAsync) asyncFilterDisposables.add(filter as AsyncDisposable);
       else {
         throw new ConfigError(
           "Async disposables cannot be used with configureSync().",
         );
       }
     }
-    if (Symbol.dispose in filter) disposables.add(filter as Disposable);
+    if (Symbol.dispose in filter) filterDisposables.add(filter as Disposable);
   }
 
   registerDisposeHook(allowAsync);
@@ -390,13 +400,10 @@ function resetInternal(): void {
  * Dispose of the disposables.
  */
 export async function dispose(): Promise<void> {
-  disposeSync();
-  const promises: PromiseLike<void>[] = [];
-  for (const disposable of asyncDisposables) {
-    promises.push(disposable[Symbol.asyncDispose]());
-    asyncDisposables.delete(disposable);
-  }
-  await Promise.all(promises);
+  disposeSyncFilters();
+  await disposeAsyncFilters();
+  disposeSyncSinks();
+  await disposeAsyncSinks();
 }
 
 /**
@@ -405,8 +412,36 @@ export async function dispose(): Promise<void> {
  * @since 0.9.0
  */
 export function disposeSync(): void {
-  for (const disposable of disposables) disposable[Symbol.dispose]();
-  disposables.clear();
+  disposeSyncFilters();
+  disposeSyncSinks();
+}
+
+function disposeSyncFilters(): void {
+  for (const disposable of filterDisposables) disposable[Symbol.dispose]();
+  filterDisposables.clear();
+}
+
+function disposeSyncSinks(): void {
+  for (const disposable of sinkDisposables) disposable[Symbol.dispose]();
+  sinkDisposables.clear();
+}
+
+async function disposeAsyncFilters(): Promise<void> {
+  const promises: PromiseLike<void>[] = [];
+  for (const disposable of asyncFilterDisposables) {
+    promises.push(disposable[Symbol.asyncDispose]());
+    asyncFilterDisposables.delete(disposable);
+  }
+  await Promise.all(promises);
+}
+
+async function disposeAsyncSinks(): Promise<void> {
+  const promises: PromiseLike<void>[] = [];
+  for (const disposable of asyncSinkDisposables) {
+    promises.push(disposable[Symbol.asyncDispose]());
+    asyncSinkDisposables.delete(disposable);
+  }
+  await Promise.all(promises);
 }
 
 /**

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -434,18 +434,44 @@ export async function dispose(): Promise<void> {
  * @since 0.9.0
  */
 export function disposeSync(): void {
-  disposeSyncFilters();
-  disposeSyncSinks();
+  const errors: unknown[] = [];
+  try {
+    disposeSyncFilters();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    disposeSyncSinks();
+  } catch (error) {
+    errors.push(error);
+  }
+  throwDisposeErrors(errors);
 }
 
 function disposeSyncFilters(): void {
-  for (const disposable of filterDisposables) disposable[Symbol.dispose]();
-  filterDisposables.clear();
+  disposeSyncDisposables(filterDisposables);
 }
 
 function disposeSyncSinks(): void {
-  for (const disposable of sinkDisposables) disposable[Symbol.dispose]();
-  sinkDisposables.clear();
+  disposeSyncDisposables(sinkDisposables);
+}
+
+function disposeSyncDisposables(disposables: Set<Disposable>): void {
+  const errors: unknown[] = [];
+  try {
+    for (const disposable of disposables) {
+      try {
+        disposable[Symbol.dispose]();
+      } catch (error) {
+        errors.push(error);
+      } finally {
+        disposables.delete(disposable);
+      }
+    }
+  } finally {
+    disposables.clear();
+  }
+  throwDisposeErrors(errors);
 }
 
 async function disposeAsyncFilters(): Promise<void> {

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -483,6 +483,37 @@ test("getThrottlingFilter() emits summaries when disposed", () => {
   assert.strictEqual(summaries[0].properties.endTime, 250);
 });
 
+test("getThrottlingFilter() uses record time for disposal summaries", () => {
+  const summaries: LogRecord[] = [];
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      summaries.push(recordWithRawMessage(message, { properties }));
+    },
+  };
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => 100_000,
+    timeSource: "record",
+    summary: { logger },
+  });
+  const firstRecord = recordWithRawMessage("Database failed", {
+    timestamp: 1_000,
+  });
+  const suppressedRecord = recordWithRawMessage("Database failed", {
+    timestamp: 1_025,
+  });
+
+  assert.strictEqual(filter(firstRecord), true);
+  assert.strictEqual(filter(suppressedRecord), false);
+  filter[Symbol.dispose]();
+
+  assert.strictEqual(summaries.length, 1);
+  assert.strictEqual(summaries[0].properties.startTime, 1_000);
+  assert.strictEqual(summaries[0].properties.endTime, 1_025);
+  assert.strictEqual(summaries[0].properties.lastRecord, suppressedRecord);
+});
+
 test("getThrottlingFilter() ignores missing summary logger methods", () => {
   const filter = getThrottlingFilter({
     limit: 1,

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -527,6 +527,45 @@ test("getThrottlingFilter() uses record time for disposal summaries", () => {
   assert.strictEqual(summaries[0].properties.lastRecord, suppressedRecord);
 });
 
+test("getThrottlingFilter() uses evicted record time for summaries", () => {
+  const summaries: LogRecord[] = [];
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      summaries.push(recordWithRawMessage(message, { properties }));
+    },
+  };
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    timeSource: "record",
+    maxKeys: 1,
+    key: (record) => String(record.properties.key),
+    summary: { logger },
+  });
+  const allowedRecord = recordWithRawMessage("Database failed", {
+    timestamp: 100,
+    properties: { key: "a" },
+  });
+  const suppressedRecord = recordWithRawMessage("Database failed", {
+    timestamp: 110,
+    properties: { key: "a" },
+  });
+  const evictingRecord = recordWithRawMessage("Other database failed", {
+    timestamp: 50,
+    properties: { key: "b" },
+  });
+
+  assert.strictEqual(filter(allowedRecord), true);
+  assert.strictEqual(filter(suppressedRecord), false);
+  assert.strictEqual(filter(evictingRecord), true);
+
+  assert.strictEqual(summaries.length, 1);
+  assert.strictEqual(summaries[0].properties.reason, "eviction");
+  assert.strictEqual(summaries[0].properties.startTime, 100);
+  assert.strictEqual(summaries[0].properties.endTime, 110);
+  assert.strictEqual(summaries[0].properties.lastRecord, suppressedRecord);
+});
+
 test("getThrottlingFilter() ignores missing summary logger methods", () => {
   const filter = getThrottlingFilter({
     limit: 1,

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -325,6 +325,21 @@ test("getThrottlingFilter() default keys preserve category and template boundari
   assert.strictEqual(stringifyCalled, false);
 });
 
+test("getThrottlingFilter() default keys handle invalid cooked template parts", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => 0,
+  });
+  const invalidCooked = Object.assign(
+    [undefined, "suffix"],
+    { raw: ["\\unicode", "suffix"] },
+  ) as unknown as TemplateStringsArray;
+
+  assert.doesNotThrow(() => filter(recordWithRawMessage(invalidCooked)));
+  assert.strictEqual(filter(recordWithRawMessage(invalidCooked)), false);
+});
+
 test("getThrottlingFilter() supports custom keys", () => {
   const filter = getThrottlingFilter({
     limit: 1,

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -187,6 +187,18 @@ test("getThrottlingFilter() prunes out-of-order record timestamps", () => {
   assert.strictEqual(filter(recordWithTimestamp(100)), true);
 });
 
+test("getThrottlingFilter() ignores future record timestamps in sliding windows", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    mode: "sliding",
+    timeSource: "record",
+  });
+
+  assert.strictEqual(filter(recordWithTimestamp(100)), true);
+  assert.strictEqual(filter(recordWithTimestamp(0)), true);
+});
+
 test("getThrottlingFilter() does not shift sliding-window timestamps", () => {
   const filter = getThrottlingFilter({
     limit: 2,

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -361,6 +361,23 @@ test("getThrottlingFilter() emits summaries when disposed", () => {
   assert.strictEqual(summaries[0].level, "error");
 });
 
+test("getThrottlingFilter() ignores missing summary logger methods", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => 0,
+    summary: {
+      logger: {},
+      level: "error",
+    },
+  });
+  const record = recordWithRawMessage("Database failed");
+
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+  assert.doesNotThrow(() => filter[Symbol.dispose]());
+});
+
 test("getThrottlingFilter() lets summary records pass through reentrantly", () => {
   const filterRef: { current?: ReturnType<typeof getThrottlingFilter> } = {};
   const logger = {

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -174,6 +174,19 @@ test("getThrottlingFilter() uses a sliding window when configured", () => {
   assert.strictEqual(filter(record), true);
 });
 
+test("getThrottlingFilter() prunes out-of-order record timestamps", () => {
+  const filter = getThrottlingFilter({
+    limit: 2,
+    windowMs: 100,
+    mode: "sliding",
+    timeSource: "record",
+  });
+
+  assert.strictEqual(filter(recordWithTimestamp(100)), true);
+  assert.strictEqual(filter(recordWithTimestamp(0)), true);
+  assert.strictEqual(filter(recordWithTimestamp(100)), true);
+});
+
 test("getThrottlingFilter() does not shift sliding-window timestamps", () => {
   const filter = getThrottlingFilter({
     limit: 2,

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import fc from "fast-check";
-import { type Filter, getLevelFilter, toFilter } from "./filter.ts";
+import {
+  type Filter,
+  getLevelFilter,
+  getThrottlingFilter,
+  toFilter,
+} from "./filter.ts";
 import { debug, error, fatal, info, trace, warning } from "./fixtures.ts";
 import { compareLogLevel, type LogLevel } from "./level.ts";
+import type { LogRecord } from "./record.ts";
 
 const logLevelArb: fc.Arbitrary<LogLevel> = fc.constantFrom<LogLevel>(
   "trace",
@@ -124,7 +130,266 @@ test("toFilter() accepts records at or above a minimum level", () => {
   );
 });
 
-function recordWithLevel(level: LogLevel) {
+test("getThrottlingFilter() limits records in fixed windows", () => {
+  let now = 1000;
+  const filter = getThrottlingFilter({
+    limit: 2,
+    windowMs: 100,
+    clock: () => now,
+  });
+  const record = recordWithRawMessage("Database failed for {tenant}");
+
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+
+  now = 1099;
+  assert.strictEqual(filter(record), false);
+
+  now = 1100;
+  assert.strictEqual(filter(record), true);
+});
+
+test("getThrottlingFilter() uses a sliding window when configured", () => {
+  let now = 0;
+  const filter = getThrottlingFilter({
+    limit: 2,
+    windowMs: 100,
+    mode: "sliding",
+    clock: () => now,
+  });
+  const record = recordWithRawMessage("Database failed for {tenant}");
+
+  assert.strictEqual(filter(record), true);
+  now = 90;
+  assert.strictEqual(filter(record), true);
+  now = 99;
+  assert.strictEqual(filter(record), false);
+  now = 100;
+  assert.strictEqual(filter(record), true);
+  now = 189;
+  assert.strictEqual(filter(record), false);
+  now = 190;
+  assert.strictEqual(filter(record), true);
+});
+
+test("getThrottlingFilter() can use record timestamps", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    timeSource: "record",
+  });
+
+  assert.strictEqual(filter(recordWithTimestamp(0)), true);
+  assert.strictEqual(filter(recordWithTimestamp(99)), false);
+  assert.strictEqual(filter(recordWithTimestamp(100)), true);
+});
+
+test("getThrottlingFilter() groups records by category, level, and template", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => 0,
+  });
+
+  assert.strictEqual(
+    filter(recordWithRawMessage("Failed for {tenant}", {
+      message: ["Failed for ", "alpha"],
+    })),
+    true,
+  );
+  assert.strictEqual(
+    filter(recordWithRawMessage("Failed for {tenant}", {
+      message: ["Failed for ", "beta"],
+    })),
+    false,
+  );
+  assert.strictEqual(
+    filter(recordWithRawMessage("Failed for {tenant}", {
+      category: ["other"],
+    })),
+    true,
+  );
+  assert.strictEqual(
+    filter(recordWithRawMessage("Failed for {tenant}", { level: "error" })),
+    true,
+  );
+  assert.strictEqual(filter(recordWithRawMessage("Other failure")), true);
+});
+
+test("getThrottlingFilter() supports custom keys", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    key: (record) => String(record.properties.tenant),
+    clock: () => 0,
+  });
+
+  assert.strictEqual(
+    filter(recordWithRawMessage("Failed", { properties: { tenant: "a" } })),
+    true,
+  );
+  assert.strictEqual(
+    filter(
+      recordWithRawMessage("Failed again", { properties: { tenant: "a" } }),
+    ),
+    false,
+  );
+  assert.strictEqual(
+    filter(recordWithRawMessage("Failed", { properties: { tenant: "b" } })),
+    true,
+  );
+});
+
+test("getThrottlingFilter() validates numeric options", () => {
+  assert.throws(
+    () => getThrottlingFilter({ limit: 0, windowMs: 100 }),
+    RangeError,
+  );
+  assert.throws(
+    () => getThrottlingFilter({ limit: 1, windowMs: 0 }),
+    RangeError,
+  );
+  assert.throws(
+    () => getThrottlingFilter({ limit: 1, windowMs: 100, maxKeys: 0 }),
+    RangeError,
+  );
+});
+
+test("getThrottlingFilter() evicts least recently used keys", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    maxKeys: 2,
+    clock: () => 0,
+  });
+  const a = recordWithRawMessage("a");
+  const b = recordWithRawMessage("b");
+  const c = recordWithRawMessage("c");
+
+  assert.strictEqual(filter(a), true);
+  assert.strictEqual(filter(b), true);
+  assert.strictEqual(filter(a), false);
+  assert.strictEqual(filter(c), true);
+  assert.strictEqual(filter(b), true);
+});
+
+test("getThrottlingFilter() emits summaries when suppression ends", () => {
+  let now = 0;
+  const summaries: LogRecord[] = [];
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      summaries.push(recordWithRawMessage(message, { properties }));
+    },
+  };
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    summary: { logger },
+  });
+  const firstRecord = recordWithRawMessage("Database failed for {tenant}", {
+    message: ["Database failed for ", "alpha"],
+  });
+  const suppressedRecord1 = recordWithRawMessage(
+    "Database failed for {tenant}",
+    {
+      message: ["Database failed for ", "beta"],
+    },
+  );
+  const suppressedRecord2 = recordWithRawMessage(
+    "Database failed for {tenant}",
+    {
+      message: ["Database failed for ", "gamma"],
+    },
+  );
+  const nextRecord = recordWithRawMessage("Database failed for {tenant}", {
+    message: ["Database failed for ", "delta"],
+  });
+
+  assert.strictEqual(filter(firstRecord), true);
+  assert.strictEqual(filter(suppressedRecord1), false);
+  assert.strictEqual(filter(suppressedRecord2), false);
+  assert.deepStrictEqual(summaries, []);
+
+  now = 100;
+  assert.strictEqual(filter(nextRecord), true);
+  assert.strictEqual(summaries.length, 1);
+  const summary = summaries[0] as LogRecord;
+  assert.deepStrictEqual(summary.properties.suppressed, 2);
+  assert.deepStrictEqual(
+    summary.properties.key,
+    JSON.stringify({
+      category: ["test"],
+      level: "info",
+      rawMessage: "Database failed for {tenant}",
+    }),
+  );
+  assert.strictEqual(summary.properties.firstRecord, firstRecord);
+  assert.strictEqual(summary.properties.lastRecord, suppressedRecord2);
+  assert.strictEqual(summary.properties.startTime, 0);
+  assert.strictEqual(summary.properties.endTime, 100);
+});
+
+test("getThrottlingFilter() emits summaries when disposed", () => {
+  const summaries: LogRecord[] = [];
+  const logger = {
+    error(message: string, properties: Record<string, unknown>) {
+      summaries.push(
+        recordWithRawMessage(message, { level: "error", properties }),
+      );
+    },
+  };
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => 0,
+    summary: {
+      logger,
+      level: "error",
+      message: (summary) => `Suppressed ${summary.suppressed} records`,
+    },
+  });
+  const record = recordWithRawMessage("Database failed");
+
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+  filter[Symbol.dispose]();
+
+  assert.strictEqual(summaries.length, 1);
+  assert.deepStrictEqual(summaries[0].message, ["Suppressed 1 records"]);
+  assert.strictEqual(summaries[0].level, "error");
+});
+
+test("getThrottlingFilter() lets summary records pass through reentrantly", () => {
+  const filterRef: { current?: ReturnType<typeof getThrottlingFilter> } = {};
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      assert.ok(filterRef.current != null);
+      assert.strictEqual(
+        filterRef.current(recordWithRawMessage(message, { properties })),
+        true,
+      );
+    },
+  };
+  let now = 0;
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    summary: { logger },
+  });
+  filterRef.current = filter;
+  const record = recordWithRawMessage("Database failed");
+
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+
+  now = 100;
+  assert.strictEqual(filter(record), true);
+});
+
+function recordWithLevel(level: LogLevel): LogRecord {
   return {
     level,
     category: ["test"],
@@ -132,5 +397,30 @@ function recordWithLevel(level: LogLevel) {
     rawMessage: "message",
     timestamp: 0,
     properties: {},
+  };
+}
+
+function recordWithTimestamp(timestamp: number): LogRecord {
+  return { ...recordWithLevel("info"), timestamp };
+}
+
+function recordWithRawMessage(
+  rawMessage: string | TemplateStringsArray,
+  options: {
+    category?: readonly string[];
+    level?: LogLevel;
+    message?: readonly unknown[];
+    timestamp?: number;
+    properties?: Record<string, unknown>;
+  } = {},
+): LogRecord {
+  return {
+    category: options.category ?? ["test"],
+    level: options.level ?? "info",
+    message: options.message ??
+      [typeof rawMessage === "string" ? rawMessage : rawMessage.join("{}")],
+    rawMessage,
+    timestamp: options.timestamp ?? 0,
+    properties: options.properties ?? {},
   };
 }

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -512,6 +512,45 @@ test("getThrottlingFilter() lets summary records pass through reentrantly", () =
   assert.strictEqual(filter(record), true);
 });
 
+test("getThrottlingFilter() recognizes copied summary properties reentrantly", () => {
+  const filterRef: { current?: ReturnType<typeof getThrottlingFilter> } = {};
+  let summaryCalls = 0;
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      summaryCalls++;
+      if (summaryCalls > 1) throw new Error("recursive summary");
+      assert.ok(filterRef.current != null);
+      assert.strictEqual(
+        filterRef.current(recordWithRawMessage(message, {
+          properties: { ...properties },
+        })),
+        true,
+      );
+    },
+  };
+  let now = 0;
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    summary: { logger },
+  });
+  filterRef.current = filter;
+  const summaryRecord = recordWithRawMessage(
+    "Last log message was suppressed {suppressed} times.",
+  );
+  const record = recordWithRawMessage("Database failed");
+
+  assert.strictEqual(filter(summaryRecord), true);
+  assert.strictEqual(filter(summaryRecord), false);
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+
+  now = 100;
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(summaryCalls, 1);
+});
+
 test("getThrottlingFilter() throttles non-summary reentrant records", () => {
   const filterRef: { current?: ReturnType<typeof getThrottlingFilter> } = {};
   const nestedRecord = recordWithRawMessage("nested", {
@@ -543,6 +582,37 @@ test("getThrottlingFilter() throttles non-summary reentrant records", () => {
 
   now = 100;
   assert.strictEqual(filter(record), true);
+});
+
+test("getThrottlingFilter() handles malformed summary record properties", () => {
+  const filterRef: { current?: ReturnType<typeof getThrottlingFilter> } = {};
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      assert.ok(filterRef.current != null);
+      assert.strictEqual(
+        filterRef.current({
+          ...recordWithRawMessage(message, { properties }),
+          properties: null as unknown as Record<string, unknown>,
+        }),
+        true,
+      );
+    },
+  };
+  let now = 0;
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    summary: { logger },
+  });
+  filterRef.current = filter;
+  const record = recordWithRawMessage("Database failed");
+
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+
+  now = 100;
+  assert.doesNotThrow(() => filter(record));
 });
 
 function recordWithLevel(level: LogLevel): LogRecord {

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -173,6 +173,34 @@ test("getThrottlingFilter() uses a sliding window when configured", () => {
   assert.strictEqual(filter(record), true);
 });
 
+test("getThrottlingFilter() does not shift sliding-window timestamps", () => {
+  const filter = getThrottlingFilter({
+    limit: 2,
+    windowMs: 100,
+    mode: "sliding",
+    timeSource: "record",
+  });
+  const originalShift = Array.prototype.shift;
+  let shiftCalled = false;
+
+  Array.prototype.shift = function shift(
+    this: unknown[],
+  ): unknown | undefined {
+    shiftCalled = true;
+    return originalShift.call(this);
+  };
+  try {
+    assert.strictEqual(filter(recordWithTimestamp(0)), true);
+    assert.strictEqual(filter(recordWithTimestamp(10)), true);
+    assert.strictEqual(filter(recordWithTimestamp(99)), false);
+    assert.strictEqual(filter(recordWithTimestamp(100)), true);
+  } finally {
+    Array.prototype.shift = originalShift;
+  }
+
+  assert.strictEqual(shiftCalled, false);
+});
+
 test("getThrottlingFilter() can use record timestamps", () => {
   const filter = getThrottlingFilter({
     limit: 1,
@@ -215,6 +243,54 @@ test("getThrottlingFilter() groups records by category, level, and template", ()
     true,
   );
   assert.strictEqual(filter(recordWithRawMessage("Other failure")), true);
+});
+
+test("getThrottlingFilter() default keys preserve category and template boundaries", () => {
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => 0,
+  });
+  const originalStringify = JSON.stringify;
+  let stringifyCalled = false;
+
+  JSON.stringify = (function stringify(
+    value: unknown,
+    replacer?:
+      | ((this: unknown, key: string, value: unknown) => unknown)
+      | (string | number)[]
+      | null,
+    space?: string | number,
+  ): string | undefined {
+    stringifyCalled = true;
+    return originalStringify(
+      value,
+      replacer as (string | number)[] | null | undefined,
+      space,
+    );
+  }) as typeof JSON.stringify;
+  try {
+    assert.strictEqual(
+      filter(
+        recordWithRawMessage(["bc", "d"] as unknown as TemplateStringsArray, {
+          category: ["a"],
+        }),
+      ),
+      true,
+    );
+    assert.strictEqual(
+      filter(recordWithRawMessage(["d"] as unknown as TemplateStringsArray, {
+        category: ["a", "bc"],
+      })),
+      true,
+    );
+    assert.strictEqual(filter(recordWithRawMessage("a\u0000b")), true);
+    assert.strictEqual(filter(recordWithRawMessage("a\u0000b")), false);
+  } finally {
+    JSON.stringify = originalStringify;
+  }
+
+  assert.strictEqual(stringifyCalled, false);
 });
 
 test("getThrottlingFilter() supports custom keys", () => {
@@ -319,11 +395,7 @@ test("getThrottlingFilter() emits summaries when suppression ends", () => {
   assert.deepStrictEqual(summary.properties.suppressed, 2);
   assert.deepStrictEqual(
     summary.properties.key,
-    JSON.stringify({
-      category: ["test"],
-      level: "info",
-      rawMessage: "Database failed for {tenant}",
-    }),
+    "c1:4:testl4:infors28:Database failed for {tenant}",
   );
   assert.strictEqual(summary.properties.firstRecord, firstRecord);
   assert.strictEqual(summary.properties.lastRecord, suppressedRecord2);

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -201,6 +201,37 @@ test("getThrottlingFilter() does not shift sliding-window timestamps", () => {
   assert.strictEqual(shiftCalled, false);
 });
 
+test("getThrottlingFilter() does not splice sliding-window timestamps", () => {
+  const filter = getThrottlingFilter({
+    limit: 2,
+    windowMs: 100,
+    mode: "sliding",
+    timeSource: "record",
+  });
+  const originalSplice = Array.prototype.splice;
+  let spliceCalled = false;
+
+  Array.prototype.splice = function splice(
+    this: unknown[],
+    start: number,
+    deleteCount?: number,
+    ...items: unknown[]
+  ): unknown[] {
+    spliceCalled = true;
+    return originalSplice.call(this, start, deleteCount ?? 0, ...items);
+  };
+  try {
+    assert.strictEqual(filter(recordWithTimestamp(0)), true);
+    assert.strictEqual(filter(recordWithTimestamp(10)), true);
+    assert.strictEqual(filter(recordWithTimestamp(100)), true);
+    assert.strictEqual(filter(recordWithTimestamp(110)), true);
+  } finally {
+    Array.prototype.splice = originalSplice;
+  }
+
+  assert.strictEqual(spliceCalled, false);
+});
+
 test("getThrottlingFilter() can use record timestamps", () => {
   const filter = getThrottlingFilter({
     limit: 1,
@@ -404,6 +435,7 @@ test("getThrottlingFilter() emits summaries when suppression ends", () => {
 });
 
 test("getThrottlingFilter() emits summaries when disposed", () => {
+  let now = 0;
   const summaries: LogRecord[] = [];
   const logger = {
     error(message: string, properties: Record<string, unknown>) {
@@ -415,7 +447,7 @@ test("getThrottlingFilter() emits summaries when disposed", () => {
   const filter = getThrottlingFilter({
     limit: 1,
     windowMs: 100,
-    clock: () => 0,
+    clock: () => now,
     summary: {
       logger,
       level: "error",
@@ -426,11 +458,13 @@ test("getThrottlingFilter() emits summaries when disposed", () => {
 
   assert.strictEqual(filter(record), true);
   assert.strictEqual(filter(record), false);
+  now = 250;
   filter[Symbol.dispose]();
 
   assert.strictEqual(summaries.length, 1);
   assert.deepStrictEqual(summaries[0].message, ["Suppressed 1 records"]);
   assert.strictEqual(summaries[0].level, "error");
+  assert.strictEqual(summaries[0].properties.endTime, 250);
 });
 
 test("getThrottlingFilter() ignores missing summary logger methods", () => {
@@ -455,6 +489,39 @@ test("getThrottlingFilter() lets summary records pass through reentrantly", () =
   const logger = {
     warning(message: string, properties: Record<string, unknown>) {
       assert.ok(filterRef.current != null);
+      assert.strictEqual(
+        filterRef.current(recordWithRawMessage(message, { properties })),
+        true,
+      );
+    },
+  };
+  let now = 0;
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    summary: { logger },
+  });
+  filterRef.current = filter;
+  const record = recordWithRawMessage("Database failed");
+
+  assert.strictEqual(filter(record), true);
+  assert.strictEqual(filter(record), false);
+
+  now = 100;
+  assert.strictEqual(filter(record), true);
+});
+
+test("getThrottlingFilter() throttles non-summary reentrant records", () => {
+  const filterRef: { current?: ReturnType<typeof getThrottlingFilter> } = {};
+  const nestedRecord = recordWithRawMessage("nested", {
+    category: ["nested"],
+  });
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      assert.ok(filterRef.current != null);
+      assert.strictEqual(filterRef.current(nestedRecord), true);
+      assert.strictEqual(filterRef.current(nestedRecord), false);
       assert.strictEqual(
         filterRef.current(recordWithRawMessage(message, { properties })),
         true,

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./filter.ts";
 import { debug, error, fatal, info, trace, warning } from "./fixtures.ts";
 import { compareLogLevel, type LogLevel } from "./level.ts";
+import { getLogger, LoggerImpl } from "./logger.ts";
 import type { LogRecord } from "./record.ts";
 
 const logLevelArb: fc.Arbitrary<LogLevel> = fc.constantFrom<LogLevel>(
@@ -549,6 +550,51 @@ test("getThrottlingFilter() recognizes copied summary properties reentrantly", (
   now = 100;
   assert.strictEqual(filter(record), true);
   assert.strictEqual(summaryCalls, 1);
+});
+
+test("getThrottlingFilter() recognizes standard logger summary records", () => {
+  const root = LoggerImpl.getLogger();
+  const summaryLogger = getLogger("summary");
+  const sourceLogger = getLogger("source");
+  const records: LogRecord[] = [];
+  let now = 0;
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    summary: { logger: summaryLogger },
+  });
+
+  try {
+    root.filters.push(filter);
+    root.sinks.push((record) => records.push(record));
+
+    summaryLogger.warning(
+      "Last log message was suppressed {suppressed} times.",
+      { suppressed: 0 },
+    );
+    summaryLogger.warning(
+      "Last log message was suppressed {suppressed} times.",
+      { suppressed: 1 },
+    );
+    sourceLogger.info("Database failed");
+    sourceLogger.info("Database failed");
+
+    now = 100;
+    assert.doesNotThrow(() => sourceLogger.info("Database failed"));
+  } finally {
+    root.resetDescendants();
+  }
+
+  const generatedSummaries = records.filter((record) =>
+    record.properties.key != null
+  );
+  assert.strictEqual(generatedSummaries.length, 1);
+  assert.strictEqual(generatedSummaries[0].properties.suppressed, 1);
+  assert.strictEqual(
+    generatedSummaries[0].properties.key,
+    "c1:6:sourcel4:infors15:Database failed",
+  );
 });
 
 test("getThrottlingFilter() throttles non-summary reentrant records", () => {

--- a/packages/logtape/src/filter.test.ts
+++ b/packages/logtape/src/filter.test.ts
@@ -566,6 +566,43 @@ test("getThrottlingFilter() uses evicted record time for summaries", () => {
   assert.strictEqual(summaries[0].properties.lastRecord, suppressedRecord);
 });
 
+test("getThrottlingFilter() clamps clock time for eviction summaries", () => {
+  let now = 1_000;
+  const summaries: LogRecord[] = [];
+  const logger = {
+    warning(message: string, properties: Record<string, unknown>) {
+      summaries.push(recordWithRawMessage(message, { properties }));
+    },
+  };
+  const filter = getThrottlingFilter({
+    limit: 1,
+    windowMs: 100,
+    clock: () => now,
+    maxKeys: 1,
+    key: (record) => String(record.properties.key),
+    summary: { logger },
+  });
+  const allowedRecord = recordWithRawMessage("Database failed", {
+    properties: { key: "a" },
+  });
+  const suppressedRecord = recordWithRawMessage("Database failed", {
+    properties: { key: "a" },
+  });
+  const evictingRecord = recordWithRawMessage("Other database failed", {
+    properties: { key: "b" },
+  });
+
+  assert.strictEqual(filter(allowedRecord), true);
+  now = 1_050;
+  assert.strictEqual(filter(suppressedRecord), false);
+  now = 900;
+  assert.strictEqual(filter(evictingRecord), true);
+
+  assert.strictEqual(summaries.length, 1);
+  assert.strictEqual(summaries[0].properties.reason, "eviction");
+  assert.strictEqual(summaries[0].properties.endTime, 1_050);
+});
+
 test("getThrottlingFilter() ignores missing summary logger methods", () => {
   const filter = getThrottlingFilter({
     limit: 1,

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -258,7 +258,7 @@ export function getThrottlingFilter(
   const getKey = options.key ?? getDefaultThrottlingKey;
   const maxKeys = options.maxKeys === undefined ? 1000 : options.maxKeys;
   const buckets = new Map<string, ThrottlingBucket>();
-  const summaryProperties = new WeakSet<Record<string, unknown>>();
+  const summaryRecord = Symbol("LogTape.throttlingSummaryRecord");
   let emittingSummary = false;
 
   if (mode !== "fixed" && mode !== "sliding") {
@@ -271,7 +271,7 @@ export function getThrottlingFilter(
   }
 
   const filter = ((record: LogRecord): boolean => {
-    if (emittingSummary && summaryProperties.has(record.properties)) {
+    if (emittingSummary && isSummaryRecord(record)) {
       return true;
     }
 
@@ -456,16 +456,23 @@ export function getThrottlingFilter(
       endTime: summary.endTime,
       firstRecord: summary.firstRecord,
       lastRecord: summary.lastRecord,
-    };
+      [summaryRecord]: true,
+    } as Record<string, unknown> & Record<typeof summaryRecord, true>;
 
-    summaryProperties.add(properties);
     emittingSummary = true;
     try {
       log.call(summaryOptions.logger, message, properties);
     } finally {
       emittingSummary = false;
-      summaryProperties.delete(properties);
     }
+  }
+
+  function isSummaryRecord(record: LogRecord): boolean {
+    const properties = record.properties;
+    return properties != null &&
+      typeof properties === "object" &&
+      (properties as Record<typeof summaryRecord, unknown>)[summaryRecord] ===
+        true;
   }
 }
 

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -219,7 +219,6 @@ interface ThrottlingBucket {
   windowStart: number;
   summaryStartTime: number;
   readonly acceptedAt: number[];
-  acceptedAtCount: number;
   allowed: number;
   suppressed: number;
   firstRecord: LogRecord;
@@ -274,9 +273,12 @@ export function getThrottlingFilter(
       return true;
     }
 
-    const now = timeSource === "record" ? record.timestamp : clock();
     const key = getKey(record);
     let bucket = buckets.get(key);
+    const observedTime = timeSource === "record" ? record.timestamp : clock();
+    const now = bucket == null || timeSource === "record"
+      ? observedTime
+      : Math.max(observedTime, bucket.lastTime);
 
     if (bucket == null) {
       evictKeysIfNeeded(now);
@@ -284,7 +286,6 @@ export function getThrottlingFilter(
         windowStart: now,
         summaryStartTime: now,
         acceptedAt: [],
-        acceptedAtCount: 0,
         allowed: 0,
         suppressed: 0,
         firstRecord: record,
@@ -305,7 +306,9 @@ export function getThrottlingFilter(
 
   filter[Symbol.dispose] = () => {
     for (const [key, bucket] of buckets) {
-      const endTime = timeSource === "record" ? bucket.lastTime : clock();
+      const endTime = timeSource === "record"
+        ? bucket.lastTime
+        : Math.max(clock(), bucket.lastTime);
       emitSummary(key, bucket, "dispose", endTime);
     }
     buckets.clear();
@@ -323,7 +326,7 @@ export function getThrottlingFilter(
       emitSummary(key, bucket, "window", now);
       bucket.windowStart = now;
       bucket.summaryStartTime = now;
-      bucket.acceptedAtCount = 0;
+      bucket.acceptedAt.length = 0;
       bucket.allowed = 0;
       bucket.suppressed = 0;
       bucket.firstRecord = record;
@@ -349,7 +352,7 @@ export function getThrottlingFilter(
   ): boolean {
     pruneExpiredAcceptedAt(bucket, now);
 
-    const allowed = bucket.acceptedAtCount < limit;
+    const allowed = bucket.acceptedAt.length < limit;
     if (allowed) {
       if (bucket.suppressed > 0) {
         emitSummary(key, bucket, "window", now);
@@ -374,20 +377,18 @@ export function getThrottlingFilter(
     now: number,
   ): void {
     let acceptedAtCount = 0;
-    for (let i = 0; i < bucket.acceptedAtCount; i++) {
-      const acceptedAt = bucket.acceptedAt[i];
+    for (let i = 0; i < bucket.acceptedAt.length; i++) {
+      const acceptedAt: number = bucket.acceptedAt[i];
       if (now - acceptedAt < windowMs) {
         bucket.acceptedAt[acceptedAtCount] = acceptedAt;
         acceptedAtCount++;
       }
     }
     bucket.acceptedAt.length = acceptedAtCount;
-    bucket.acceptedAtCount = acceptedAtCount;
   }
 
   function pushAcceptedAt(bucket: ThrottlingBucket, acceptedAt: number): void {
-    bucket.acceptedAt[bucket.acceptedAtCount] = acceptedAt;
-    bucket.acceptedAtCount++;
+    bucket.acceptedAt.push(acceptedAt);
   }
 
   function evictKeysIfNeeded(now: number): void {
@@ -397,7 +398,9 @@ export function getThrottlingFilter(
       if (keyToEvict === undefined) return;
       const bucket = buckets.get(keyToEvict);
       if (bucket != null) {
-        const endTime = timeSource === "record" ? bucket.lastTime : now;
+        const endTime = timeSource === "record"
+          ? bucket.lastTime
+          : Math.max(now, bucket.lastTime);
         emitSummary(keyToEvict, bucket, "eviction", endTime);
         buckets.delete(keyToEvict);
       }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -325,7 +325,6 @@ export function getThrottlingFilter(
       emitSummary(key, bucket, "window", now);
       bucket.windowStart = now;
       bucket.summaryStartTime = now;
-      bucket.acceptedAt.length = 0;
       bucket.acceptedAtHead = 0;
       bucket.acceptedAtCount = 0;
       bucket.allowed = 0;
@@ -385,16 +384,17 @@ export function getThrottlingFilter(
       bucket.acceptedAtCount--;
     }
     if (bucket.acceptedAtCount < 1) {
-      bucket.acceptedAt.length = 0;
       bucket.acceptedAtHead = 0;
     }
   }
 
   function pushAcceptedAt(bucket: ThrottlingBucket, acceptedAt: number): void {
-    const index = bucket.acceptedAt.length < limit
+    const index = bucket.acceptedAtCount < bucket.acceptedAt.length
+      ? (bucket.acceptedAtHead + bucket.acceptedAtCount) %
+        bucket.acceptedAt.length
+      : bucket.acceptedAt.length < limit
       ? bucket.acceptedAt.length
-      : (bucket.acceptedAtHead + bucket.acceptedAtCount) %
-        bucket.acceptedAt.length;
+      : bucket.acceptedAtHead;
     bucket.acceptedAt[index] = acceptedAt;
     bucket.acceptedAtCount++;
   }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -376,16 +376,17 @@ export function getThrottlingFilter(
     bucket: ThrottlingBucket,
     now: number,
   ): void {
-    while (bucket.acceptedAtCount > 0) {
-      const acceptedAt = bucket.acceptedAt[bucket.acceptedAtHead];
-      if (now - acceptedAt < windowMs) break;
-      bucket.acceptedAtHead = (bucket.acceptedAtHead + 1) %
-        bucket.acceptedAt.length;
-      bucket.acceptedAtCount--;
+    let acceptedAtCount = 0;
+    for (let i = 0; i < bucket.acceptedAtCount; i++) {
+      const index = (bucket.acceptedAtHead + i) % bucket.acceptedAt.length;
+      const acceptedAt = bucket.acceptedAt[index];
+      if (now - acceptedAt < windowMs) {
+        bucket.acceptedAt[acceptedAtCount] = acceptedAt;
+        acceptedAtCount++;
+      }
     }
-    if (bucket.acceptedAtCount < 1) {
-      bucket.acceptedAtHead = 0;
-    }
+    bucket.acceptedAtHead = 0;
+    bucket.acceptedAtCount = acceptedAtCount;
   }
 
   function pushAcceptedAt(bucket: ThrottlingBucket, acceptedAt: number): void {

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -392,9 +392,7 @@ export function getThrottlingFilter(
     const index = bucket.acceptedAtCount < bucket.acceptedAt.length
       ? (bucket.acceptedAtHead + bucket.acceptedAtCount) %
         bucket.acceptedAt.length
-      : bucket.acceptedAt.length < limit
-      ? bucket.acceptedAt.length
-      : bucket.acceptedAtHead;
+      : bucket.acceptedAt.length;
     bucket.acceptedAt[index] = acceptedAt;
     bucket.acceptedAtCount++;
   }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -220,6 +220,7 @@ interface ThrottlingBucket {
   summaryStartTime: number;
   readonly acceptedAt: number[];
   acceptedAtHead: number;
+  acceptedAtCount: number;
   allowed: number;
   suppressed: number;
   firstRecord: LogRecord;
@@ -257,6 +258,7 @@ export function getThrottlingFilter(
   const getKey = options.key ?? getDefaultThrottlingKey;
   const maxKeys = options.maxKeys === undefined ? 1000 : options.maxKeys;
   const buckets = new Map<string, ThrottlingBucket>();
+  const summaryProperties = new WeakSet<Record<string, unknown>>();
   let emittingSummary = false;
 
   if (mode !== "fixed" && mode !== "sliding") {
@@ -269,7 +271,9 @@ export function getThrottlingFilter(
   }
 
   const filter = ((record: LogRecord): boolean => {
-    if (emittingSummary) return true;
+    if (emittingSummary && summaryProperties.has(record.properties)) {
+      return true;
+    }
 
     const now = timeSource === "record" ? record.timestamp : clock();
     const key = getKey(record);
@@ -282,6 +286,7 @@ export function getThrottlingFilter(
         summaryStartTime: now,
         acceptedAt: [],
         acceptedAtHead: 0,
+        acceptedAtCount: 0,
         allowed: 0,
         suppressed: 0,
         firstRecord: record,
@@ -301,8 +306,9 @@ export function getThrottlingFilter(
   }) as Filter & Disposable;
 
   filter[Symbol.dispose] = () => {
+    const endTime = clock();
     for (const [key, bucket] of buckets) {
-      emitSummary(key, bucket, "dispose", bucket.lastTime);
+      emitSummary(key, bucket, "dispose", endTime);
     }
     buckets.clear();
   };
@@ -321,6 +327,7 @@ export function getThrottlingFilter(
       bucket.summaryStartTime = now;
       bucket.acceptedAt.length = 0;
       bucket.acceptedAtHead = 0;
+      bucket.acceptedAtCount = 0;
       bucket.allowed = 0;
       bucket.suppressed = 0;
       bucket.firstRecord = record;
@@ -330,7 +337,7 @@ export function getThrottlingFilter(
 
     if (bucket.allowed < limit) {
       bucket.allowed++;
-      bucket.acceptedAt.push(now);
+      pushAcceptedAt(bucket, now);
       bucket.lastRecord = record;
       bucket.lastTime = now;
       return true;
@@ -348,16 +355,9 @@ export function getThrottlingFilter(
     record: LogRecord,
     now: number,
   ): boolean {
-    while (
-      bucket.acceptedAtHead < bucket.acceptedAt.length &&
-      now - bucket.acceptedAt[bucket.acceptedAtHead] >= windowMs
-    ) {
-      bucket.acceptedAtHead++;
-    }
+    pruneExpiredAcceptedAt(bucket, now);
 
-    compactAcceptedAt(bucket);
-
-    if (bucket.acceptedAt.length - bucket.acceptedAtHead < limit) {
+    if (bucket.acceptedAtCount < limit) {
       if (bucket.suppressed > 0) {
         emitSummary(key, bucket, "window", now);
         bucket.allowed = 0;
@@ -367,7 +367,7 @@ export function getThrottlingFilter(
         bucket.lastRecord = record;
         bucket.lastTime = now;
       }
-      bucket.acceptedAt.push(now);
+      pushAcceptedAt(bucket, now);
       bucket.allowed++;
       bucket.lastRecord = record;
       bucket.lastTime = now;
@@ -380,15 +380,30 @@ export function getThrottlingFilter(
     return false;
   }
 
-  function compactAcceptedAt(bucket: ThrottlingBucket): void {
-    if (
-      bucket.acceptedAtHead < 1 ||
-      bucket.acceptedAtHead * 2 < bucket.acceptedAt.length
-    ) {
-      return;
+  function pruneExpiredAcceptedAt(
+    bucket: ThrottlingBucket,
+    now: number,
+  ): void {
+    while (bucket.acceptedAtCount > 0) {
+      const acceptedAt = bucket.acceptedAt[bucket.acceptedAtHead];
+      if (now - acceptedAt < windowMs) break;
+      bucket.acceptedAtHead = (bucket.acceptedAtHead + 1) %
+        bucket.acceptedAt.length;
+      bucket.acceptedAtCount--;
     }
-    bucket.acceptedAt.splice(0, bucket.acceptedAtHead);
-    bucket.acceptedAtHead = 0;
+    if (bucket.acceptedAtCount < 1) {
+      bucket.acceptedAt.length = 0;
+      bucket.acceptedAtHead = 0;
+    }
+  }
+
+  function pushAcceptedAt(bucket: ThrottlingBucket, acceptedAt: number): void {
+    const index = bucket.acceptedAt.length < limit
+      ? bucket.acceptedAt.length
+      : (bucket.acceptedAtHead + bucket.acceptedAtCount) %
+        bucket.acceptedAt.length;
+    bucket.acceptedAt[index] = acceptedAt;
+    bucket.acceptedAtCount++;
   }
 
   function evictKeysIfNeeded(now: number): void {
@@ -432,21 +447,24 @@ export function getThrottlingFilter(
         "Last log message was suppressed {suppressed} times.";
     const log = summaryOptions.logger[level];
     if (typeof log !== "function") return;
+    const properties = {
+      key: summary.key,
+      suppressed: summary.suppressed,
+      allowed: summary.allowed,
+      reason: summary.reason,
+      startTime: summary.startTime,
+      endTime: summary.endTime,
+      firstRecord: summary.firstRecord,
+      lastRecord: summary.lastRecord,
+    };
 
+    summaryProperties.add(properties);
     emittingSummary = true;
     try {
-      log.call(summaryOptions.logger, message, {
-        key: summary.key,
-        suppressed: summary.suppressed,
-        allowed: summary.allowed,
-        reason: summary.reason,
-        startTime: summary.startTime,
-        endTime: summary.endTime,
-        firstRecord: summary.firstRecord,
-        lastRecord: summary.lastRecord,
-      });
+      log.call(summaryOptions.logger, message, properties);
     } finally {
       emittingSummary = false;
+      summaryProperties.delete(properties);
     }
   }
 }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -219,6 +219,7 @@ interface ThrottlingBucket {
   windowStart: number;
   summaryStartTime: number;
   readonly acceptedAt: number[];
+  acceptedAtHead: number;
   allowed: number;
   suppressed: number;
   firstRecord: LogRecord;
@@ -280,6 +281,7 @@ export function getThrottlingFilter(
         windowStart: now,
         summaryStartTime: now,
         acceptedAt: [],
+        acceptedAtHead: 0,
         allowed: 0,
         suppressed: 0,
         firstRecord: record,
@@ -318,6 +320,7 @@ export function getThrottlingFilter(
       bucket.windowStart = now;
       bucket.summaryStartTime = now;
       bucket.acceptedAt.length = 0;
+      bucket.acceptedAtHead = 0;
       bucket.allowed = 0;
       bucket.suppressed = 0;
       bucket.firstRecord = record;
@@ -346,13 +349,15 @@ export function getThrottlingFilter(
     now: number,
   ): boolean {
     while (
-      bucket.acceptedAt.length > 0 &&
-      now - bucket.acceptedAt[0] >= windowMs
+      bucket.acceptedAtHead < bucket.acceptedAt.length &&
+      now - bucket.acceptedAt[bucket.acceptedAtHead] >= windowMs
     ) {
-      bucket.acceptedAt.shift();
+      bucket.acceptedAtHead++;
     }
 
-    if (bucket.acceptedAt.length < limit) {
+    compactAcceptedAt(bucket);
+
+    if (bucket.acceptedAt.length - bucket.acceptedAtHead < limit) {
       if (bucket.suppressed > 0) {
         emitSummary(key, bucket, "window", now);
         bucket.allowed = 0;
@@ -373,6 +378,17 @@ export function getThrottlingFilter(
     bucket.lastRecord = record;
     bucket.lastTime = now;
     return false;
+  }
+
+  function compactAcceptedAt(bucket: ThrottlingBucket): void {
+    if (
+      bucket.acceptedAtHead < 1 ||
+      bucket.acceptedAtHead * 2 < bucket.acceptedAt.length
+    ) {
+      return;
+    }
+    bucket.acceptedAt.splice(0, bucket.acceptedAtHead);
+    bucket.acceptedAtHead = 0;
   }
 
   function evictKeysIfNeeded(now: number): void {
@@ -448,15 +464,26 @@ function validatePositiveNumber(name: string, value: number): void {
 }
 
 function getDefaultThrottlingKey(record: LogRecord): string {
-  return JSON.stringify({
-    category: record.category,
-    level: record.level,
-    rawMessage: getRawMessageTemplate(record.rawMessage),
-  });
+  const categoryKey = encodeKeyParts(record.category);
+  const rawMessage = getRawMessageTemplate(record.rawMessage);
+  const rawMessageKey = typeof rawMessage === "string"
+    ? `s${encodeKeyPart(rawMessage)}`
+    : `t${encodeKeyParts(rawMessage)}`;
+  return `c${categoryKey}l${encodeKeyPart(record.level)}r${rawMessageKey}`;
 }
 
 function getRawMessageTemplate(
   rawMessage: string | TemplateStringsArray,
 ): string | readonly string[] {
   return typeof rawMessage === "string" ? rawMessage : Array.from(rawMessage);
+}
+
+function encodeKeyParts(parts: readonly string[]): string {
+  let key = `${parts.length}:`;
+  for (const part of parts) key += encodeKeyPart(part);
+  return key;
+}
+
+function encodeKeyPart(part: string): string {
+  return `${part.length}:${part}`;
 }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -331,21 +331,18 @@ export function getThrottlingFilter(
       bucket.allowed = 0;
       bucket.suppressed = 0;
       bucket.firstRecord = record;
-      bucket.lastRecord = record;
-      bucket.lastTime = now;
     }
 
-    if (bucket.allowed < limit) {
+    const allowed = bucket.allowed < limit;
+    if (allowed) {
       bucket.allowed++;
-      bucket.lastRecord = record;
-      bucket.lastTime = now;
-      return true;
+    } else {
+      bucket.suppressed++;
     }
 
-    bucket.suppressed++;
     bucket.lastRecord = record;
     bucket.lastTime = now;
-    return false;
+    return allowed;
   }
 
   function filterSlidingWindow(
@@ -356,27 +353,24 @@ export function getThrottlingFilter(
   ): boolean {
     pruneExpiredAcceptedAt(bucket, now);
 
-    if (bucket.acceptedAtCount < limit) {
+    const allowed = bucket.acceptedAtCount < limit;
+    if (allowed) {
       if (bucket.suppressed > 0) {
         emitSummary(key, bucket, "window", now);
         bucket.allowed = 0;
         bucket.suppressed = 0;
         bucket.summaryStartTime = now;
         bucket.firstRecord = record;
-        bucket.lastRecord = record;
-        bucket.lastTime = now;
       }
       pushAcceptedAt(bucket, now);
       bucket.allowed++;
-      bucket.lastRecord = record;
-      bucket.lastTime = now;
-      return true;
+    } else {
+      bucket.suppressed++;
     }
 
-    bucket.suppressed++;
     bucket.lastRecord = record;
     bucket.lastTime = now;
-    return false;
+    return allowed;
   }
 
   function pruneExpiredAcceptedAt(
@@ -499,6 +493,10 @@ function getDefaultThrottlingKey(record: LogRecord): string {
 function getRawMessageTemplate(
   rawMessage: string | TemplateStringsArray,
 ): string | readonly string[] {
+  if (typeof rawMessage === "string") return rawMessage;
+  for (const part of rawMessage) {
+    if (typeof part !== "string") return rawMessage.raw;
+  }
   return rawMessage;
 }
 

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -379,7 +379,7 @@ export function getThrottlingFilter(
     let acceptedAtCount = 0;
     for (let i = 0; i < bucket.acceptedAt.length; i++) {
       const acceptedAt: number = bucket.acceptedAt[i];
-      if (now - acceptedAt < windowMs) {
+      if (acceptedAt <= now && now - acceptedAt < windowMs) {
         bucket.acceptedAt[acceptedAtCount] = acceptedAt;
         acceptedAtCount++;
       }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -257,7 +257,7 @@ export function getThrottlingFilter(
   const getKey = options.key ?? getDefaultThrottlingKey;
   const maxKeys = options.maxKeys === undefined ? 1000 : options.maxKeys;
   const buckets = new Map<string, ThrottlingBucket>();
-  const summaryRecord = Symbol("LogTape.throttlingSummaryRecord");
+  const summaryRecord = Symbol.for("LogTape.throttlingSummaryRecord");
   let emittingSummary = false;
 
   if (mode !== "fixed" && mode !== "sliding") {
@@ -381,6 +381,7 @@ export function getThrottlingFilter(
         acceptedAtCount++;
       }
     }
+    bucket.acceptedAt.length = acceptedAtCount;
     bucket.acceptedAtCount = acceptedAtCount;
   }
 
@@ -396,7 +397,8 @@ export function getThrottlingFilter(
       if (keyToEvict === undefined) return;
       const bucket = buckets.get(keyToEvict);
       if (bucket != null) {
-        emitSummary(keyToEvict, bucket, "eviction", now);
+        const endTime = timeSource === "record" ? bucket.lastTime : now;
+        emitSummary(keyToEvict, bucket, "eviction", endTime);
         buckets.delete(keyToEvict);
       }
     }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -11,6 +11,158 @@ import type { LogRecord } from "./record.ts";
 export type Filter = (record: LogRecord) => boolean;
 
 /**
+ * Summary information emitted by {@link getThrottlingFilter} when suppressed
+ * records are reported.
+ *
+ * @since 2.1.0
+ */
+export interface ThrottlingFilterSummary {
+  /**
+   * The throttling key whose records were suppressed.
+   */
+  readonly key: string;
+
+  /**
+   * The number of records suppressed since the previous summary for the key.
+   */
+  readonly suppressed: number;
+
+  /**
+   * The number of records allowed during the same summary period.
+   */
+  readonly allowed: number;
+
+  /**
+   * Why the summary was emitted.
+   */
+  readonly reason: "window" | "eviction" | "dispose";
+
+  /**
+   * The time at which the summary period started, in milliseconds.
+   */
+  readonly startTime: number;
+
+  /**
+   * The time at which the summary period ended, in milliseconds.
+   */
+  readonly endTime: number;
+
+  /**
+   * The first record observed in the summary period.
+   */
+  readonly firstRecord: LogRecord;
+
+  /**
+   * The most recent record observed in the summary period.
+   */
+  readonly lastRecord: LogRecord;
+}
+
+/**
+ * A logger-like object used by {@link getThrottlingFilter} to emit summaries.
+ *
+ * A regular {@link Logger} returned by `getLogger()` satisfies this interface.
+ *
+ * @since 2.1.0
+ */
+export type ThrottlingSummaryLogger = {
+  readonly [Level in LogLevel]?: (
+    message: string,
+    properties: Record<string, unknown>,
+  ) => void;
+};
+
+/**
+ * Summary logging options for {@link getThrottlingFilter}.
+ *
+ * @since 2.1.0
+ */
+export interface ThrottlingFilterSummaryOptions {
+  /**
+   * The logger used to emit summary records.
+   */
+  readonly logger: ThrottlingSummaryLogger;
+
+  /**
+   * The summary log level.
+   * @default `"warning"`
+   */
+  readonly level?:
+    | LogLevel
+    | ((summary: ThrottlingFilterSummary) => LogLevel);
+
+  /**
+   * The summary message.
+   * @default `"Last log message was suppressed {suppressed} times."`
+   */
+  readonly message?:
+    | string
+    | ((summary: ThrottlingFilterSummary) => string);
+}
+
+/**
+ * Options for {@link getThrottlingFilter}.
+ *
+ * @since 2.1.0
+ */
+export interface ThrottlingFilterOptions {
+  /**
+   * Number of records allowed for each key in the configured window.
+   */
+  readonly limit: number;
+
+  /**
+   * Window size in milliseconds.
+   */
+  readonly windowMs: number;
+
+  /**
+   * Window algorithm.
+   *
+   * - `"fixed"` starts a window when the first record for a key arrives.
+   * - `"sliding"` counts records accepted during the previous `windowMs`.
+   *
+   * @default `"fixed"`
+   */
+  readonly mode?: "fixed" | "sliding";
+
+  /**
+   * Source of time for window calculations.
+   *
+   * - `"clock"` uses {@link ThrottlingFilterOptions.clock}.
+   * - `"record"` uses {@link LogRecord.timestamp}.
+   *
+   * @default `"clock"`
+   */
+  readonly timeSource?: "clock" | "record";
+
+  /**
+   * Clock used when {@link timeSource} is `"clock"`.
+   * @default `Date.now`
+   */
+  readonly clock?: () => number;
+
+  /**
+   * Derives a throttling key from a log record.  By default, records are keyed
+   * by category, level, and raw message template.
+   */
+  readonly key?: (record: LogRecord) => string;
+
+  /**
+   * Maximum number of keys tracked by the filter.  When the limit is reached,
+   * the least recently used key is evicted.  Set to `null` to disable the cap.
+   *
+   * @default `1000`
+   */
+  readonly maxKeys?: number | null;
+
+  /**
+   * Summary logging options for suppressed records.
+   */
+  readonly summary?: ThrottlingFilterSummaryOptions;
+}
+
+/**
  * A filter-like value is either a {@link Filter} or a {@link LogLevel}.
  * `null` is also allowed to represent a filter that rejects all records.
  */
@@ -61,4 +213,261 @@ export function getLevelFilter(level: LogLevel | null): Filter {
       record.level === "debug";
   } else if (level === "trace") return () => true;
   throw new TypeError(`Invalid log level: ${level}.`);
+}
+
+interface ThrottlingBucket {
+  windowStart: number;
+  summaryStartTime: number;
+  readonly acceptedAt: number[];
+  allowed: number;
+  suppressed: number;
+  firstRecord: LogRecord;
+  lastRecord: LogRecord;
+  lastTime: number;
+  lastAccess: number;
+}
+
+/**
+ * Returns a stateful filter that rate-limits repeated log records.
+ *
+ * The default key treats records with the same category, level, and raw
+ * message template as identical, ignoring substituted values.  If summary
+ * logging is enabled, the filter logs summaries as a side effect when
+ * suppression ends, when a suppressed key is evicted, or when the filter is
+ * disposed.
+ *
+ * @param options Throttling options.
+ * @returns A throttling filter.
+ * @since 2.1.0
+ */
+export function getThrottlingFilter(
+  options: ThrottlingFilterOptions,
+): Filter & Disposable {
+  validatePositiveInteger("limit", options.limit);
+  validatePositiveNumber("windowMs", options.windowMs);
+  if (options.maxKeys != null) {
+    validatePositiveInteger("maxKeys", options.maxKeys);
+  }
+
+  const limit = options.limit;
+  const windowMs = options.windowMs;
+  const mode = options.mode ?? "fixed";
+  const timeSource = options.timeSource ?? "clock";
+  const clock = options.clock ?? Date.now;
+  const getKey = options.key ?? getDefaultThrottlingKey;
+  const maxKeys = options.maxKeys === undefined ? 1000 : options.maxKeys;
+  const buckets = new Map<string, ThrottlingBucket>();
+  let accessCounter = 0;
+  let emittingSummary = false;
+
+  if (mode !== "fixed" && mode !== "sliding") {
+    throw new TypeError(`Invalid throttling mode: ${String(mode)}.`);
+  }
+  if (timeSource !== "clock" && timeSource !== "record") {
+    throw new TypeError(
+      `Invalid throttling timeSource: ${String(timeSource)}.`,
+    );
+  }
+
+  const filter = ((record: LogRecord): boolean => {
+    if (emittingSummary) return true;
+
+    const now = timeSource === "record" ? record.timestamp : clock();
+    const key = getKey(record);
+    let bucket = buckets.get(key);
+
+    if (bucket == null) {
+      evictKeysIfNeeded(now);
+      bucket = {
+        windowStart: now,
+        summaryStartTime: now,
+        acceptedAt: [],
+        allowed: 0,
+        suppressed: 0,
+        firstRecord: record,
+        lastRecord: record,
+        lastTime: now,
+        lastAccess: ++accessCounter,
+      };
+      buckets.set(key, bucket);
+    } else {
+      bucket.lastAccess = ++accessCounter;
+    }
+
+    if (mode === "fixed") {
+      return filterFixedWindow(key, bucket, record, now);
+    }
+    return filterSlidingWindow(key, bucket, record, now);
+  }) as Filter & Disposable;
+
+  filter[Symbol.dispose] = () => {
+    for (const [key, bucket] of buckets) {
+      emitSummary(key, bucket, "dispose", bucket.lastTime);
+    }
+    buckets.clear();
+  };
+
+  return filter;
+
+  function filterFixedWindow(
+    key: string,
+    bucket: ThrottlingBucket,
+    record: LogRecord,
+    now: number,
+  ): boolean {
+    if (now - bucket.windowStart >= windowMs) {
+      emitSummary(key, bucket, "window", now);
+      bucket.windowStart = now;
+      bucket.summaryStartTime = now;
+      bucket.acceptedAt.length = 0;
+      bucket.allowed = 0;
+      bucket.suppressed = 0;
+      bucket.firstRecord = record;
+      bucket.lastRecord = record;
+      bucket.lastTime = now;
+    }
+
+    if (bucket.allowed < limit) {
+      bucket.allowed++;
+      bucket.acceptedAt.push(now);
+      bucket.lastRecord = record;
+      bucket.lastTime = now;
+      return true;
+    }
+
+    bucket.suppressed++;
+    bucket.lastRecord = record;
+    bucket.lastTime = now;
+    return false;
+  }
+
+  function filterSlidingWindow(
+    key: string,
+    bucket: ThrottlingBucket,
+    record: LogRecord,
+    now: number,
+  ): boolean {
+    while (
+      bucket.acceptedAt.length > 0 &&
+      now - bucket.acceptedAt[0] >= windowMs
+    ) {
+      bucket.acceptedAt.shift();
+    }
+
+    if (bucket.acceptedAt.length < limit) {
+      if (bucket.suppressed > 0) {
+        emitSummary(key, bucket, "window", now);
+        bucket.allowed = 0;
+        bucket.suppressed = 0;
+        bucket.summaryStartTime = now;
+        bucket.firstRecord = record;
+        bucket.lastRecord = record;
+        bucket.lastTime = now;
+      }
+      bucket.acceptedAt.push(now);
+      bucket.allowed++;
+      bucket.lastRecord = record;
+      bucket.lastTime = now;
+      return true;
+    }
+
+    bucket.suppressed++;
+    bucket.lastRecord = record;
+    bucket.lastTime = now;
+    return false;
+  }
+
+  function evictKeysIfNeeded(now: number): void {
+    if (maxKeys == null) return;
+    while (buckets.size >= maxKeys) {
+      let keyToEvict: string | undefined;
+      let oldestAccess = Infinity;
+      for (const [key, bucket] of buckets) {
+        if (bucket.lastAccess < oldestAccess) {
+          keyToEvict = key;
+          oldestAccess = bucket.lastAccess;
+        }
+      }
+      if (keyToEvict == null) return;
+      const bucket = buckets.get(keyToEvict);
+      if (bucket != null) {
+        emitSummary(keyToEvict, bucket, "eviction", now);
+        buckets.delete(keyToEvict);
+      }
+    }
+  }
+
+  function emitSummary(
+    key: string,
+    bucket: ThrottlingBucket,
+    reason: ThrottlingFilterSummary["reason"],
+    endTime: number,
+  ): void {
+    const summaryOptions = options.summary;
+    if (summaryOptions == null || bucket.suppressed < 1) return;
+
+    const summary: ThrottlingFilterSummary = {
+      key,
+      suppressed: bucket.suppressed,
+      allowed: bucket.allowed,
+      reason,
+      startTime: bucket.summaryStartTime,
+      endTime,
+      firstRecord: bucket.firstRecord,
+      lastRecord: bucket.lastRecord,
+    };
+    const level = typeof summaryOptions.level === "function"
+      ? summaryOptions.level(summary)
+      : summaryOptions.level ?? "warning";
+    const message = typeof summaryOptions.message === "function"
+      ? summaryOptions.message(summary)
+      : summaryOptions.message ??
+        "Last log message was suppressed {suppressed} times.";
+    const log = summaryOptions.logger[level];
+    if (typeof log !== "function") {
+      throw new TypeError(`Summary logger has no ${level}() method.`);
+    }
+
+    emittingSummary = true;
+    try {
+      log.call(summaryOptions.logger, message, {
+        key: summary.key,
+        suppressed: summary.suppressed,
+        allowed: summary.allowed,
+        reason: summary.reason,
+        startTime: summary.startTime,
+        endTime: summary.endTime,
+        firstRecord: summary.firstRecord,
+        lastRecord: summary.lastRecord,
+      });
+    } finally {
+      emittingSummary = false;
+    }
+  }
+}
+
+function validatePositiveInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a positive integer.`);
+  }
+}
+
+function validatePositiveNumber(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive number.`);
+  }
+}
+
+function getDefaultThrottlingKey(record: LogRecord): string {
+  return JSON.stringify({
+    category: record.category,
+    level: record.level,
+    rawMessage: getRawMessageTemplate(record.rawMessage),
+  });
+}
+
+function getRawMessageTemplate(
+  rawMessage: string | TemplateStringsArray,
+): string | readonly string[] {
+  return typeof rawMessage === "string" ? rawMessage : Array.from(rawMessage);
 }

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -224,7 +224,6 @@ interface ThrottlingBucket {
   firstRecord: LogRecord;
   lastRecord: LogRecord;
   lastTime: number;
-  lastAccess: number;
 }
 
 /**
@@ -257,7 +256,6 @@ export function getThrottlingFilter(
   const getKey = options.key ?? getDefaultThrottlingKey;
   const maxKeys = options.maxKeys === undefined ? 1000 : options.maxKeys;
   const buckets = new Map<string, ThrottlingBucket>();
-  let accessCounter = 0;
   let emittingSummary = false;
 
   if (mode !== "fixed" && mode !== "sliding") {
@@ -287,11 +285,11 @@ export function getThrottlingFilter(
         firstRecord: record,
         lastRecord: record,
         lastTime: now,
-        lastAccess: ++accessCounter,
       };
       buckets.set(key, bucket);
     } else {
-      bucket.lastAccess = ++accessCounter;
+      buckets.delete(key);
+      buckets.set(key, bucket);
     }
 
     if (mode === "fixed") {
@@ -380,15 +378,8 @@ export function getThrottlingFilter(
   function evictKeysIfNeeded(now: number): void {
     if (maxKeys == null) return;
     while (buckets.size >= maxKeys) {
-      let keyToEvict: string | undefined;
-      let oldestAccess = Infinity;
-      for (const [key, bucket] of buckets) {
-        if (bucket.lastAccess < oldestAccess) {
-          keyToEvict = key;
-          oldestAccess = bucket.lastAccess;
-        }
-      }
-      if (keyToEvict == null) return;
+      const keyToEvict = buckets.keys().next().value;
+      if (keyToEvict === undefined) return;
       const bucket = buckets.get(keyToEvict);
       if (bucket != null) {
         emitSummary(keyToEvict, bucket, "eviction", now);
@@ -424,9 +415,7 @@ export function getThrottlingFilter(
       : summaryOptions.message ??
         "Last log message was suppressed {suppressed} times.";
     const log = summaryOptions.logger[level];
-    if (typeof log !== "function") {
-      throw new TypeError(`Summary logger has no ${level}() method.`);
-    }
+    if (typeof log !== "function") return;
 
     emittingSummary = true;
     try {

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -306,8 +306,8 @@ export function getThrottlingFilter(
   }) as Filter & Disposable;
 
   filter[Symbol.dispose] = () => {
-    const endTime = clock();
     for (const [key, bucket] of buckets) {
+      const endTime = timeSource === "record" ? bucket.lastTime : clock();
       emitSummary(key, bucket, "dispose", endTime);
     }
     buckets.clear();

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -294,7 +294,7 @@ export function getThrottlingFilter(
         lastTime: now,
       };
       buckets.set(key, bucket);
-    } else {
+    } else if (maxKeys != null) {
       buckets.delete(key);
       buckets.set(key, bucket);
     }
@@ -337,7 +337,6 @@ export function getThrottlingFilter(
 
     if (bucket.allowed < limit) {
       bucket.allowed++;
-      pushAcceptedAt(bucket, now);
       bucket.lastRecord = record;
       bucket.lastTime = now;
       return true;
@@ -500,7 +499,7 @@ function getDefaultThrottlingKey(record: LogRecord): string {
 function getRawMessageTemplate(
   rawMessage: string | TemplateStringsArray,
 ): string | readonly string[] {
-  return typeof rawMessage === "string" ? rawMessage : Array.from(rawMessage);
+  return rawMessage;
 }
 
 function encodeKeyParts(parts: readonly string[]): string {

--- a/packages/logtape/src/filter.ts
+++ b/packages/logtape/src/filter.ts
@@ -219,7 +219,6 @@ interface ThrottlingBucket {
   windowStart: number;
   summaryStartTime: number;
   readonly acceptedAt: number[];
-  acceptedAtHead: number;
   acceptedAtCount: number;
   allowed: number;
   suppressed: number;
@@ -285,7 +284,6 @@ export function getThrottlingFilter(
         windowStart: now,
         summaryStartTime: now,
         acceptedAt: [],
-        acceptedAtHead: 0,
         acceptedAtCount: 0,
         allowed: 0,
         suppressed: 0,
@@ -325,7 +323,6 @@ export function getThrottlingFilter(
       emitSummary(key, bucket, "window", now);
       bucket.windowStart = now;
       bucket.summaryStartTime = now;
-      bucket.acceptedAtHead = 0;
       bucket.acceptedAtCount = 0;
       bucket.allowed = 0;
       bucket.suppressed = 0;
@@ -378,23 +375,17 @@ export function getThrottlingFilter(
   ): void {
     let acceptedAtCount = 0;
     for (let i = 0; i < bucket.acceptedAtCount; i++) {
-      const index = (bucket.acceptedAtHead + i) % bucket.acceptedAt.length;
-      const acceptedAt = bucket.acceptedAt[index];
+      const acceptedAt = bucket.acceptedAt[i];
       if (now - acceptedAt < windowMs) {
         bucket.acceptedAt[acceptedAtCount] = acceptedAt;
         acceptedAtCount++;
       }
     }
-    bucket.acceptedAtHead = 0;
     bucket.acceptedAtCount = acceptedAtCount;
   }
 
   function pushAcceptedAt(bucket: ThrottlingBucket, acceptedAt: number): void {
-    const index = bucket.acceptedAtCount < bucket.acceptedAt.length
-      ? (bucket.acceptedAtHead + bucket.acceptedAtCount) %
-        bucket.acceptedAt.length
-      : bucket.acceptedAt.length;
-    bucket.acceptedAt[index] = acceptedAt;
+    bucket.acceptedAt[bucket.acceptedAtCount] = acceptedAt;
     bucket.acceptedAtCount++;
   }
 

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -12,6 +12,9 @@ import type { Sink } from "./sink.ts";
  * Symbol to identify lazy values.
  */
 const lazySymbol: unique symbol = Symbol.for("logtape.lazy");
+const throttlingSummaryRecordSymbol = Symbol.for(
+  "LogTape.throttlingSummaryRecord",
+);
 
 /**
  * A lazy value that is evaluated at logging time.
@@ -79,10 +82,16 @@ function resolveProperties(
   }
   const symbolProperties = properties as Record<symbol, unknown>;
   const symbolResolved = resolved as Record<symbol, unknown>;
-  for (const key of Object.getOwnPropertySymbols(properties)) {
-    if (!Object.prototype.propertyIsEnumerable.call(properties, key)) continue;
-    const value = symbolProperties[key];
-    symbolResolved[key] = isLazy(value) ? value.getter() : value;
+  if (
+    Object.prototype.propertyIsEnumerable.call(
+      properties,
+      throttlingSummaryRecordSymbol,
+    )
+  ) {
+    const value = symbolProperties[throttlingSummaryRecordSymbol];
+    symbolResolved[throttlingSummaryRecordSymbol] = isLazy(value)
+      ? value.getter()
+      : value;
   }
   return resolved;
 }

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -77,6 +77,13 @@ function resolveProperties(
     const value = properties[key];
     resolved[key] = isLazy(value) ? value.getter() : value;
   }
+  const symbolProperties = properties as Record<symbol, unknown>;
+  const symbolResolved = resolved as Record<symbol, unknown>;
+  for (const key of Object.getOwnPropertySymbols(properties)) {
+    if (!Object.prototype.propertyIsEnumerable.call(properties, key)) continue;
+    const value = symbolProperties[key];
+    symbolResolved[key] = isLazy(value) ? value.getter() : value;
+  }
   return resolved;
 }
 

--- a/packages/logtape/src/mod.ts
+++ b/packages/logtape/src/mod.ts
@@ -19,6 +19,11 @@ export {
   type Filter,
   type FilterLike,
   getLevelFilter,
+  getThrottlingFilter,
+  type ThrottlingFilterOptions,
+  type ThrottlingFilterSummary,
+  type ThrottlingFilterSummaryOptions,
+  type ThrottlingSummaryLogger,
   toFilter,
 } from "./filter.ts";
 export {


### PR DESCRIPTION
## Summary

This adds `getThrottlingFilter()` to *@logtape/logtape* for suppressing repeated log records during bursts. The filter can use fixed or sliding windows, group records by the default category/level/raw-message-template key, or use a custom key for application-specific throttling.

## Related issue

Closes #158.

## Changes

- Added the `getThrottlingFilter()` public API, plus `ThrottlingFilterOptions`, `ThrottlingFilterSummary`, `ThrottlingFilterSummaryOptions`, and `ThrottlingSummaryLogger` in *packages/logtape/src/filter.ts* and *packages/logtape/src/mod.ts*.
- Added support for fixed windows, sliding windows, `Date.now()`-based clocks, record timestamp-based windows, custom keys, LRU key eviction, and summary logging through a configured logger.
- Added regression coverage in *packages/logtape/src/filter.test.ts* for window behavior, default and custom keys, option validation, LRU eviction, summary emission, disposal summaries, and reentrant summary logging.
- Documented the new filter in *docs/manual/filters.md* and added a changelog entry in *CHANGES.md*.

## Verification

- `deno test packages/logtape/src/filter.test.ts`
- `mise run check`
- `mise run test`
- Self-review via the Codex code review loop path