### PR TITLE
feat: Add support for SQLite dialect on drizzle-orm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,14 +18,16 @@ To be released.
 
 [#167]: https://github.com/dahlia/logtape/issues/167
 
-### @logtape/drizzle=orm
+### @logtape/drizzle-orm
 
- -  Added SQLite support to drizzle-orm logger [[#168], [#169] by Van-sh]
-     -  Added `type DrizzleDialects = "pg" | "sqlite"`
+ -  Added SQLite support to `DrizzleLogger`.  [[#168], [#169] by Van-sh]
+
+     -  Added `DrizzleDialects` type.
      -  Added `DrizzleLoggerOptions.dialect?: DrizzleDialects` option which
-        defaults to `"pg"`
-     -  Updated `serialize`, `stringLiteral` functions and `DrizzleLogger`
-        constructor to take in a `dialect?: DrizzleDialect` parameter
+        defaults to `"pg"`.
+     -  Now `serialize()` and `stringLiteral()` functions and
+        `DrizzleLogger` constructor take an optional `dialect?: DrizzleDialect`
+        parameter.
 
 [#168]: https://github.com/dahlia/logtape/issues/168
 [#169]: https://github.com/dahlia/logtape/pull/169

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,18 @@ To be released.
 
 [#167]: https://github.com/dahlia/logtape/issues/167
 
+### @logtape/drizzle=orm
+
+ -  Added SQLite support to drizzle-orm logger [[#168], [#169] by Van-sh]
+     -  Added `type DrizzleDialects = "pg" | "sqlite"`
+     -  Added `DrizzleLoggerOptions.dialect?: DrizzleDialects` option which
+        defaults to `"pg"`
+     -  Updated `serialize`, `stringLiteral` functions and `DrizzleLogger`
+        constructor to take in a `dialect?: DrizzleDialect` parameter
+
+[#168]: https://github.com/dahlia/logtape/issues/168
+[#169]: https://github.com/dahlia/logtape/pull/169
+
 
 Version 2.1.1
 -------------

--- a/docs/manual/integrations.md
+++ b/docs/manual/integrations.md
@@ -87,16 +87,15 @@ const logger = getLogger({
 });
 ~~~~
 
-### Different SQL Dialects
+### Dialects
 
-By default, the Postgres Dialect is used. You can change this:
+By default, the PostgreSQL dialect (`"pg"`) is used. You can change this:
 
 ~~~~ typescript twoslash
 import { getLogger } from "@logtape/drizzle-orm";
 // ---cut-before---
 const logger = getLogger({
-  // "pg" | "sqlite"
-    dialect: "sqlite",
+  dialect: "sqlite",  // "pg" | "sqlite"
 });
 ~~~~
 

--- a/docs/manual/integrations.md
+++ b/docs/manual/integrations.md
@@ -87,6 +87,19 @@ const logger = getLogger({
 });
 ~~~~
 
+### Different SQL Dialects
+
+By default, the Postgres Dialect is used. You can change this:
+
+~~~~ typescript twoslash
+import { getLogger } from "@logtape/drizzle-orm";
+// ---cut-before---
+const logger = getLogger({
+  // "pg" | "sqlite"
+    dialect: "sqlite",
+});
+~~~~
+
 ### Structured logging output
 
 The adapter logs queries with structured data that includes:

--- a/packages/drizzle-orm/README.md
+++ b/packages/drizzle-orm/README.md
@@ -84,16 +84,15 @@ const db = drizzle(client, {
 ~~~~
 
 
-Different SQL Dialects
-----------------------
+Dialects
+--------
 
-By default, the Postgres Dialect is used. You can change this:
+By default, the PostgreSQL dialect (`"pg"`) is used. You can change this:
 
 ~~~~ typescript
 const db = drizzle(client, {
   logger: getLogger({
-    // "pg" | "sqlite"
-    dialect: "sqlite",
+    dialect: "sqlite",  // "pg" | "sqlite"
   }),
 });
 ~~~~

--- a/packages/drizzle-orm/README.md
+++ b/packages/drizzle-orm/README.md
@@ -84,6 +84,21 @@ const db = drizzle(client, {
 ~~~~
 
 
+Different SQL Dialects
+----------------------
+
+By default, the Postgres Dialect is used. You can change this:
+
+~~~~ typescript
+const db = drizzle(client, {
+  logger: getLogger({
+    // "pg" | "sqlite"
+    dialect: "sqlite",
+  }),
+});
+~~~~
+
+
 Structured logging
 ------------------
 

--- a/packages/drizzle-orm/src/mod.test.ts
+++ b/packages/drizzle-orm/src/mod.test.ts
@@ -144,7 +144,7 @@ test("getLogger(): supports all log levels", async () => {
 });
 
 // ============================================
-// Query Logging Tests
+// Query Logging Tests (pg)
 // ============================================
 
 test("logQuery(): logs query with structured data", async () => {
@@ -224,6 +224,96 @@ test("logQuery(): log message contains formatted query", async () => {
   const { logs, cleanup } = await setupLogtape();
   try {
     const logger = getLogger();
+    logger.logQuery("SELECT 1", []);
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].rawMessage, "Query: {formattedQuery}");
+  } finally {
+    await cleanup();
+  }
+});
+
+// ============================================
+// Query Logging Tests (sqlite)
+// ============================================
+
+test("logQuery({ dialect: 'sqlite' }): logs query with structured data", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery("SELECT * FROM users WHERE id = ?", ["123"]);
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.query,
+      "SELECT * FROM users WHERE id = ?",
+    );
+    assert.deepStrictEqual(logs[0].properties.params, ["123"]);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users WHERE id = '123'",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("logQuery({ dialect: 'sqlite' }): formats query with multiple parameters", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery(
+      "SELECT * FROM users WHERE name = ? AND age > ?",
+      ["Alice", 25],
+    );
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users WHERE name = 'Alice' AND age > 25",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("logQuery({ dialect: 'sqlite' }): handles empty parameters", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery("SELECT * FROM users", []);
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users",
+    );
+    assert.deepStrictEqual(logs[0].properties.params, []);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("logQuery({ dialect: 'sqlite' }): handles unmatched placeholders", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery("SELECT * FROM users WHERE id = ? AND name = ?", ["123"]);
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users WHERE id = '123' AND name = ?",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("logQuery({ dialect: 'sqlite' }): log message contains formatted query", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
     logger.logQuery("SELECT 1", []);
 
     assert.strictEqual(logs.length, 1);

--- a/packages/drizzle-orm/src/mod.test.ts
+++ b/packages/drizzle-orm/src/mod.test.ts
@@ -323,8 +323,62 @@ test("logQuery({ dialect: 'sqlite' }): log message contains formatted query", as
   }
 });
 
+test("logQuery({ dialect: 'sqlite' }): handles boolean parameters", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery(
+      "SELECT * FROM users WHERE active = ? AND verified = ?",
+      [true, false],
+    );
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users WHERE active = 1 AND verified = 0",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("logQuery({ dialect: 'sqlite' }): handles array parameter as JSON", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery(
+      "SELECT * FROM users WHERE ids = ?",
+      [[1, 2, 3]],
+    );
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users WHERE ids = '[1,2,3]'",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+test("logQuery({ dialect: 'sqlite' }): escapes single quotes in strings", async () => {
+  const { logs, cleanup } = await setupLogtape();
+  try {
+    const logger = getLogger({ dialect: "sqlite" });
+    logger.logQuery("SELECT * FROM users WHERE name = ?", ["O'Brien"]);
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(
+      logs[0].properties.formattedQuery,
+      "SELECT * FROM users WHERE name = 'O''Brien'",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
 // ============================================
-// Parameter Serialization Tests
+// Parameter Serialization Tests (pg)
 // ============================================
 
 test("serialize(): handles null", () => {
@@ -391,7 +445,72 @@ test("serialize(): handles mixed arrays", () => {
 });
 
 // ============================================
-// String Literal Tests
+// Parameter Serialization Tests (sqlite)
+// ============================================
+
+test("serialize({ dialect: 'sqlite' }): handles null", () => {
+  assert.strictEqual(serialize(null, "sqlite"), "NULL");
+});
+
+test("serialize({ dialect: 'sqlite' }): handles strings", () => {
+  assert.strictEqual(serialize("hello", "sqlite"), "'hello'");
+});
+
+test("serialize({ dialect: 'sqlite' }): doubles single quotes", () => {
+  assert.strictEqual(serialize("it's", "sqlite"), "'it''s'");
+  assert.strictEqual(serialize("O'Brien", "sqlite"), "'O''Brien'");
+});
+
+test("serialize({ dialect: 'sqlite' }): leaves backslashes literal", () => {
+  assert.strictEqual(serialize("back\\slash", "sqlite"), "'back\\slash'");
+});
+
+test("serialize({ dialect: 'sqlite' }): leaves control characters literal", () => {
+  assert.strictEqual(serialize("hello\nworld", "sqlite"), "'hello\nworld'");
+  assert.strictEqual(serialize("tab\there", "sqlite"), "'tab\there'");
+});
+
+test("serialize({ dialect: 'sqlite' }): handles booleans as integers", () => {
+  assert.strictEqual(serialize(true, "sqlite"), "1");
+  assert.strictEqual(serialize(false, "sqlite"), "0");
+});
+
+test("serialize({ dialect: 'sqlite' }): handles arrays as JSON", () => {
+  assert.strictEqual(serialize([1, 2, 3], "sqlite"), "'[1,2,3]'");
+  assert.strictEqual(serialize(["a", "b"], "sqlite"), `'["a","b"]'`);
+  assert.strictEqual(serialize([], "sqlite"), "'[]'");
+});
+
+test("serialize({ dialect: 'sqlite' }): handles nested arrays as JSON", () => {
+  assert.strictEqual(
+    serialize([[1, 2], [3, 4]], "sqlite"),
+    "'[[1,2],[3,4]]'",
+  );
+});
+
+test("serialize({ dialect: 'sqlite' }): handles objects as JSON", () => {
+  assert.strictEqual(
+    serialize({ key: "value" }, "sqlite"),
+    '\'{"key":"value"}\'',
+  );
+});
+
+test("serialize({ dialect: 'sqlite' }): handles mixed arrays as JSON", () => {
+  assert.strictEqual(
+    serialize([1, "two", true], "sqlite"),
+    `'[1,"two",true]'`,
+  );
+});
+
+test("serialize({ dialect: 'sqlite' }): handles array with null", () => {
+  assert.strictEqual(
+    serialize([1, null, undefined, 2], "sqlite"),
+    "'[1,null,null,2]'",
+  );
+});
+
+// ============================================
+// String Literal Tests (pg)
 // ============================================
 
 test("stringLiteral(): wraps simple strings", () => {
@@ -429,6 +548,26 @@ test("stringLiteral(): escapes multiple special characters", () => {
 
 test("stringLiteral(): handles empty string", () => {
   assert.strictEqual(stringLiteral(""), "''");
+});
+
+// ============================================
+// String Literal Tests (sqlite)
+// ============================================
+
+test("stringLiteral({ dialect: 'sqlite' }): wraps simple strings", () => {
+  assert.strictEqual(stringLiteral("hello", "sqlite"), "'hello'");
+});
+
+test("stringLiteral({ dialect: 'sqlite' }): doubles single quotes", () => {
+  assert.strictEqual(stringLiteral("it's", "sqlite"), "'it''s'");
+});
+
+test("stringLiteral({ dialect: 'sqlite' }): leaves backslashes literal", () => {
+  assert.strictEqual(stringLiteral("back\\slash", "sqlite"), "'back\\slash'");
+});
+
+test("stringLiteral({ dialect: 'sqlite' }): leaves newlines literal", () => {
+  assert.strictEqual(stringLiteral("line1\nline2", "sqlite"), "'line1\nline2'");
 });
 
 // ============================================

--- a/packages/drizzle-orm/src/mod.ts
+++ b/packages/drizzle-orm/src/mod.ts
@@ -29,7 +29,7 @@ export interface DrizzleLoggerOptions {
   readonly level?: LogLevel;
 
   /**
-   * The dialect used in drizzle-orm
+   * The dialect used for drizzle-orm
    * @default "pg"
    */
   readonly dialect?: DrizzleDialects;
@@ -69,6 +69,7 @@ export class DrizzleLogger implements Logger {
    * Creates a new DrizzleLogger instance.
    * @param logger The LogTape logger to use.
    * @param level The log level to use for query logging.
+   * @param dialect The dialect used for drizzle-orm
    */
   constructor(
     logger: LogTapeLogger,

--- a/packages/drizzle-orm/src/mod.ts
+++ b/packages/drizzle-orm/src/mod.ts
@@ -7,6 +7,11 @@ import {
 export type { LogLevel } from "@logtape/logtape";
 
 /**
+ * Supported Drizzle Dialects
+ */
+export type DrizzleDialects = "pg" | "sqlite";
+
+/**
  * Options for configuring the Drizzle ORM LogTape logger.
  * @since 1.3.0
  */
@@ -22,6 +27,12 @@ export interface DrizzleLoggerOptions {
    * @default "debug"
    */
   readonly level?: LogLevel;
+
+  /**
+   * The dialect used in drizzle-orm
+   * @default "pg"
+   */
+  readonly dialect?: DrizzleDialects;
 }
 
 /**
@@ -52,15 +63,21 @@ export interface Logger {
 export class DrizzleLogger implements Logger {
   readonly #logger: LogTapeLogger;
   readonly #level: LogLevel;
+  readonly #dialect: DrizzleDialects;
 
   /**
    * Creates a new DrizzleLogger instance.
    * @param logger The LogTape logger to use.
    * @param level The log level to use for query logging.
    */
-  constructor(logger: LogTapeLogger, level: LogLevel = "debug") {
+  constructor(
+    logger: LogTapeLogger,
+    level: LogLevel = "debug",
+    dialect: DrizzleDialects = "pg",
+  ) {
     this.#logger = logger;
     this.#level = level;
+    this.#dialect = dialect;
   }
 
   /**
@@ -77,10 +94,27 @@ export class DrizzleLogger implements Logger {
    */
   logQuery(query: string, params: unknown[]): void {
     const stringifiedParams = params.map(serialize);
-    const formattedQuery = query.replace(/\$(\d+)/g, (match) => {
-      const index = Number.parseInt(match.slice(1), 10);
-      return stringifiedParams[index - 1] ?? match;
-    });
+    let formattedQuery: string;
+    switch (this.#dialect) {
+      case "pg": {
+        formattedQuery = query.replace(/\$(\d+)/g, (match) => {
+          const index = Number.parseInt(match.slice(1), 10);
+          return stringifiedParams[index - 1] ?? match;
+        });
+        break;
+      }
+      case "sqlite": {
+        let index = -1;
+        formattedQuery = query.replace(/\?/g, (match) => {
+          index += 1;
+          return stringifiedParams[index] ?? match;
+        });
+        break;
+      }
+      default: {
+        throw new Error(`${this.#dialect satisfies never} is not supported`);
+      }
+    }
 
     const logMethod = this.#logger[this.#level].bind(this.#logger);
     logMethod("Query: {formattedQuery}", {
@@ -184,5 +218,9 @@ function normalizeCategory(
 export function getLogger(options: DrizzleLoggerOptions = {}): DrizzleLogger {
   const category = normalizeCategory(options.category ?? ["drizzle-orm"]);
   const logger = getLogTapeLogger(category);
-  return new DrizzleLogger(logger, options.level ?? "debug");
+  return new DrizzleLogger(
+    logger,
+    options.level ?? "debug",
+    options.dialect ?? "pg",
+  );
 }

--- a/packages/drizzle-orm/src/mod.ts
+++ b/packages/drizzle-orm/src/mod.ts
@@ -93,7 +93,9 @@ export class DrizzleLogger implements Logger {
    * @param params The parameter values.
    */
   logQuery(query: string, params: unknown[]): void {
-    const stringifiedParams = params.map(serialize);
+    const stringifiedParams = params.map((param) =>
+      serialize(param, this.#dialect)
+    );
     let formattedQuery: string;
     switch (this.#dialect) {
       case "pg": {
@@ -129,47 +131,82 @@ export class DrizzleLogger implements Logger {
  * Serializes a parameter value to a SQL-safe string representation.
  *
  * @param value The value to serialize.
+ * @param dialect The SQL dialect to format for. Defaults to PostgreSQL.
  * @returns The serialized string representation.
  * @since 1.3.0
  */
-export function serialize(value: unknown): string {
+export function serialize(
+  value: unknown,
+  dialect: DrizzleDialects = "pg",
+): string {
   if (typeof value === "undefined" || value === null) return "NULL";
-  if (typeof value === "string") return stringLiteral(value);
+  if (typeof value === "string") return stringLiteral(value, dialect);
   if (typeof value === "number" || typeof value === "bigint") {
     return value.toString();
   }
-  if (typeof value === "boolean") return value ? "'t'" : "'f'";
-  if (value instanceof Date) return stringLiteral(value.toISOString());
+  if (typeof value === "boolean") {
+    switch (dialect) {
+      case "sqlite":
+        return value ? "1" : "0";
+      case "pg":
+        return value ? "'t'" : "'f'";
+      default:
+        throw new Error(`${dialect satisfies never} is not supported`);
+    }
+  }
+  if (value instanceof Date) {
+    return stringLiteral(value.toISOString(), dialect);
+  }
   if (Array.isArray(value)) {
-    return `ARRAY[${value.map(serialize).join(", ")}]`;
+    switch (dialect) {
+      case "sqlite":
+        return stringLiteral(JSON.stringify(value), dialect);
+      case "pg":
+        return `ARRAY[${
+          value.map((item) => serialize(item, dialect)).join(", ")
+        }]`;
+      default:
+        throw new Error(`${dialect satisfies never} is not supported`);
+    }
   }
   if (typeof value === "object") {
-    // Assume it's a JSON object
-    return stringLiteral(JSON.stringify(value));
+    return stringLiteral(JSON.stringify(value), dialect);
   }
-  return stringLiteral(String(value));
+  return stringLiteral(String(value), dialect);
 }
 
 /**
  * Converts a string to a SQL string literal with proper escaping.
  *
  * @param str The string to convert.
+ * @param dialect The SQL dialect to format for. Defaults to PostgreSQL.
  * @returns The escaped SQL string literal.
  * @since 1.3.0
  */
-export function stringLiteral(str: string): string {
-  if (/[\\'\n\r\t\b\f]/.test(str)) {
-    let escaped = str;
-    escaped = escaped.replaceAll("\\", "\\\\");
-    escaped = escaped.replaceAll("'", "\\'");
-    escaped = escaped.replaceAll("\n", "\\n");
-    escaped = escaped.replaceAll("\r", "\\r");
-    escaped = escaped.replaceAll("\t", "\\t");
-    escaped = escaped.replaceAll("\b", "\\b");
-    escaped = escaped.replaceAll("\f", "\\f");
-    return `E'${escaped}'`;
+export function stringLiteral(
+  str: string,
+  dialect: DrizzleDialects = "pg",
+): string {
+  switch (dialect) {
+    case "sqlite":
+      return `'${str.replaceAll("'", "''")}'`;
+    case "pg": {
+      if (/[\\'\n\r\t\b\f]/.test(str)) {
+        let escaped = str;
+        escaped = escaped.replaceAll("\\", "\\\\");
+        escaped = escaped.replaceAll("'", "\\'");
+        escaped = escaped.replaceAll("\n", "\\n");
+        escaped = escaped.replaceAll("\r", "\\r");
+        escaped = escaped.replaceAll("\t", "\\t");
+        escaped = escaped.replaceAll("\b", "\\b");
+        escaped = escaped.replaceAll("\f", "\\f");
+        return `E'${escaped}'`;
+      }
+      return `'${str}'`;
+    }
+    default:
+      throw new Error(`${dialect satisfies never} is not supported`);
   }
-  return `'${str}'`;
 }
 
 /**


### PR DESCRIPTION
- Adds SQLite dialect support on the drizzle-orm logger
- Adds Unit tests on logQuery with the SQLite dialect

resolves #168