### PR TITLE
Async HMAC pseudonymization for field redaction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,9 @@ To be released.
     reported during asynchronous disposal instead of being swallowed as
     redaction failures.  [[#160], [#164]]
 
+ -  Improved `redactByFieldAsync()` performance by starting independent async
+    redaction work concurrently while preserving output order.  [[#160], [#164]]
+
  -  Fixed `createHmacPseudonymizer()` so `CryptoKey` inputs derive the default
     output prefix from the key's HMAC hash algorithm and reject explicit hash
     mismatches.  [[#160], [#164]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,9 +89,12 @@ To be released.
  -  Fixed field-based redaction so non-sensitive nested message placeholders
     keep their path value while sibling fields are redacted.  [[#160], [#164]]
 
- -  Fixed `redactByFieldAsync()` so errors thrown by the wrapped sink are
-    reported during asynchronous disposal instead of being swallowed as
-    redaction failures.  [[#160], [#164]]
+ -  Fixed `redactByFieldAsync()` so errors thrown or asynchronously rejected by
+    the wrapped sink are reported during asynchronous disposal instead of being
+    swallowed as redaction failures.  [[#160], [#164]]
+
+ -  Fixed `redactByFieldAsync()` so dropped records caused by redaction
+    failures are reported to the meta logger.  [[#160], [#164]]
 
  -  Improved `redactByFieldAsync()` performance by starting independent async
     redaction work concurrently while preserving output order.  [[#160], [#164]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,9 @@ To be released.
  -  Fixed field-based redaction so cyclic arrays are preserved instead of
     causing recursive redaction to fail.  [[#160], [#164]]
 
+ -  Fixed field-based redaction so non-sensitive nested message placeholders
+    keep their path value while sibling fields are redacted.  [[#160], [#164]]
+
  -  Fixed `createHmacPseudonymizer()` so `CryptoKey` inputs derive the default
     output prefix from the key's HMAC hash algorithm and reject explicit hash
     mismatches.  [[#160], [#164]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,26 @@ To be released.
 [#162]: https://github.com/dahlia/logtape/pull/162
 [#163]: https://github.com/dahlia/logtape/pull/163
 
+### @logtape/adaptor-bunyan
+
+ -  Initial release of *@logtape/adaptor-bunyan*.  Forwards LogTape log
+    records to [Bunyan] loggers, with structured properties passed through
+    as the bunyan merge-object and a category formatting surface mirroring
+    *@logtape/adaptor-pino*.  [[#58], [#154]]
+
+[Bunyan]: https://github.com/trentm/node-bunyan
+[#58]: https://github.com/dahlia/logtape/issues/58
+[#154]: https://github.com/dahlia/logtape/pull/154
+
+### @logtape/hono
+
+ -  Changed the `HonoContext` interface to extend Hono's `Context` so custom
+    formatter and skip callbacks receive the real runtime context.  Custom
+    formatters can now read context variables via APIs like `c.get()`.
+    [[#150] by Hamza Zia]
+
+[#150]: https://github.com/dahlia/logtape/pull/150
+
 ### @logtape/pretty
 
  -  Added `timeZone` support to `getPrettyFormatter()` for timestamp rendering,
@@ -102,26 +122,6 @@ To be released.
 [#155]: https://github.com/dahlia/logtape/pull/155
 [#160]: https://github.com/dahlia/logtape/issues/160
 [#164]: https://github.com/dahlia/logtape/pull/164
-
-### @logtape/hono
-
- -  Changed the `HonoContext` interface to extend Hono's `Context` so custom
-    formatter and skip callbacks receive the real runtime context.  Custom
-    formatters can now read context variables via APIs like `c.get()`.
-    [[#150] by Hamza Zia]
-
-[#150]: https://github.com/dahlia/logtape/pull/150
-
-### @logtape/adaptor-bunyan
-
- -  Initial release of *@logtape/adaptor-bunyan*.  Forwards LogTape log
-    records to [Bunyan] loggers, with structured properties passed through
-    as the bunyan merge-object and a category formatting surface mirroring
-    *@logtape/adaptor-pino*.  [[#58], [#154]]
-
-[Bunyan]: https://github.com/trentm/node-bunyan
-[#58]: https://github.com/dahlia/logtape/issues/58
-[#154]: https://github.com/dahlia/logtape/pull/154
 
 
 Version 2.0.9

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,16 @@ To be released.
 
 ### @logtape/redaction
 
+ -  Added `redactByFieldAsync()` for field-based redaction actions that need
+    asynchronous work, and added `createHmacPseudonymizer()` for replacing
+    sensitive fields with stable keyed HMAC pseudonyms.  [[#160], [#164]]
+
+     -  Added `AsyncFieldRedactionAction` type.
+     -  Added `AsyncFieldRedactionOptions` interface.
+     -  Added `FieldRedactionAction` type.
+     -  Added `HmacPseudonymizer` type.
+     -  Added `HmacPseudonymizerOptions` interface.
+
  -  Fixed `redactByField()` and `shouldFieldRedacted()` so field patterns using
     global or sticky regular expressions produce consistent results across
     repeated records.  [[#155]]
@@ -82,6 +92,8 @@ To be released.
     object.  [[#155]]
 
 [#155]: https://github.com/dahlia/logtape/pull/155
+[#160]: https://github.com/dahlia/logtape/issues/160
+[#164]: https://github.com/dahlia/logtape/pull/164
 
 ### @logtape/hono
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,10 @@ To be released.
  -  Fixed field-based redaction so non-sensitive nested message placeholders
     keep their path value while sibling fields are redacted.  [[#160], [#164]]
 
+ -  Fixed `redactByFieldAsync()` so errors thrown by the wrapped sink are
+    reported during asynchronous disposal instead of being swallowed as
+    redaction failures.  [[#160], [#164]]
+
  -  Fixed `createHmacPseudonymizer()` so `CryptoKey` inputs derive the default
     output prefix from the key's HMAC hash algorithm and reject explicit hash
     mismatches.  [[#160], [#164]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,34 +74,22 @@ To be released.
 ### @logtape/redaction
 
  -  Added `redactByFieldAsync()` for field-based redaction actions that need
-    asynchronous work, and added `createHmacPseudonymizer()` for replacing
-    sensitive fields with stable keyed HMAC pseudonyms.  [[#160], [#164]]
+    asynchronous work.  It preserves record order while starting independent
+    redaction work concurrently, preserves cyclic arrays, redacts
+    non-sensitive nested message placeholders from redacted properties when
+    sibling fields change, reports redaction failures to the meta logger, and
+    reports wrapped sink errors during asynchronous disposal.  [[#160], [#164]]
+
+ -  Added `createHmacPseudonymizer()` for replacing sensitive fields with stable
+    keyed HMAC pseudonyms.  `CryptoKey` inputs derive the default output prefix
+    from the key's HMAC hash algorithm and reject explicit hash mismatches.
+    [[#160], [#164]]
 
      -  Added `AsyncFieldRedactionAction` type.
      -  Added `AsyncFieldRedactionOptions` interface.
      -  Added `FieldRedactionAction` type.
      -  Added `HmacPseudonymizer` type.
      -  Added `HmacPseudonymizerOptions` interface.
-
- -  Fixed field-based redaction so cyclic arrays are preserved instead of
-    causing recursive redaction to fail.  [[#160], [#164]]
-
- -  Fixed field-based redaction so non-sensitive nested message placeholders
-    keep their path value while sibling fields are redacted.  [[#160], [#164]]
-
- -  Fixed `redactByFieldAsync()` so errors thrown or asynchronously rejected by
-    the wrapped sink are reported during asynchronous disposal instead of being
-    swallowed as redaction failures.  [[#160], [#164]]
-
- -  Fixed `redactByFieldAsync()` so dropped records caused by redaction
-    failures are reported to the meta logger.  [[#160], [#164]]
-
- -  Improved `redactByFieldAsync()` performance by starting independent async
-    redaction work concurrently while preserving output order.  [[#160], [#164]]
-
- -  Fixed `createHmacPseudonymizer()` so `CryptoKey` inputs derive the default
-    output prefix from the key's HMAC hash algorithm and reject explicit hash
-    mismatches.  [[#160], [#164]]
 
  -  Fixed `redactByField()` and `shouldFieldRedacted()` so field patterns using
     global or sticky regular expressions produce consistent results across

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,13 @@ To be released.
      -  Added `HmacPseudonymizer` type.
      -  Added `HmacPseudonymizerOptions` interface.
 
+ -  Fixed field-based redaction so cyclic arrays are preserved instead of
+    causing recursive redaction to fail.  [[#160], [#164]]
+
+ -  Fixed `createHmacPseudonymizer()` so `CryptoKey` inputs derive the default
+    output prefix from the key's HMAC hash algorithm and reject explicit hash
+    mismatches.  [[#160], [#164]]
+
  -  Fixed `redactByField()` and `shouldFieldRedacted()` so field patterns using
     global or sticky regular expressions produce consistent results across
     repeated records.  [[#155]]

--- a/docs/manual/redaction.md
+++ b/docs/manual/redaction.md
@@ -188,6 +188,55 @@ const customSink = redactByField(getConsoleSink(), {
 Field redaction is recursive and will redact sensitive fields in nested objects
 and arrays as well.
 
+### Pseudonymizing fields for correlation
+
+Sometimes you may want to hide a sensitive identifier while still keeping a
+stable value for correlation.  For example, the same user ID or email address
+can be replaced with the same pseudonym across log records, without writing the
+original value to the log.
+
+Use `createHmacPseudonymizer()` with `redactByFieldAsync()` for this:
+
+~~~~ typescript twoslash
+import { configure, dispose, getConsoleSink } from "@logtape/logtape";
+import {
+  createHmacPseudonymizer,
+  redactByFieldAsync,
+} from "@logtape/redaction";
+
+const pseudonymize = await createHmacPseudonymizer({
+  key: "replace-with-a-secret-key",
+});
+
+const sink = redactByFieldAsync(getConsoleSink(), {
+  fieldPatterns: [/userId/i, /email/i],
+  action: pseudonymize,
+});
+
+await configure({
+  sinks: {
+    console: sink,
+  },
+  loggers: [
+    { category: "my-app", sinks: ["console"] },
+  ],
+});
+
+// Later, before shutdown:
+await dispose();
+~~~~
+
+`createHmacPseudonymizer()` uses keyed HMAC through the [Web Crypto API].
+This is safer than a plain salted hash for values with small input spaces, such
+as email addresses or numeric user IDs.  By default, it returns values prefixed
+with `hmac-sha256:` and encoded as base64url.
+
+Because the [Web Crypto API] is asynchronous, `redactByFieldAsync()` returns a
+sink with asynchronous disposal semantics.  Use it with `configure()` and call
+`dispose()` during shutdown so pending redaction work can finish.
+
+[Web Crypto API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API
+
 
 Comparing redaction approaches
 ------------------------------

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -1426,9 +1426,13 @@ test("redactByFieldAsync()", async () => {
     assert.strictEqual(disposedAfterRecords, true);
   }
 
-  { // flushes records queued while async disposal is starting
+  { // ignores records queued after async disposal starts
     const records: string[] = [];
     let disposed = false;
+    let releaseFirst = () => {};
+    const firstRedaction = new Promise<string>((resolve) => {
+      releaseFirst = () => resolve("p:first");
+    });
     const sink: Sink & AsyncDisposable = (record) => {
       if (disposed) throw new Error("sink already disposed");
       records.push(String(record.properties.id));
@@ -1439,14 +1443,19 @@ test("redactByFieldAsync()", async () => {
     };
     const wrappedSink = redactByFieldAsync(sink, {
       fieldPatterns: ["id"],
-      action: (value) => Promise.resolve(`p:${value}`),
+      action: (value) => {
+        if (value === "first") return firstRedaction;
+        return Promise.resolve(`p:${value}`);
+      },
     });
 
+    wrappedSink(recordWithId("first"));
     const disposal = wrappedSink[Symbol.asyncDispose]();
     wrappedSink(recordWithId("during"));
+    releaseFirst();
     await disposal;
 
-    assert.deepStrictEqual(records, ["p:during"]);
+    assert.deepStrictEqual(records, ["p:first"]);
     assert.strictEqual(disposed, true);
   }
 

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import fc from "fast-check";
 import type { LogRecord, Sink } from "@logtape/logtape";
 import {
+  createHmacPseudonymizer,
   type FieldPatterns,
   redactByField,
+  redactByFieldAsync,
   redactProperties,
   shouldFieldRedacted,
 } from "./field.ts";
@@ -918,6 +921,238 @@ test("redactByField()", async () => {
   }
 });
 
+test("createHmacPseudonymizer()", async () => {
+  { // uses HMAC-SHA-256 and base64url output by default
+    const pseudonymize = await createHmacPseudonymizer({ key: "secret" });
+
+    const result = await pseudonymize("user@example.com");
+
+    assert.strictEqual(
+      result,
+      "hmac-sha256:_rymVrH6IjQINijRdPJQ3YVyglkBeJCRbLb_wHEjQN4",
+    );
+  }
+
+  { // supports hex output and custom prefix
+    const pseudonymize = await createHmacPseudonymizer({
+      key: "secret",
+      encoding: "hex",
+      prefix: "user:",
+    });
+
+    const result = await pseudonymize("user@example.com");
+
+    assert.strictEqual(
+      result,
+      "user:febca656b1fa2234083628d174f250dd85728259017890916cb6ffc0712340de",
+    );
+  }
+
+  { // allows disabling the prefix
+    const pseudonymize = await createHmacPseudonymizer({
+      key: "secret",
+      prefix: "",
+    });
+
+    const result = await pseudonymize("user@example.com");
+
+    assert.strictEqual(
+      result,
+      "_rymVrH6IjQINijRdPJQ3YVyglkBeJCRbLb_wHEjQN4",
+    );
+  }
+
+  { // encodes non-string values using String(value)
+    const pseudonymize = await createHmacPseudonymizer({ key: "secret" });
+
+    assert.strictEqual(
+      await pseudonymize(123),
+      await pseudonymize("123"),
+    );
+  }
+
+  { // is deterministic but distinguishes different values
+    const pseudonymize = await createHmacPseudonymizer({ key: "secret" });
+
+    const first = await pseudonymize("alice@example.com");
+    const second = await pseudonymize("alice@example.com");
+    const third = await pseudonymize("bob@example.com");
+
+    assert.strictEqual(first, second);
+    assert.notStrictEqual(first, third);
+    assert.strictEqual(typeof first, "string");
+    assert.ok(!first.includes("alice@example.com"));
+  }
+
+  { // reports a clear error when the Web Crypto API is unavailable
+    const originalCrypto = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "crypto",
+    );
+    try {
+      Object.defineProperty(globalThis, "crypto", {
+        value: undefined,
+        configurable: true,
+      });
+
+      await assert.rejects(
+        createHmacPseudonymizer({ key: "secret" }),
+        new TypeError("The Web Crypto API is not available."),
+      );
+    } finally {
+      if (originalCrypto == null) {
+        delete (globalThis as { crypto?: Crypto }).crypto;
+      } else {
+        Object.defineProperty(globalThis, "crypto", originalCrypto);
+      }
+    }
+  }
+});
+
+test("redactByFieldAsync()", async () => {
+  { // applies async action to properties and string-template messages
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["email"],
+      action: (value) => Promise.resolve(`p:${value}`),
+    });
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["Email: ", "user@example.com", ""],
+      rawMessage: "Email: {email}",
+      timestamp: Date.now(),
+      properties: { email: "user@example.com" },
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.strictEqual(records.length, 1);
+    assert.strictEqual(records[0].properties.email, "p:user@example.com");
+    assert.strictEqual(records[0].message[1], "p:user@example.com");
+    assert.strictEqual(typeof records[0].message[1], "string");
+  }
+
+  { // redacts nested values and wildcard placeholders
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: [/email/i],
+      action: () => Promise.resolve("[PSEUDONYMIZED]"),
+    });
+
+    const properties = { args: [{ email: "user@example.com" }] };
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["", properties, ""],
+      rawMessage: "{*}",
+      timestamp: Date.now(),
+      properties,
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.deepStrictEqual(records[0].properties, {
+      args: [{ email: "[PSEUDONYMIZED]" }],
+    });
+    assert.deepStrictEqual(records[0].message[1], {
+      args: [{ email: "[PSEUDONYMIZED]" }],
+    });
+  }
+
+  { // redacts tagged-template message values by comparison
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["email"],
+      action: () => Promise.resolve("[PSEUDONYMIZED]"),
+    });
+    const rawMessage = ["Email: ", ""] as unknown as TemplateStringsArray;
+    Object.defineProperty(rawMessage, "raw", { value: rawMessage });
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["Email: ", "user@example.com", ""],
+      rawMessage,
+      timestamp: Date.now(),
+      properties: { email: "user@example.com" },
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.strictEqual(records[0].message[1], "[PSEUDONYMIZED]");
+    assert.strictEqual(records[0].properties.email, "[PSEUDONYMIZED]");
+  }
+
+  { // preserves record order even when actions resolve out of order
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["id"],
+      action: async (value) => {
+        if (value === "first") await delay(10);
+        return `p:${value}`;
+      },
+    });
+
+    wrappedSink(recordWithId("first"));
+    wrappedSink(recordWithId("second"));
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.deepStrictEqual(
+      records.map((record) => record.properties.id),
+      ["p:first", "p:second"],
+    );
+  }
+
+  { // disposes the wrapped sink after pending redaction work
+    const records: LogRecord[] = [];
+    let disposedAfterRecords = false;
+    const sink: Sink & AsyncDisposable = (record) => records.push(record);
+    sink[Symbol.asyncDispose] = () => {
+      disposedAfterRecords = records.length === 1;
+      return Promise.resolve();
+    };
+    const wrappedSink = redactByFieldAsync(sink, {
+      fieldPatterns: ["id"],
+      action: (value) => Promise.resolve(`p:${value}`),
+    });
+
+    wrappedSink(recordWithId("first"));
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.strictEqual(disposedAfterRecords, true);
+  }
+
+  { // rejected actions drop only the failed record
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["id"],
+      action: (value) => {
+        if (value === "bad") return Promise.reject(new Error("boom"));
+        return Promise.resolve(`p:${value}`);
+      },
+    });
+
+    wrappedSink(recordWithId("bad"));
+    wrappedSink(recordWithId("good"));
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.deepStrictEqual(
+      records.map((record) => record.properties.id),
+      ["p:good"],
+    );
+  }
+});
+
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function recordWithId(id: string): LogRecord {
+  return {
+    level: "info",
+    category: ["test"],
+    message: ["ID: ", id, ""],
+    rawMessage: "ID: {id}",
+    timestamp: Date.now(),
+    properties: { id },
+  };
 }

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -699,6 +699,29 @@ test("redactByField()", async () => {
     });
   }
 
+  { // quoted path placeholders use redacted properties
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByField((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => "[REDACTED]",
+    });
+    const profile = { name: "Alice", password: "secret" };
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["Profile: ", profile, ""],
+      rawMessage: 'Profile: {user["profile"]}',
+      timestamp: Date.now(),
+      properties: { user: { profile } },
+    });
+
+    assert.deepStrictEqual(records[0].message[1], {
+      name: "Alice",
+      password: "[REDACTED]",
+    });
+  }
+
   { // delete action uses empty string in message
     const records: LogRecord[] = [];
     const wrappedSink = redactByField((r) => records.push(r), {
@@ -1158,6 +1181,21 @@ test("redactByFieldAsync()", async () => {
     });
   }
 
+  { // only own properties are redacted
+    const properties = Object.create({ password: "inherited" }) as Record<
+      string,
+      unknown
+    >;
+    properties.name = "Alice";
+
+    const result = await redactPropertiesAsync(properties, {
+      fieldPatterns: ["password"],
+      action: (value) => Promise.resolve(`p:${value}`),
+    });
+
+    assert.deepStrictEqual(result, { name: "Alice" });
+  }
+
   { // applies async action to properties and string-template messages
     const records: LogRecord[] = [];
     const wrappedSink = redactByFieldAsync((r) => records.push(r), {
@@ -1275,6 +1313,30 @@ test("redactByFieldAsync()", async () => {
 
     assert.strictEqual(records[0].message[1], "Alice");
     assert.deepStrictEqual(records[0].properties.user, {
+      name: "Alice",
+      password: "[REDACTED]",
+    });
+  }
+
+  { // quoted path placeholders use redacted properties
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => Promise.resolve("[REDACTED]"),
+    });
+    const profile = { name: "Alice", password: "secret" };
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["Profile: ", profile, ""],
+      rawMessage: 'Profile: {user["profile"]}',
+      timestamp: Date.now(),
+      properties: { user: { profile } },
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.deepStrictEqual(records[0].message[1], {
       name: "Alice",
       password: "[REDACTED]",
     });

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 import fc from "fast-check";
-import type { LogRecord, Sink } from "@logtape/logtape";
+import { configure, type LogRecord, reset, type Sink } from "@logtape/logtape";
 import {
   createHmacPseudonymizer,
   type FieldPatterns,
@@ -1150,6 +1150,53 @@ test("redactByFieldAsync()", async () => {
     assert.strictEqual(typeof records[0].message[1], "string");
   }
 
+  { // starts string-template message redactions concurrently
+    const records: LogRecord[] = [];
+    const started: string[] = [];
+    let releaseFirstMessage = () => {};
+    const firstMessageRedaction = new Promise<string>((resolve) => {
+      releaseFirstMessage = () => resolve("p:msg:first");
+    });
+    let firstMessageStarted = () => {};
+    const firstMessageStartedPromise = new Promise<void>((resolve) => {
+      firstMessageStarted = resolve;
+    });
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["first", "second"],
+      action: (value) => {
+        started.push(String(value));
+        if (value === "msg:first") {
+          firstMessageStarted();
+          return firstMessageRedaction;
+        }
+        return Promise.resolve(`p:${value}`);
+      },
+    });
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["", "msg:first", " ", "msg:second", ""],
+      rawMessage: "{first} {second}",
+      timestamp: Date.now(),
+      properties: { first: "prop:first", second: "prop:second" },
+    });
+    await firstMessageStartedPromise;
+    await Promise.resolve();
+
+    assert.ok(started.includes("msg:second"));
+    releaseFirstMessage();
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.deepStrictEqual(records[0].message, [
+      "",
+      "p:msg:first",
+      " ",
+      "p:msg:second",
+      "",
+    ]);
+  }
+
   { // redacts nested values and wildcard placeholders
     const records: LogRecord[] = [];
     const wrappedSink = redactByFieldAsync((r) => records.push(r), {
@@ -1279,6 +1326,36 @@ test("redactByFieldAsync()", async () => {
     assert.strictEqual(records[0].properties.email, "[PSEUDONYMIZED]");
   }
 
+  { // starts redaction for later records before earlier records are emitted
+    const records: LogRecord[] = [];
+    const started: string[] = [];
+    let releaseFirst = () => {};
+    const firstRedaction = new Promise<string>((resolve) => {
+      releaseFirst = () => resolve("p:first");
+    });
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["id"],
+      action: (value) => {
+        started.push(String(value));
+        if (value === "first") return firstRedaction;
+        return Promise.resolve(`p:${value}`);
+      },
+    });
+
+    wrappedSink(recordWithId("first"));
+    wrappedSink(recordWithId("second"));
+    await Promise.resolve();
+
+    assert.deepStrictEqual(started, ["first", "second"]);
+    releaseFirst();
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.deepStrictEqual(
+      records.map((record) => record.properties.id),
+      ["p:first", "p:second"],
+    );
+  }
+
   { // preserves record order even when actions resolve out of order
     const records: LogRecord[] = [];
     const wrappedSink = redactByFieldAsync((r) => records.push(r), {
@@ -1343,6 +1420,34 @@ test("redactByFieldAsync()", async () => {
     );
   }
 
+  { // surfaces wrapped async sink rejections during disposal
+    const records: LogRecord[] = [];
+    const sinkError = new Error("async sink failed");
+    const sink = ((record: LogRecord) => {
+      if (record.properties.id === "p:bad") {
+        return Promise.reject(sinkError);
+      }
+      records.push(record);
+      return Promise.resolve();
+    }) as Sink;
+    const wrappedSink = redactByFieldAsync(sink, {
+      fieldPatterns: ["id"],
+      action: (value) => Promise.resolve(`p:${value}`),
+    });
+
+    wrappedSink(recordWithId("bad"));
+    wrappedSink(recordWithId("good"));
+
+    await assert.rejects(
+      async () => await wrappedSink[Symbol.asyncDispose](),
+      sinkError,
+    );
+    assert.deepStrictEqual(
+      records.map((record) => record.properties.id),
+      ["p:good"],
+    );
+  }
+
   { // rejected actions drop only the failed record
     const records: LogRecord[] = [];
     const wrappedSink = redactByFieldAsync((r) => records.push(r), {
@@ -1361,6 +1466,43 @@ test("redactByFieldAsync()", async () => {
       records.map((record) => record.properties.id),
       ["p:good"],
     );
+  }
+
+  { // reports redaction failures to the meta logger
+    const records: LogRecord[] = [];
+    const metaRecords: LogRecord[] = [];
+    const redactionError = new Error("redaction failed");
+    await configure({
+      sinks: { meta: (record) => metaRecords.push(record) },
+      loggers: [
+        {
+          category: ["logtape", "meta"],
+          lowestLevel: "warning",
+          sinks: ["meta"],
+        },
+      ],
+    });
+    try {
+      const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+        fieldPatterns: ["id"],
+        action: (value) => {
+          if (value === "bad") return Promise.reject(redactionError);
+          return Promise.resolve(`p:${value}`);
+        },
+      });
+
+      wrappedSink(recordWithId("bad"));
+      await wrappedSink[Symbol.asyncDispose]();
+
+      assert.deepStrictEqual(records, []);
+      assert.strictEqual(metaRecords.length, 1);
+      assert.strictEqual(metaRecords[0].category[0], "logtape");
+      assert.strictEqual(metaRecords[0].category[1], "meta");
+      assert.strictEqual(metaRecords[0].level, "warning");
+      assert.strictEqual(metaRecords[0].properties.error, redactionError);
+    } finally {
+      await reset();
+    }
   }
 });
 

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -673,6 +673,31 @@ test("redactByField()", async () => {
     assert.strictEqual(records[0].message[1], "[REDACTED]");
   }
 
+  { // preserves non-sensitive nested message placeholders
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByField((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => "[REDACTED]",
+    });
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["User ", "Alice", ""],
+      rawMessage: "User {user.name}",
+      timestamp: Date.now(),
+      properties: {
+        user: { name: "Alice", password: "secret" },
+      },
+    });
+
+    assert.strictEqual(records[0].message[1], "Alice");
+    assert.deepStrictEqual(records[0].properties.user, {
+      name: "Alice",
+      password: "[REDACTED]",
+    });
+  }
+
   { // delete action uses empty string in message
     const records: LogRecord[] = [];
     const wrappedSink = redactByField((r) => records.push(r), {
@@ -1119,6 +1144,32 @@ test("redactByFieldAsync()", async () => {
     });
     assert.deepStrictEqual(records[0].message[1], {
       args: [{ email: "[PSEUDONYMIZED]" }],
+    });
+  }
+
+  { // preserves non-sensitive nested message placeholders
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => Promise.resolve("[REDACTED]"),
+    });
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["User ", "Alice", ""],
+      rawMessage: "User {user.name}",
+      timestamp: Date.now(),
+      properties: {
+        user: { name: "Alice", password: "secret" },
+      },
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.strictEqual(records[0].message[1], "Alice");
+    assert.deepStrictEqual(records[0].properties.user, {
+      name: "Alice",
+      password: "[REDACTED]",
     });
   }
 

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -9,6 +9,7 @@ import {
   redactByField,
   redactByFieldAsync,
   redactProperties,
+  redactPropertiesAsync,
   shouldFieldRedacted,
 } from "./field.ts";
 
@@ -1098,6 +1099,34 @@ test("createHmacPseudonymizer()", async () => {
 });
 
 test("redactByFieldAsync()", async () => {
+  { // starts async property redactions concurrently
+    const started: string[] = [];
+    let releaseFirst = () => {};
+    const firstRedaction = new Promise<string>((resolve) => {
+      releaseFirst = () => resolve("p:first");
+    });
+
+    const redaction = redactPropertiesAsync(
+      { first: "first", second: "second" },
+      {
+        fieldPatterns: ["first", "second"],
+        action: (value) => {
+          started.push(String(value));
+          if (value === "first") return firstRedaction;
+          return Promise.resolve("p:second");
+        },
+      },
+    );
+    await Promise.resolve();
+
+    assert.deepStrictEqual(started, ["first", "second"]);
+    releaseFirst();
+    assert.deepStrictEqual(await redaction, {
+      first: "p:first",
+      second: "p:second",
+    });
+  }
+
   { // applies async action to properties and string-template messages
     const records: LogRecord[] = [];
     const wrappedSink = redactByFieldAsync((r) => records.push(r), {

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -1,8 +1,8 @@
+import { configure, type LogRecord, reset, type Sink } from "@logtape/logtape";
+import fc from "fast-check";
 import assert from "node:assert/strict";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
-import fc from "fast-check";
-import { configure, type LogRecord, reset, type Sink } from "@logtape/logtape";
 import {
   createHmacPseudonymizer,
   type FieldPatterns,
@@ -1198,6 +1198,21 @@ test("createHmacPseudonymizer()", async () => {
       new TypeError(
         'The HMAC CryptoKey uses SHA-512, but the "hash" option is SHA-256.',
       ),
+    );
+  }
+
+  { // rejects a CryptoKey that cannot sign HMAC values
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode("secret"),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+
+    await assert.rejects(
+      createHmacPseudonymizer({ key }),
+      new TypeError('The HMAC CryptoKey must include the "sign" usage.'),
     );
   }
 });

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -1289,6 +1289,31 @@ test("redactByFieldAsync()", async () => {
     assert.strictEqual(disposedAfterRecords, true);
   }
 
+  { // surfaces wrapped sink failures during disposal
+    const records: LogRecord[] = [];
+    const sinkError = new Error("sink failed");
+    const sink: Sink = (record) => {
+      if (record.properties.id === "p:bad") throw sinkError;
+      records.push(record);
+    };
+    const wrappedSink = redactByFieldAsync(sink, {
+      fieldPatterns: ["id"],
+      action: (value) => Promise.resolve(`p:${value}`),
+    });
+
+    wrappedSink(recordWithId("bad"));
+    wrappedSink(recordWithId("good"));
+
+    await assert.rejects(
+      async () => await wrappedSink[Symbol.asyncDispose](),
+      sinkError,
+    );
+    assert.deepStrictEqual(
+      records.map((record) => record.properties.id),
+      ["p:good"],
+    );
+  }
+
   { // rejected actions drop only the failed record
     const records: LogRecord[] = [];
     const wrappedSink = redactByFieldAsync((r) => records.push(r), {

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -1080,6 +1080,37 @@ test("createHmacPseudonymizer()", async () => {
     assert.match(result, /^hmac-sha512:/u);
   }
 
+  { // recognizes CryptoKey values across constructor boundaries
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode("secret"),
+      { name: "HMAC", hash: "SHA-512" },
+      false,
+      ["sign"],
+    );
+    const originalCryptoKey = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "CryptoKey",
+    );
+    try {
+      Object.defineProperty(globalThis, "CryptoKey", {
+        value: class CryptoKey {},
+        configurable: true,
+      });
+
+      const pseudonymize = await createHmacPseudonymizer({ key });
+      const result = await pseudonymize("user@example.com");
+
+      assert.match(result, /^hmac-sha512:/u);
+    } finally {
+      if (originalCryptoKey == null) {
+        delete (globalThis as { CryptoKey?: typeof CryptoKey }).CryptoKey;
+      } else {
+        Object.defineProperty(globalThis, "CryptoKey", originalCryptoKey);
+      }
+    }
+  }
+
   { // rejects a CryptoKey whose HMAC hash does not match the option
     const key = await crypto.subtle.importKey(
       "raw",
@@ -1393,6 +1424,30 @@ test("redactByFieldAsync()", async () => {
     await wrappedSink[Symbol.asyncDispose]();
 
     assert.strictEqual(disposedAfterRecords, true);
+  }
+
+  { // flushes records queued while async disposal is starting
+    const records: string[] = [];
+    let disposed = false;
+    const sink: Sink & AsyncDisposable = (record) => {
+      if (disposed) throw new Error("sink already disposed");
+      records.push(String(record.properties.id));
+    };
+    sink[Symbol.asyncDispose] = () => {
+      disposed = true;
+      return Promise.resolve();
+    };
+    const wrappedSink = redactByFieldAsync(sink, {
+      fieldPatterns: ["id"],
+      action: (value) => Promise.resolve(`p:${value}`),
+    });
+
+    const disposal = wrappedSink[Symbol.asyncDispose]();
+    wrappedSink(recordWithId("during"));
+    await disposal;
+
+    assert.deepStrictEqual(records, ["p:during"]);
+    assert.strictEqual(disposed, true);
   }
 
   { // surfaces wrapped sink failures during disposal

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -722,6 +722,29 @@ test("redactByField()", async () => {
     });
   }
 
+  { // quoted path placeholders allow whitespace inside brackets
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByField((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => "[REDACTED]",
+    });
+    const profile = { name: "Alice", password: "secret" };
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["Profile: ", profile, ""],
+      rawMessage: 'Profile: {user[ "profile" ]}',
+      timestamp: Date.now(),
+      properties: { user: { profile } },
+    });
+
+    assert.deepStrictEqual(records[0].message[1], {
+      name: "Alice",
+      password: "[REDACTED]",
+    });
+  }
+
   { // delete action uses empty string in message
     const records: LogRecord[] = [];
     const wrappedSink = redactByField((r) => records.push(r), {
@@ -827,6 +850,33 @@ test("redactByField()", async () => {
     // Message should be redacted by value comparison
     assert.strictEqual(records[0].message[1], "[REDACTED]");
     assert.strictEqual(records[0].properties.password, "[REDACTED]");
+  }
+
+  { // tagged template ignores inherited property values
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByField((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => "[REDACTED]",
+    });
+    const properties = Object.create({ inherited: "from-prototype" }) as Record<
+      string,
+      unknown
+    >;
+    properties.name = "Alice";
+    const rawMessage = ["Value: ", ""] as unknown as TemplateStringsArray;
+    Object.defineProperty(rawMessage, "raw", { value: rawMessage });
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["Value: ", "from-prototype", ""],
+      rawMessage,
+      timestamp: Date.now(),
+      properties,
+    });
+
+    assert.strictEqual(records[0].message[1], "from-prototype");
+    assert.deepStrictEqual(records[0].properties, { name: "Alice" });
   }
 
   { // array access path in message

--- a/packages/redaction/src/field.test.ts
+++ b/packages/redaction/src/field.test.ts
@@ -294,6 +294,37 @@ test("redactProperties()", () => {
     assert.ok(result.self === result, "Circular reference should be preserved");
   }
 
+  { // handles circular arrays to prevent stack overflow
+    const array: unknown[] = [{ password: "some-password" }];
+    array.push(array);
+
+    const result = redactProperties({ array }, {
+      fieldPatterns: ["password"],
+      action: () => "REDACTED",
+    });
+
+    const redactedArray = result.array as unknown[];
+    assert.deepStrictEqual(redactedArray[0], { password: "REDACTED" });
+    assert.strictEqual(redactedArray[1], redactedArray);
+  }
+
+  { // preserves holes in sparse arrays
+    const array: unknown[] = [];
+    array.length = 3;
+    array[1] = { password: "some-password" };
+
+    const result = redactProperties({ array }, {
+      fieldPatterns: ["password"],
+      action: () => "REDACTED",
+    });
+
+    const redactedArray = result.array as unknown[];
+    assert.strictEqual(redactedArray.length, 3);
+    assert.ok(!Object.hasOwn(redactedArray, 0));
+    assert.deepStrictEqual(redactedArray[1], { password: "REDACTED" });
+    assert.ok(!Object.hasOwn(redactedArray, 2));
+  }
+
   { // redacts fields in class instances
     class User {
       constructor(public name: string, public password: string) {}
@@ -1007,6 +1038,38 @@ test("createHmacPseudonymizer()", async () => {
       }
     }
   }
+
+  { // derives the default prefix from a supplied CryptoKey
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode("secret"),
+      { name: "HMAC", hash: "SHA-512" },
+      false,
+      ["sign"],
+    );
+    const pseudonymize = await createHmacPseudonymizer({ key });
+
+    const result = await pseudonymize("user@example.com");
+
+    assert.match(result, /^hmac-sha512:/u);
+  }
+
+  { // rejects a CryptoKey whose HMAC hash does not match the option
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode("secret"),
+      { name: "HMAC", hash: "SHA-512" },
+      false,
+      ["sign"],
+    );
+
+    await assert.rejects(
+      createHmacPseudonymizer({ key, hash: "SHA-256" }),
+      new TypeError(
+        'The HMAC CryptoKey uses SHA-512, but the "hash" option is SHA-256.',
+      ),
+    );
+  }
 });
 
 test("redactByFieldAsync()", async () => {
@@ -1057,6 +1120,60 @@ test("redactByFieldAsync()", async () => {
     assert.deepStrictEqual(records[0].message[1], {
       args: [{ email: "[PSEUDONYMIZED]" }],
     });
+  }
+
+  { // preserves circular arrays instead of dropping the record
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => Promise.resolve("REDACTED"),
+    });
+    const array: unknown[] = [{ password: "some-password" }];
+    array.push(array);
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["", array, ""],
+      rawMessage: "{array}",
+      timestamp: Date.now(),
+      properties: { array },
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    assert.strictEqual(records.length, 1);
+    const redactedArray = records[0].properties.array as unknown[];
+    assert.deepStrictEqual(redactedArray[0], { password: "REDACTED" });
+    assert.strictEqual(redactedArray[1], redactedArray);
+    assert.strictEqual(records[0].message[1], redactedArray);
+  }
+
+  { // preserves sparse arrays
+    const records: LogRecord[] = [];
+    const wrappedSink = redactByFieldAsync((r) => records.push(r), {
+      fieldPatterns: ["password"],
+      action: () => Promise.resolve("REDACTED"),
+    });
+    const array: unknown[] = [];
+    array.length = 3;
+    array[1] = { password: "some-password" };
+
+    wrappedSink({
+      level: "info",
+      category: ["test"],
+      message: ["", array, ""],
+      rawMessage: "{array}",
+      timestamp: Date.now(),
+      properties: { array },
+    });
+    await wrappedSink[Symbol.asyncDispose]();
+
+    const redactedArray = records[0].properties.array as unknown[];
+    assert.strictEqual(redactedArray.length, 3);
+    assert.ok(!Object.hasOwn(redactedArray, 0));
+    assert.deepStrictEqual(redactedArray[1], { password: "REDACTED" });
+    assert.ok(!Object.hasOwn(redactedArray, 2));
+    assert.strictEqual(records[0].message[1], redactedArray);
   }
 
   { // redacts tagged-template message values by comparison

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -432,7 +432,7 @@ export function redactProperties(
   const copy: Record<string, unknown> = {};
   visited.set(properties, copy);
 
-  for (const field in properties) {
+  for (const field of Object.keys(properties)) {
     if (shouldFieldRedacted(field, options.fieldPatterns)) {
       if (typeof options.action === "function") {
         setProperty(copy, field, options.action(properties[field]));
@@ -486,7 +486,7 @@ export async function redactPropertiesAsync(
 
   const fields: string[] = [];
   const values: Promise<unknown>[] = [];
-  for (const field in properties) {
+  for (const field of Object.keys(properties)) {
     fields.push(field);
     if (shouldFieldRedacted(field, options.fieldPatterns)) {
       values.push(Promise.resolve(options.action(properties[field])));
@@ -703,17 +703,52 @@ function extractPlaceholderNames(template: string): string[] {
 function parsePathSegments(path: string): string[] {
   const segments: string[] = [];
   let current = "";
+  let inBracket = false;
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  const pushCurrent = (): void => {
+    if (current) segments.push(current);
+    current = "";
+  };
+
   for (const char of path) {
-    if (char === "." || char === "[") {
-      if (current) segments.push(current);
-      current = "";
-    } else if (char === "]" || char === "?") {
-      // Skip these characters
-    } else {
-      current += char;
+    if (quote != null) {
+      if (escaped) {
+        current += char;
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
     }
+
+    if (inBracket && (char === '"' || char === "'") && current === "") {
+      quote = char;
+      continue;
+    }
+    if (char === "." && !inBracket) {
+      pushCurrent();
+      continue;
+    }
+    if (char === "[") {
+      pushCurrent();
+      inBracket = true;
+      continue;
+    }
+    if (char === "]") {
+      pushCurrent();
+      inBracket = false;
+      continue;
+    }
+    if (char === "?") continue;
+    current += char;
   }
-  if (current) segments.push(current);
+  pushCurrent();
   return segments;
 }
 

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -700,11 +700,13 @@ function parsePathSegments(path: string): string[] {
   const segments: string[] = [];
   let current = "";
   let inBracket = false;
+  let quotedBracketSegment = false;
   let quote: '"' | "'" | undefined;
   let escaped = false;
 
-  const pushCurrent = (): void => {
-    if (current) segments.push(current);
+  const pushCurrent = (trim = false): void => {
+    const segment = trim ? current.trimEnd() : current;
+    if (segment) segments.push(segment);
     current = "";
   };
 
@@ -723,8 +725,15 @@ function parsePathSegments(path: string): string[] {
       continue;
     }
 
+    if (inBracket && current === "" && /\s/.test(char)) {
+      continue;
+    }
     if (inBracket && (char === '"' || char === "'") && current === "") {
       quote = char;
+      quotedBracketSegment = true;
+      continue;
+    }
+    if (inBracket && quotedBracketSegment && /\s/.test(char)) {
       continue;
     }
     if (char === "." && !inBracket) {
@@ -737,8 +746,9 @@ function parsePathSegments(path: string): string[] {
       continue;
     }
     if (char === "]") {
-      pushCurrent();
+      pushCurrent(!quotedBracketSegment);
       inBracket = false;
+      quotedBracketSegment = false;
       continue;
     }
     if (char === "?") continue;
@@ -916,7 +926,7 @@ function collectRedactedValues(
   redacted: Record<string, unknown>,
   map: Map<unknown, unknown>,
 ): void {
-  for (const key in original) {
+  for (const key of Object.keys(original)) {
     const origVal = original[key];
     const redVal = redacted[key];
 

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -315,7 +315,7 @@ export async function createHmacPseudonymizer(
   if (subtle == null) {
     throw new TypeError("The Web Crypto API is not available.");
   }
-  const hash = options.hash ?? "SHA-256";
+  const hash = getHmacHash(options.key, options.hash);
   const encoding = options.encoding ?? "base64url";
   const prefix = options.prefix ??
     `hmac-${hash.toLowerCase().replaceAll("-", "")}:`;
@@ -476,22 +476,33 @@ function redactArray(
   options: FieldRedactionOptions,
   visited: Map<object, object>,
 ): unknown[] {
-  return array.map((item) => {
+  if (visited.has(array)) return visited.get(array) as unknown[];
+
+  const copy: unknown[] = [];
+  copy.length = array.length;
+  visited.set(array, copy);
+  for (let i = 0; i < array.length; i++) {
+    if (!(i in array)) continue;
+    const item = array[i];
     if (Array.isArray(item)) {
-      return redactArray(item, options, visited);
+      copy[i] = redactArray(item, options, visited);
+      continue;
     }
     if (typeof item === "object" && item !== null) {
       if (isBuiltInObject(item)) {
-        return item;
+        copy[i] = item;
+      } else {
+        copy[i] = redactProperties(
+          item as Record<string, unknown>,
+          options,
+          visited,
+        );
       }
-      return redactProperties(
-        item as Record<string, unknown>,
-        options,
-        visited,
-      );
+      continue;
     }
-    return item;
-  });
+    copy[i] = item;
+  }
+  return copy;
 }
 
 async function redactArrayAsync(
@@ -499,25 +510,28 @@ async function redactArrayAsync(
   options: AsyncFieldRedactionOptions,
   visited: Map<object, object>,
 ): Promise<unknown[]> {
+  if (visited.has(array)) return visited.get(array) as unknown[];
+
   const copy: unknown[] = [];
+  copy.length = array.length;
   visited.set(array, copy);
-  for (const item of array) {
+  for (let i = 0; i < array.length; i++) {
+    if (!(i in array)) continue;
+    const item = array[i];
     if (Array.isArray(item)) {
-      copy.push(await redactArrayAsync(item, options, visited));
+      copy[i] = await redactArrayAsync(item, options, visited);
     } else if (typeof item === "object" && item !== null) {
       if (isBuiltInObject(item)) {
-        copy.push(item);
+        copy[i] = item;
       } else {
-        copy.push(
-          await redactPropertiesAsync(
-            item as Record<string, unknown>,
-            options,
-            visited,
-          ),
+        copy[i] = await redactPropertiesAsync(
+          item as Record<string, unknown>,
+          options,
+          visited,
         );
       }
     } else {
-      copy.push(item);
+      copy[i] = item;
     }
   }
   return copy;
@@ -839,6 +853,45 @@ function isCryptoKey(
   key: string | Uint8Array | ArrayBuffer | CryptoKey,
 ): key is CryptoKey {
   return typeof CryptoKey !== "undefined" && key instanceof CryptoKey;
+}
+
+function getHmacHash(
+  key: string | Uint8Array | ArrayBuffer | CryptoKey,
+  hash: HmacPseudonymizerOptions["hash"],
+): NonNullable<HmacPseudonymizerOptions["hash"]> {
+  if (!isCryptoKey(key)) return hash ?? "SHA-256";
+  const keyHash = getCryptoKeyHmacHash(key);
+  if (hash != null && hash !== keyHash) {
+    throw new TypeError(
+      `The HMAC CryptoKey uses ${keyHash}, but the "hash" option is ${hash}.`,
+    );
+  }
+  return keyHash;
+}
+
+function getCryptoKeyHmacHash(
+  key: CryptoKey,
+): NonNullable<HmacPseudonymizerOptions["hash"]> {
+  const algorithm = key.algorithm;
+  if (algorithm.name !== "HMAC" || !("hash" in algorithm)) {
+    throw new TypeError("The CryptoKey must be an HMAC key.");
+  }
+  const hashAlgorithm = algorithm.hash;
+  if (
+    typeof hashAlgorithm !== "object" || hashAlgorithm == null ||
+    !("name" in hashAlgorithm) || typeof hashAlgorithm.name !== "string"
+  ) {
+    throw new TypeError("The CryptoKey must specify an HMAC hash algorithm.");
+  }
+  const hash = hashAlgorithm.name;
+  switch (hash) {
+    case "SHA-256":
+    case "SHA-384":
+    case "SHA-512":
+      return hash;
+    default:
+      throw new TypeError(`Unsupported HMAC hash algorithm: ${hash}.`);
+  }
 }
 
 function encodeBytes(bytes: Uint8Array, encoding: "base64url" | "hex"): string {

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -240,8 +240,11 @@ export function redactByFieldAsync(
   options: AsyncFieldRedactionOptions,
 ): Sink & AsyncDisposable {
   let lastPromise = Promise.resolve();
+  let closed = false;
   const sinkErrors: unknown[] = [];
   const wrapped: Sink & AsyncDisposable = (record: LogRecord) => {
+    if (closed) return;
+
     const work = redactLogRecordAsync(record, options).catch((error) => {
       reportRedactionFailure(error);
       return null;
@@ -262,7 +265,13 @@ export function redactByFieldAsync(
     });
   };
   wrapped[Symbol.asyncDispose] = async () => {
-    await lastPromise;
+    for (;;) {
+      const pending = lastPromise;
+      await pending;
+      if (pending === lastPromise) break;
+    }
+    closed = true;
+
     let disposeError: unknown;
     try {
       if (Symbol.asyncDispose in sink) {
@@ -949,7 +958,8 @@ function keyToBytes(key: string | Uint8Array | ArrayBuffer): BufferSource {
 function isCryptoKey(
   key: string | Uint8Array | ArrayBuffer | CryptoKey,
 ): key is CryptoKey {
-  return typeof CryptoKey !== "undefined" && key instanceof CryptoKey;
+  return typeof key === "object" && key !== null &&
+    Object.prototype.toString.call(key) === "[object CryptoKey]";
 }
 
 function getHmacHash(

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -546,9 +546,7 @@ function redactArray(
     const item = array[i];
     if (Array.isArray(item)) {
       copy[i] = redactArray(item, options, visited);
-      continue;
-    }
-    if (typeof item === "object" && item !== null) {
+    } else if (typeof item === "object" && item !== null) {
       if (isBuiltInObject(item)) {
         copy[i] = item;
       } else {
@@ -558,9 +556,9 @@ function redactArray(
           visited,
         );
       }
-      continue;
+    } else {
+      copy[i] = item;
     }
-    copy[i] = item;
   }
   return copy;
 }

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -1,4 +1,4 @@
-import type { LogRecord, Sink } from "@logtape/logtape";
+import { getLogger, type LogRecord, type Sink } from "@logtape/logtape";
 
 /**
  * The type for a field pattern used in redaction.  A string or a regular
@@ -33,6 +33,9 @@ export type AsyncFieldRedactionAction = (
  * @since 2.1.0
  */
 export type HmacPseudonymizer = (value: unknown) => Promise<string>;
+
+const metaLogger = getLogger(["logtape", "meta"]);
+let reportingRedactionFailure = false;
 
 /**
  * Default field patterns for redaction.  These patterns will match
@@ -239,53 +242,19 @@ export function redactByFieldAsync(
   let lastPromise = Promise.resolve();
   const sinkErrors: unknown[] = [];
   const wrapped: Sink & AsyncDisposable = (record: LogRecord) => {
+    const work = redactLogRecordAsync(record, options).catch((error) => {
+      reportRedactionFailure(error);
+      return null;
+    });
     lastPromise = lastPromise.then(async () => {
-      let redactedProperties: Record<string, unknown>;
-      let redactedMessage = record.message;
-      try {
-        redactedProperties = await redactPropertiesAsync(
-          record.properties,
-          options,
-        );
-
-        if (typeof record.rawMessage === "string") {
-          const placeholders = extractPlaceholderNames(record.rawMessage);
-          const { redactedIndices, wildcardIndices } =
-            getRedactedPlaceholderIndices(
-              placeholders,
-              options.fieldPatterns,
-            );
-          redactedMessage = await redactMessageArrayAsync(
-            record.message,
-            placeholders,
-            redactedIndices,
-            wildcardIndices,
-            redactedProperties,
-            options.action,
-          );
-        } else {
-          const redactedValues = getRedactedValues(
-            record.properties,
-            redactedProperties,
-          );
-          if (redactedValues.size > 0) {
-            redactedMessage = redactMessageByValues(
-              record.message,
-              redactedValues,
-            );
-          }
-        }
-      } catch {
-        // Drop records that cannot be safely redacted, but keep the chain alive
-        // so later records can still be processed.
-        return;
-      }
+      const result = await work;
+      if (result == null) return;
 
       try {
-        sink({
+        await sink({
           ...record,
-          message: redactedMessage,
-          properties: redactedProperties,
+          message: result.message,
+          properties: result.properties,
         });
       } catch (error) {
         sinkErrors.push(error);
@@ -320,6 +289,66 @@ export function redactByFieldAsync(
     }
   };
   return wrapped;
+}
+
+async function redactLogRecordAsync(
+  record: LogRecord,
+  options: AsyncFieldRedactionOptions,
+): Promise<Pick<LogRecord, "message" | "properties">> {
+  const redactedProperties = await redactPropertiesAsync(
+    record.properties,
+    options,
+  );
+
+  if (typeof record.rawMessage === "string") {
+    const placeholders = extractPlaceholderNames(record.rawMessage);
+    const { redactedIndices, wildcardIndices } = getRedactedPlaceholderIndices(
+      placeholders,
+      options.fieldPatterns,
+    );
+    return {
+      message: await redactMessageArrayAsync(
+        record.message,
+        placeholders,
+        redactedIndices,
+        wildcardIndices,
+        redactedProperties,
+        options.action,
+      ),
+      properties: redactedProperties,
+    };
+  }
+
+  let redactedMessage = record.message;
+  const redactedValues = getRedactedValues(
+    record.properties,
+    redactedProperties,
+  );
+  if (redactedValues.size > 0) {
+    redactedMessage = redactMessageByValues(
+      record.message,
+      redactedValues,
+    );
+  }
+  return { message: redactedMessage, properties: redactedProperties };
+}
+
+function reportRedactionFailure(error: unknown): void {
+  if (reportingRedactionFailure || typeof metaLogger.warn !== "function") {
+    return;
+  }
+  try {
+    reportingRedactionFailure = true;
+    metaLogger.warn(
+      "Failed to redact a log record; dropping the record to avoid leaking " +
+        "sensitive data: {error}",
+      { error },
+    );
+  } catch {
+    // Meta logging failures must not make normal logging fail.
+  } finally {
+    reportingRedactionFailure = false;
+  }
 }
 
 /**
@@ -781,6 +810,7 @@ async function redactMessageArrayAsync(
   action: AsyncFieldRedactionAction,
 ): Promise<readonly unknown[]> {
   const result: unknown[] = [];
+  const tasks: Promise<void>[] = [];
   let placeholderIndex = 0;
 
   for (let i = 0; i < message.length; i++) {
@@ -790,7 +820,13 @@ async function redactMessageArrayAsync(
       if (wildcardIndices.has(placeholderIndex)) {
         result.push(redactedProperties);
       } else if (redactedIndices.has(placeholderIndex)) {
-        result.push(await action(message[i]));
+        const index = result.length;
+        result.push(undefined);
+        tasks.push(
+          Promise.resolve(action(message[i])).then((redacted) => {
+            result[index] = redacted;
+          }),
+        );
       } else {
         const placeholderName = placeholders[placeholderIndex];
         const redactedValue = getPathValue(redactedProperties, placeholderName);
@@ -803,6 +839,7 @@ async function redactMessageArrayAsync(
       placeholderIndex++;
     }
   }
+  await Promise.all(tasks);
   return result;
 }
 

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -269,11 +269,7 @@ export function redactByFieldAsync(
   };
   wrapped[Symbol.asyncDispose] = async () => {
     closed = true;
-    for (;;) {
-      const pending = lastPromise;
-      await pending;
-      if (pending === lastPromise) break;
-    }
+    await lastPromise;
 
     let disposeError: unknown;
     try {
@@ -990,7 +986,7 @@ function redactMessageByValues(
 function keyToBytes(key: string | Uint8Array | ArrayBuffer): BufferSource {
   if (typeof key === "string") return new TextEncoder().encode(key);
   if (key instanceof ArrayBuffer) return key;
-  return new Uint8Array(key);
+  return key as Uint8Array<ArrayBuffer>;
 }
 
 function isCryptoKey(

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -265,12 +265,12 @@ export function redactByFieldAsync(
     });
   };
   wrapped[Symbol.asyncDispose] = async () => {
+    closed = true;
     for (;;) {
       const pending = lastPromise;
       await pending;
       if (pending === lastPromise) break;
     }
-    closed = true;
 
     let disposeError: unknown;
     try {

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -573,35 +573,35 @@ async function redactArrayAsync(
   const copy: unknown[] = [];
   copy.length = array.length;
   visited.set(array, copy);
-  const tasks: Promise<void>[] = [];
+  const itemPromises: Promise<unknown>[] = [];
   for (let i = 0; i < array.length; i++) {
-    if (!(i in array)) continue;
+    if (!(i in array)) {
+      itemPromises.push(Promise.resolve(undefined));
+      continue;
+    }
     const item = array[i];
     if (Array.isArray(item)) {
-      tasks.push(
-        redactArrayAsync(item, options, visited).then((redacted) => {
-          copy[i] = redacted;
-        }),
-      );
+      itemPromises.push(redactArrayAsync(item, options, visited));
     } else if (typeof item === "object" && item !== null) {
       if (isBuiltInObject(item)) {
-        copy[i] = item;
+        itemPromises.push(Promise.resolve(item));
       } else {
-        tasks.push(
+        itemPromises.push(
           redactPropertiesAsync(
             item as Record<string, unknown>,
             options,
             visited,
-          ).then((redacted) => {
-            copy[i] = redacted;
-          }),
+          ),
         );
       }
     } else {
-      copy[i] = item;
+      itemPromises.push(Promise.resolve(item));
     }
   }
-  await Promise.all(tasks);
+  const redactedItems = await Promise.all(itemPromises);
+  for (let i = 0; i < redactedItems.length; i++) {
+    if (i in array) copy[i] = redactedItems[i];
+  }
   return copy;
 }
 

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -237,14 +237,16 @@ export function redactByFieldAsync(
   options: AsyncFieldRedactionOptions,
 ): Sink & AsyncDisposable {
   let lastPromise = Promise.resolve();
+  const sinkErrors: unknown[] = [];
   const wrapped: Sink & AsyncDisposable = (record: LogRecord) => {
-    lastPromise = lastPromise
-      .then(async () => {
-        const redactedProperties = await redactPropertiesAsync(
+    lastPromise = lastPromise.then(async () => {
+      let redactedProperties: Record<string, unknown>;
+      let redactedMessage = record.message;
+      try {
+        redactedProperties = await redactPropertiesAsync(
           record.properties,
           options,
         );
-        let redactedMessage = record.message;
 
         if (typeof record.rawMessage === "string") {
           const placeholders = extractPlaceholderNames(record.rawMessage);
@@ -273,24 +275,48 @@ export function redactByFieldAsync(
             );
           }
         }
+      } catch {
+        // Drop records that cannot be safely redacted, but keep the chain alive
+        // so later records can still be processed.
+        return;
+      }
 
+      try {
         sink({
           ...record,
           message: redactedMessage,
           properties: redactedProperties,
         });
-      })
-      .catch(() => {
-        // Drop records that cannot be safely redacted, but keep the chain alive
-        // so later records can still be processed.
-      });
+      } catch (error) {
+        sinkErrors.push(error);
+      }
+    });
   };
   wrapped[Symbol.asyncDispose] = async () => {
     await lastPromise;
-    if (Symbol.asyncDispose in sink) {
-      await sink[Symbol.asyncDispose]();
-    } else if (Symbol.dispose in sink) {
-      sink[Symbol.dispose]();
+    let disposeError: unknown;
+    try {
+      if (Symbol.asyncDispose in sink) {
+        await sink[Symbol.asyncDispose]();
+      } else if (Symbol.dispose in sink) {
+        sink[Symbol.dispose]();
+      }
+    } catch (error) {
+      disposeError = error;
+    }
+
+    if (sinkErrors.length > 0) {
+      const errors = disposeError == null
+        ? sinkErrors
+        : [...sinkErrors, disposeError];
+      if (errors.length === 1) throw errors[0];
+      throw new AggregateError(
+        errors,
+        "One or more errors occurred while emitting redacted log records.",
+      );
+    }
+    if (disposeError != null) {
+      throw disposeError;
     }
   };
   return wrapped;

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -443,23 +443,24 @@ export async function redactPropertiesAsync(
   const copy: Record<string, unknown> = {};
   visited.set(properties, copy);
 
+  const fields: string[] = [];
+  const values: Promise<unknown>[] = [];
   for (const field in properties) {
+    fields.push(field);
     if (shouldFieldRedacted(field, options.fieldPatterns)) {
-      setProperty(copy, field, await options.action(properties[field]));
+      values.push(Promise.resolve(options.action(properties[field])));
       continue;
     }
 
     const value = properties[field];
     if (Array.isArray(value)) {
-      setProperty(copy, field, await redactArrayAsync(value, options, visited));
+      values.push(redactArrayAsync(value, options, visited));
     } else if (typeof value === "object" && value !== null) {
       if (isBuiltInObject(value)) {
-        setProperty(copy, field, value);
+        values.push(Promise.resolve(value));
       } else {
-        setProperty(
-          copy,
-          field,
-          await redactPropertiesAsync(
+        values.push(
+          redactPropertiesAsync(
             value as Record<string, unknown>,
             options,
             visited,
@@ -467,8 +468,12 @@ export async function redactPropertiesAsync(
         );
       }
     } else {
-      setProperty(copy, field, value);
+      values.push(Promise.resolve(value));
     }
+  }
+  const redactedValues = await Promise.all(values);
+  for (let i = 0; i < fields.length; i++) {
+    setProperty(copy, fields[i], redactedValues[i]);
   }
   return copy;
 }
@@ -541,25 +546,35 @@ async function redactArrayAsync(
   const copy: unknown[] = [];
   copy.length = array.length;
   visited.set(array, copy);
+  const tasks: Promise<void>[] = [];
   for (let i = 0; i < array.length; i++) {
     if (!(i in array)) continue;
     const item = array[i];
     if (Array.isArray(item)) {
-      copy[i] = await redactArrayAsync(item, options, visited);
+      tasks.push(
+        redactArrayAsync(item, options, visited).then((redacted) => {
+          copy[i] = redacted;
+        }),
+      );
     } else if (typeof item === "object" && item !== null) {
       if (isBuiltInObject(item)) {
         copy[i] = item;
       } else {
-        copy[i] = await redactPropertiesAsync(
-          item as Record<string, unknown>,
-          options,
-          visited,
+        tasks.push(
+          redactPropertiesAsync(
+            item as Record<string, unknown>,
+            options,
+            visited,
+          ).then((redacted) => {
+            copy[i] = redacted;
+          }),
         );
       }
     } else {
       copy[i] = item;
     }
   }
+  await Promise.all(tasks);
   return copy;
 }
 

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -221,7 +221,10 @@ export function redactByField(
  * @example
  * ```ts
  * import { getConsoleSink } from "@logtape/logtape";
- * import { createHmacPseudonymizer, redactByFieldAsync } from "@logtape/redaction";
+ * import {
+ *   createHmacPseudonymizer,
+ *   redactByFieldAsync,
+ * } from "@logtape/redaction";
  *
  * const pseudonymize = await createHmacPseudonymizer({ key: "secret" });
  * const sink = redactByFieldAsync(getConsoleSink(), {
@@ -363,10 +366,10 @@ function reportRedactionFailure(error: unknown): void {
 /**
  * Creates an asynchronous pseudonymizer based on HMAC using the Web Crypto API.
  *
- * The returned function converts each value with `String(value)`, encodes it as
- * UTF-8, and returns a stable pseudonym.  Because HMAC is keyed, this is safer
- * than a plain salted hash for values with small input spaces, such as email
- * addresses or numeric user IDs.
+ * The returned function converts each value with `String(value)`, encodes it
+ * as UTF-8, and returns a stable pseudonym.  Because HMAC is keyed, this is
+ * safer than a plain salted hash for values with small input spaces, such as
+ * email addresses or numeric user IDs.
  *
  * @param options The HMAC pseudonymizer options.
  * @returns An async redaction action.

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -718,9 +718,9 @@ function redactMessageArray(
         // For non-redacted placeholders, use value from redactedProperties
         // to ensure nested sensitive fields are redacted
         const placeholderName = placeholders[placeholderIndex];
-        const rootKey = parsePathSegments(placeholderName)[0];
-        if (rootKey in redactedProperties) {
-          result.push(redactedProperties[rootKey]);
+        const redactedValue = getPathValue(redactedProperties, placeholderName);
+        if (redactedValue.found) {
+          result.push(redactedValue.value);
         } else {
           result.push(message[i]);
         }
@@ -752,9 +752,9 @@ async function redactMessageArrayAsync(
         result.push(await action(message[i]));
       } else {
         const placeholderName = placeholders[placeholderIndex];
-        const rootKey = parsePathSegments(placeholderName)[0];
-        if (rootKey in redactedProperties) {
-          result.push(redactedProperties[rootKey]);
+        const redactedValue = getPathValue(redactedProperties, placeholderName);
+        if (redactedValue.found) {
+          result.push(redactedValue.value);
         } else {
           result.push(message[i]);
         }
@@ -763,6 +763,27 @@ async function redactMessageArrayAsync(
     }
   }
   return result;
+}
+
+function getPathValue(
+  properties: Record<string, unknown>,
+  path: string,
+): { found: true; value: unknown } | { found: false } {
+  const segments = parsePathSegments(path);
+  if (segments.length < 1) return { found: false };
+
+  let value: unknown = properties;
+  for (const segment of segments) {
+    if (
+      (typeof value !== "object" && typeof value !== "function") ||
+      value == null ||
+      !Object.hasOwn(value, segment)
+    ) {
+      return { found: false };
+    }
+    value = (value as Record<string, unknown>)[segment];
+  }
+  return { found: true, value };
 }
 
 /**

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -15,6 +15,26 @@ export type FieldPattern = string | RegExp;
 export type FieldPatterns = FieldPattern[];
 
 /**
+ * The synchronous action to perform on a redacted field value.
+ * @since 0.10.0
+ */
+export type FieldRedactionAction = "delete" | ((value: unknown) => unknown);
+
+/**
+ * The asynchronous action to perform on a redacted field value.
+ * @since 2.1.0
+ */
+export type AsyncFieldRedactionAction = (
+  value: unknown,
+) => PromiseLike<unknown>;
+
+/**
+ * A pseudonymizer created by {@link createHmacPseudonymizer}.
+ * @since 2.1.0
+ */
+export type HmacPseudonymizer = (value: unknown) => Promise<string>;
+
+/**
  * Default field patterns for redaction.  These patterns will match
  * common sensitive fields such as passwords, tokens, and personal
  * information.
@@ -60,7 +80,56 @@ export interface FieldRedactionOptions {
    * properties.
    * @default `"delete"`
    */
-  readonly action?: "delete" | ((value: unknown) => unknown);
+  readonly action?: FieldRedactionAction;
+}
+
+/**
+ * Options for asynchronously redacting fields in a {@link LogRecord}.  Used by
+ * the {@link redactByFieldAsync} function.
+ * @since 2.1.0
+ */
+export interface AsyncFieldRedactionOptions {
+  /**
+   * The field patterns to match against.  This can be an array of
+   * strings or regular expressions.  If a field matches any of the
+   * patterns, it will be redacted.
+   */
+  readonly fieldPatterns: FieldPatterns;
+
+  /**
+   * The asynchronous action to perform on the matched fields.
+   */
+  readonly action: AsyncFieldRedactionAction;
+}
+
+/**
+ * Options for the {@link createHmacPseudonymizer} function.
+ * @since 2.1.0
+ */
+export interface HmacPseudonymizerOptions {
+  /**
+   * The secret key to use for HMAC.  Strings are encoded as UTF-8.
+   */
+  readonly key: string | Uint8Array | ArrayBuffer | CryptoKey;
+
+  /**
+   * The HMAC hash algorithm.
+   * @default `"SHA-256"`
+   */
+  readonly hash?: "SHA-256" | "SHA-384" | "SHA-512";
+
+  /**
+   * The digest encoding.
+   * @default `"base64url"`
+   */
+  readonly encoding?: "base64url" | "hex";
+
+  /**
+   * The string prefix to prepend to each pseudonym.  If omitted, a prefix based
+   * on the hash algorithm is used, such as `"hmac-sha256:"`.  Set this to an
+   * empty string to disable the prefix.
+   */
+  readonly prefix?: string;
 }
 
 /**
@@ -139,6 +208,136 @@ export function redactByField(
 }
 
 /**
+ * Redacts properties and message values in a {@link LogRecord} based on the
+ * provided field patterns and asynchronous action.
+ *
+ * The returned sink preserves record ordering by processing redaction work in
+ * sequence and implements {@link AsyncDisposable} so callers can wait for all
+ * pending redaction work before shutdown.
+ *
+ * @example
+ * ```ts
+ * import { getConsoleSink } from "@logtape/logtape";
+ * import { createHmacPseudonymizer, redactByFieldAsync } from "@logtape/redaction";
+ *
+ * const pseudonymize = await createHmacPseudonymizer({ key: "secret" });
+ * const sink = redactByFieldAsync(getConsoleSink(), {
+ *   fieldPatterns: [/userId/i, /email/i],
+ *   action: pseudonymize,
+ * });
+ * ```
+ *
+ * @param sink The sink to wrap.
+ * @param options The async redaction options.
+ * @returns The wrapped sink.
+ * @since 2.1.0
+ */
+export function redactByFieldAsync(
+  sink: Sink | Sink & Disposable | Sink & AsyncDisposable,
+  options: AsyncFieldRedactionOptions,
+): Sink & AsyncDisposable {
+  let lastPromise = Promise.resolve();
+  const wrapped: Sink & AsyncDisposable = (record: LogRecord) => {
+    lastPromise = lastPromise
+      .then(async () => {
+        const redactedProperties = await redactPropertiesAsync(
+          record.properties,
+          options,
+        );
+        let redactedMessage = record.message;
+
+        if (typeof record.rawMessage === "string") {
+          const placeholders = extractPlaceholderNames(record.rawMessage);
+          const { redactedIndices, wildcardIndices } =
+            getRedactedPlaceholderIndices(
+              placeholders,
+              options.fieldPatterns,
+            );
+          redactedMessage = await redactMessageArrayAsync(
+            record.message,
+            placeholders,
+            redactedIndices,
+            wildcardIndices,
+            redactedProperties,
+            options.action,
+          );
+        } else {
+          const redactedValues = getRedactedValues(
+            record.properties,
+            redactedProperties,
+          );
+          if (redactedValues.size > 0) {
+            redactedMessage = redactMessageByValues(
+              record.message,
+              redactedValues,
+            );
+          }
+        }
+
+        sink({
+          ...record,
+          message: redactedMessage,
+          properties: redactedProperties,
+        });
+      })
+      .catch(() => {
+        // Drop records that cannot be safely redacted, but keep the chain alive
+        // so later records can still be processed.
+      });
+  };
+  wrapped[Symbol.asyncDispose] = async () => {
+    await lastPromise;
+    if (Symbol.asyncDispose in sink) {
+      await sink[Symbol.asyncDispose]();
+    } else if (Symbol.dispose in sink) {
+      sink[Symbol.dispose]();
+    }
+  };
+  return wrapped;
+}
+
+/**
+ * Creates an asynchronous pseudonymizer based on HMAC using the Web Crypto API.
+ *
+ * The returned function converts each value with `String(value)`, encodes it as
+ * UTF-8, and returns a stable pseudonym.  Because HMAC is keyed, this is safer
+ * than a plain salted hash for values with small input spaces, such as email
+ * addresses or numeric user IDs.
+ *
+ * @param options The HMAC pseudonymizer options.
+ * @returns An async redaction action.
+ * @since 2.1.0
+ */
+export async function createHmacPseudonymizer(
+  options: HmacPseudonymizerOptions,
+): Promise<HmacPseudonymizer> {
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle == null) {
+    throw new TypeError("The Web Crypto API is not available.");
+  }
+  const hash = options.hash ?? "SHA-256";
+  const encoding = options.encoding ?? "base64url";
+  const prefix = options.prefix ??
+    `hmac-${hash.toLowerCase().replaceAll("-", "")}:`;
+  const key = isCryptoKey(options.key) ? options.key : await subtle.importKey(
+    "raw",
+    keyToBytes(options.key),
+    { name: "HMAC", hash },
+    false,
+    ["sign"],
+  );
+  const encoder = new TextEncoder();
+
+  return async (value: unknown): Promise<string> => {
+    const data = encoder.encode(String(value));
+    const signature = new Uint8Array(
+      await subtle.sign("HMAC", key, data),
+    );
+    return prefix + encodeBytes(signature, encoding);
+  };
+}
+
+/**
  * Redacts properties from an object based on specified field patterns.
  *
  * This function creates a shallow copy of the input object and applies
@@ -198,6 +397,56 @@ export function redactProperties(
   return copy;
 }
 
+/**
+ * Redacts properties from an object using an asynchronous action.
+ * @param properties The properties to redact.
+ * @param options The async redaction options.
+ * @param visited Map of visited objects to prevent circular reference issues.
+ * @returns The redacted properties.
+ * @since 2.1.0
+ */
+export async function redactPropertiesAsync(
+  properties: Record<string, unknown>,
+  options: AsyncFieldRedactionOptions,
+  visited = new Map<object, object>(),
+): Promise<Record<string, unknown>> {
+  if (visited.has(properties)) {
+    return visited.get(properties) as Record<string, unknown>;
+  }
+
+  const copy: Record<string, unknown> = {};
+  visited.set(properties, copy);
+
+  for (const field in properties) {
+    if (shouldFieldRedacted(field, options.fieldPatterns)) {
+      setProperty(copy, field, await options.action(properties[field]));
+      continue;
+    }
+
+    const value = properties[field];
+    if (Array.isArray(value)) {
+      setProperty(copy, field, await redactArrayAsync(value, options, visited));
+    } else if (typeof value === "object" && value !== null) {
+      if (isBuiltInObject(value)) {
+        setProperty(copy, field, value);
+      } else {
+        setProperty(
+          copy,
+          field,
+          await redactPropertiesAsync(
+            value as Record<string, unknown>,
+            options,
+            visited,
+          ),
+        );
+      }
+    } else {
+      setProperty(copy, field, value);
+    }
+  }
+  return copy;
+}
+
 function setProperty(
   object: Record<string, unknown>,
   field: string,
@@ -243,6 +492,35 @@ function redactArray(
     }
     return item;
   });
+}
+
+async function redactArrayAsync(
+  array: unknown[],
+  options: AsyncFieldRedactionOptions,
+  visited: Map<object, object>,
+): Promise<unknown[]> {
+  const copy: unknown[] = [];
+  visited.set(array, copy);
+  for (const item of array) {
+    if (Array.isArray(item)) {
+      copy.push(await redactArrayAsync(item, options, visited));
+    } else if (typeof item === "object" && item !== null) {
+      if (isBuiltInObject(item)) {
+        copy.push(item);
+      } else {
+        copy.push(
+          await redactPropertiesAsync(
+            item as Record<string, unknown>,
+            options,
+            visited,
+          ),
+        );
+      }
+    } else {
+      copy.push(item);
+    }
+  }
+  return copy;
 }
 
 /**
@@ -439,6 +717,40 @@ function redactMessageArray(
   return result;
 }
 
+async function redactMessageArrayAsync(
+  message: readonly unknown[],
+  placeholders: string[],
+  redactedIndices: Set<number>,
+  wildcardIndices: Set<number>,
+  redactedProperties: Record<string, unknown>,
+  action: AsyncFieldRedactionAction,
+): Promise<readonly unknown[]> {
+  const result: unknown[] = [];
+  let placeholderIndex = 0;
+
+  for (let i = 0; i < message.length; i++) {
+    if (i % 2 === 0) {
+      result.push(message[i]);
+    } else {
+      if (wildcardIndices.has(placeholderIndex)) {
+        result.push(redactedProperties);
+      } else if (redactedIndices.has(placeholderIndex)) {
+        result.push(await action(message[i]));
+      } else {
+        const placeholderName = placeholders[placeholderIndex];
+        const rootKey = parsePathSegments(placeholderName)[0];
+        if (rootKey in redactedProperties) {
+          result.push(redactedProperties[rootKey]);
+        } else {
+          result.push(message[i]);
+        }
+      }
+      placeholderIndex++;
+    }
+  }
+  return result;
+}
+
 /**
  * Collects redacted value mappings from original to redacted properties.
  * @param original The original properties.
@@ -513,6 +825,44 @@ function redactMessageByValues(
         result.push(val);
       }
     }
+  }
+  return result;
+}
+
+function keyToBytes(key: string | Uint8Array | ArrayBuffer): BufferSource {
+  if (typeof key === "string") return new TextEncoder().encode(key);
+  if (key instanceof ArrayBuffer) return key;
+  return new Uint8Array(key);
+}
+
+function isCryptoKey(
+  key: string | Uint8Array | ArrayBuffer | CryptoKey,
+): key is CryptoKey {
+  return typeof CryptoKey !== "undefined" && key instanceof CryptoKey;
+}
+
+function encodeBytes(bytes: Uint8Array, encoding: "base64url" | "hex"): string {
+  switch (encoding) {
+    case "base64url":
+      return encodeBase64Url(bytes);
+    case "hex":
+      return encodeHex(bytes);
+  }
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+function encodeHex(bytes: Uint8Array): string {
+  let result = "";
+  for (const byte of bytes) {
+    result += byte.toString(16).padStart(2, "0");
   }
   return result;
 }

--- a/packages/redaction/src/field.ts
+++ b/packages/redaction/src/field.ts
@@ -1011,6 +1011,9 @@ function getHmacHash(
   hash: HmacPseudonymizerOptions["hash"],
 ): NonNullable<HmacPseudonymizerOptions["hash"]> {
   if (!isCryptoKey(key)) return hash ?? "SHA-256";
+  if (!key.usages.includes("sign")) {
+    throw new TypeError('The HMAC CryptoKey must include the "sign" usage.');
+  }
   const keyHash = getCryptoKeyHmacHash(key);
   if (hash != null && hash !== keyHash) {
     throw new TypeError(

--- a/packages/redaction/src/mod.ts
+++ b/packages/redaction/src/mod.ts
@@ -1,8 +1,15 @@
 export {
+  type AsyncFieldRedactionAction,
+  type AsyncFieldRedactionOptions,
+  createHmacPseudonymizer,
   DEFAULT_REDACT_FIELDS,
   type FieldPattern,
   type FieldPatterns,
+  type FieldRedactionAction,
   type FieldRedactionOptions,
+  type HmacPseudonymizer,
+  type HmacPseudonymizerOptions,
   redactByField,
+  redactByFieldAsync,
 } from "./field.ts";
 export * from "./pattern.ts";


### PR DESCRIPTION
## What changed

This adds async field redaction to *@logtape/redaction* so redaction actions can call async APIs such as the Web Crypto API. The main use case is stable pseudonymization: `createHmacPseudonymizer()` returns an async action that replaces matching field values with keyed HMAC pseudonyms, and `redactByFieldAsync()` wraps a sink while preserving record order until disposal.

The public API changes are in *packages/redaction/src/field.ts* and exported from *packages/redaction/src/mod.ts*. The manual now documents pseudonymizing fields in *docs/manual/redaction.md*, and the unreleased changelog entry is in *CHANGES.md*.

## Details

`createHmacPseudonymizer()` supports string, `Uint8Array`, `ArrayBuffer`, and `CryptoKey` keys, with configurable HMAC hash, base64url or hex output, and custom prefixes. `CryptoKey` inputs derive the default prefix from the key’s HMAC hash algorithm and reject explicit hash mismatches.

`redactByFieldAsync()` keeps async redaction work ordered, exposes async disposal so callers can wait for pending work, preserves cyclic arrays and sparse arrays, keeps non-sensitive nested placeholders such as `{user.name}` as their resolved path value, and reports wrapped sink failures during async disposal instead of swallowing them as redaction failures.

Fixes #160.

## Verification

- `deno test packages/redaction/src/field.test.ts packages/redaction/src/pattern.test.ts`
- `pnpm --filter @logtape/redaction test`
- `pnpm --filter @logtape/redaction test:bun`
- `mise check && mise test`
- `cd docs && pnpm build`