### PR TITLE
Add request context options to HTTP integrations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,10 +18,10 @@ To be released.
 
 [implicit context]: https://logtape.org/manual/contexts#implicit-contexts
 
-### @logtape/express, @logtape/hono, @logtape/koa, and @logtape/elysia
+### @logtape/elysia, @logtape/express, @logtape/hono, and @logtape/koa
 
- -  Added opt-in request-scoped context support to `expressLogger()`,
-    `honoLogger()`, `koaLogger()`, and `elysiaLogger()`.  Set
+ -  Added opt-in request-scoped context support to `elysiaLogger()`,
+    `expressLogger()`, `honoLogger()`, and `koaLogger()`.  Set
     `context: true` to read the incoming `x-request-id` header, generate a
     request ID when the header is missing, write the resolved ID to the
     `x-request-id` response header, and add `requestId` to request log records
@@ -29,8 +29,8 @@ To be released.
     handling the request.  [[#172], [#174]]
 
      -  Added `context?: boolean | RequestContextOptions` to
-        `ExpressLogTapeOptions`, `HonoLogTapeOptions`, `KoaLogTapeOptions`,
-        and `ElysiaLogTapeOptions`.
+        `ElysiaLogTapeOptions`, `ExpressLogTapeOptions`, `HonoLogTapeOptions`,
+        and `KoaLogTapeOptions`.
      -  Added `RequestContextOptions` with
         `requestId?: boolean | RequestIdOptions`,
         `include?: readonly RequestContextField[]`, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,34 @@ To be released.
 
 [implicit context]: https://logtape.org/manual/contexts#implicit-contexts
 
+### @logtape/express, @logtape/hono, @logtape/koa, and @logtape/elysia
+
+ -  Added opt-in request-scoped context support to `expressLogger()`,
+    `honoLogger()`, `koaLogger()`, and `elysiaLogger()`.  Set
+    `context: true` to read the incoming `x-request-id` header, generate a
+    request ID when the header is missing, write the resolved ID to the
+    `x-request-id` response header, and add `requestId` to request log records
+    and, when implicit context storage is configured, logs emitted while
+    handling the request.  [[#172], [#174]]
+
+     -  Added `context?: boolean | RequestContextOptions` to
+        `ExpressLogTapeOptions`, `HonoLogTapeOptions`, `KoaLogTapeOptions`,
+        and `ElysiaLogTapeOptions`.
+     -  Added `RequestContextOptions` with
+        `requestId?: boolean | RequestIdOptions`,
+        `include?: readonly RequestContextField[]`, and
+        `enrich?: (...) => Record<string, unknown> | Promise<Record<string, unknown>>`.
+     -  Added `RequestIdOptions` with `property?: string`,
+        `headerNames?: readonly string[]`,
+        `responseHeader?: string | false`, `generate?: () => string`, and
+        `normalize?: (value: string) => string | null`.
+     -  Added `RequestContextField` for selecting request fields in implicit
+        context.  The Express integration also supports the `httpVersion`
+        field.
+
+[#172]: https://github.com/dahlia/logtape/issues/172
+[#174]: https://github.com/dahlia/logtape/pull/174
+
 ### @logtape/file
 
  -  Fixed a bug where `getRotatingFileSink()` with `maxFiles: 0` or a negative

--- a/docs/manual/contexts.md
+++ b/docs/manual/contexts.md
@@ -196,6 +196,41 @@ implicit context `requestId` even though the `requestId` is not passed to the
 > are correctly inherited by all subroutines and asynchronous operations.
 > In other words, implicit contexts are more than just a global variable.
 
+### HTTP request contexts
+
+The Express, Elysia, Hono, and Koa integrations can establish implicit context
+for each request.  Set the integration's `context` option to `true` to read the
+incoming `x-request-id` header, generate a request ID when the header is
+missing, propagate the resolved ID to the `x-request-id` response header, and
+add `requestId` to request log records:
+
+~~~~ typescript twoslash
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+import { expressLogger } from "@logtape/express";
+
+await configure({
+  sinks: {},
+  loggers: [],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+const middleware = expressLogger({ context: true });
+~~~~
+
+With `~Config.contextLocalStorage` configured, logs emitted by application code
+while handling the request inherit the same `requestId` automatically.  The
+integrations still establish the context when their `skip` option suppresses
+the request log, so application logs inside skipped requests can remain
+correlated.
+
+The `context` option also accepts a `RequestContextOptions` object for custom
+request ID headers, response header propagation, included request fields, and
+application-specific enrichment.  See [third-party integrations] for
+framework-specific examples.
+
+[third-party integrations]: ./integrations.md
+
 ### Nesting
 
 Implicit contexts can be nested.  Here's an example of nesting implicit

--- a/docs/manual/integrations.md
+++ b/docs/manual/integrations.md
@@ -199,6 +199,53 @@ const middleware = expressLogger({
   format: "dev",                 // Predefined format (default: "combined")
   skip: (req, res) => res.statusCode < 400,  // Skip successful requests
   immediate: false,              // Log after response (default: false)
+  context: true,                 // Add requestId to request-scoped logs
+});
+~~~~
+
+### Request context
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the middleware reads the `x-request-id` request header, generates an ID when
+the header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to the request log record.
+
+To make logs emitted by route handlers inherit the same `requestId`, configure
+LogTape with `~Config.contextLocalStorage` as described in
+[implicit contexts](./contexts.md#implicit-contexts):
+
+~~~~ typescript twoslash
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+import { expressLogger } from "@logtape/express";
+
+await configure({
+  sinks: {},
+  loggers: [],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+const middleware = expressLogger({ context: true });
+~~~~
+
+The context is established even when `skip` suppresses the request log, so
+application logs inside the skipped request can still carry the same request
+ID.
+
+You can customize request ID headers and include additional request fields:
+
+~~~~ typescript twoslash
+import { expressLogger } from "@logtape/express";
+// ---cut-before---
+const middleware = expressLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "url", "httpVersion"],
+    enrich: (req) => ({ route: req.path }),
+  },
 });
 ~~~~
 
@@ -328,6 +375,53 @@ const plugin = elysiaLogger({
   skip: (ctx) => ctx.path === "/health",  // Skip health check endpoint
   logRequest: false,             // Log after response (default: false)
   scope: "global",               // Plugin scope (default: "global")
+  context: true,                 // Add requestId to request-scoped logs
+});
+~~~~
+
+### Request context
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the plugin reads the `x-request-id` request header, generates an ID when the
+header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to request and error log records.
+
+To make logs emitted by route handlers inherit the same `requestId`, configure
+LogTape with `~Config.contextLocalStorage` as described in
+[implicit contexts](./contexts.md#implicit-contexts):
+
+~~~~ typescript twoslash
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+import { elysiaLogger } from "@logtape/elysia";
+
+await configure({
+  sinks: {},
+  loggers: [],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+const plugin = elysiaLogger({ context: true });
+~~~~
+
+The context is established even when `skip` suppresses the request log, so
+application logs inside the skipped request can still carry the same request
+ID.
+
+You can customize request ID headers and include additional request fields:
+
+~~~~ typescript twoslash
+import { elysiaLogger } from "@logtape/elysia";
+// ---cut-before---
+const plugin = elysiaLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "path", "userAgent"],
+    enrich: (ctx) => ({ route: ctx.path }),
+  },
 });
 ~~~~
 
@@ -480,6 +574,53 @@ const middleware = honoLogger({
   format: "dev",                 // Predefined format (default: "combined")
   skip: (c) => c.req.path === "/health",  // Skip health check endpoint
   logRequest: false,             // Log after response (default: false)
+  context: true,                 // Add requestId to request-scoped logs
+});
+~~~~
+
+### Request context
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the middleware reads the `x-request-id` request header, generates an ID when
+the header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to the request log record.
+
+To make logs emitted by route handlers inherit the same `requestId`, configure
+LogTape with `~Config.contextLocalStorage` as described in
+[implicit contexts](./contexts.md#implicit-contexts):
+
+~~~~ typescript twoslash
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+import { honoLogger } from "@logtape/hono";
+
+await configure({
+  sinks: {},
+  loggers: [],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+const middleware = honoLogger({ context: true });
+~~~~
+
+The context is established even when `skip` suppresses the request log, so
+application logs inside the skipped request can still carry the same request
+ID.
+
+You can customize request ID headers and include additional request fields:
+
+~~~~ typescript twoslash
+import { honoLogger } from "@logtape/hono";
+// ---cut-before---
+const middleware = honoLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "path", "userAgent"],
+    enrich: (c) => ({ route: c.req.path }),
+  },
 });
 ~~~~
 
@@ -730,6 +871,53 @@ const middleware = koaLogger({
   format: "dev",                 // Predefined format (default: "combined")
   skip: (ctx) => ctx.path === "/health",  // Skip health check endpoint
   logRequest: false,             // Log after response (default: false)
+  context: true,                 // Add requestId to request-scoped logs
+});
+~~~~
+
+### Request context
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the middleware reads the `x-request-id` request header, generates an ID when
+the header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to the request log record.
+
+To make logs emitted by route handlers inherit the same `requestId`, configure
+LogTape with `~Config.contextLocalStorage` as described in
+[implicit contexts](./contexts.md#implicit-contexts):
+
+~~~~ typescript twoslash
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+import { koaLogger } from "@logtape/koa";
+
+await configure({
+  sinks: {},
+  loggers: [],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+const middleware = koaLogger({ context: true });
+~~~~
+
+The context is established even when `skip` suppresses the request log, so
+application logs inside the skipped request can still carry the same request
+ID.
+
+You can customize request ID headers and include additional request fields:
+
+~~~~ typescript twoslash
+import { koaLogger } from "@logtape/koa";
+// ---cut-before---
+const middleware = koaLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "path", "remoteAddr"],
+    enrich: (ctx) => ({ route: ctx.path }),
+  },
 });
 ~~~~
 
@@ -793,7 +981,8 @@ SvelteKit
 ---------
 
 [SvelteKit] can use LogTape in both server-side hooks and API routes.
-Use hooks for global request logging:
+Unlike Express, Elysia, Hono, and Koa, LogTape does not provide a dedicated
+SvelteKit adapter.  Use hooks with `withContext()` for global request logging:
 
 ~~~~ typescript [src/hooks.server.ts] twoslash
 import {

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -66,6 +66,51 @@ app.use(elysiaLogger({
   skip: (ctx) => ctx.path === "/health",  // Skip logging for specific paths
   logRequest: true,              // Log at request start (default: false)
   scope: "global",               // Plugin scope (default: "global")
+  context: true,                 // Add requestId to request-scoped logs
+}));
+~~~~
+
+
+Request context
+---------------
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the plugin reads the `x-request-id` request header, generates an ID when the
+header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to request and error log records.
+
+To make logs emitted by your route handlers inherit the same `requestId`, also
+configure LogTape with `contextLocalStorage`:
+
+~~~~ typescript
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+
+await configure({
+  // ... sinks and loggers ...
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+new Elysia()
+  .use(elysiaLogger({ context: true }))
+  .get("/", () => ({ hello: "world" }));
+~~~~
+
+The context is still established when `skip` suppresses the request log, so
+application logs inside the skipped request can keep the same request ID.
+
+You can customize request ID headers and add more request fields:
+
+~~~~ typescript
+app.use(elysiaLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "path", "userAgent"],
+    enrich: (ctx) => ({ route: ctx.path }),
+  },
 }));
 ~~~~
 

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -923,6 +923,42 @@ test("elysiaLogger(): local scope wraps optional ALL routes", async () => {
   }
 });
 
+test("elysiaLogger(): local scope fallback matches optional routes", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-fallback-123" } },
+    })
+      .all("/users/:id?", () => {
+        appLogger.info("Handled local optional fallback route");
+        return "Hello";
+      });
+    const routeMatcher = plugin as unknown as {
+      router?: { http?: { find: () => unknown } };
+    };
+    if (routeMatcher.router?.http != null) {
+      routeMatcher.router.http.find = () => undefined;
+    }
+    const app = new Elysia().use(plugin);
+
+    const res = await app.handle(
+      new Request("http://localhost/users", { method: "POST" }),
+    );
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-fallback-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-fallback-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-fallback-123");
+  } finally {
+    await cleanup();
+  }
+});
+
 // ============================================
 // Error Logging Tests
 // ============================================

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -48,6 +48,17 @@ async function setupLogtape(options: {
   return { logs, cleanup: () => reset() };
 }
 
+function assertRecentResponseTime(
+  responseTime: unknown,
+  startedAt: number,
+): void {
+  assert.ok(typeof responseTime === "number");
+  assert.ok(
+    responseTime <= performance.now() - startedAt + 50,
+    `expected recent response time, got ${responseTime}`,
+  );
+}
+
 // ============================================
 // Basic Plugin Creation Tests
 // ============================================
@@ -757,6 +768,37 @@ test("elysiaLogger(): context appears on error logs", async () => {
   }
 });
 
+test("elysiaLogger(): context enrich errors keep local response time recent", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const enrichError = new Error("enrich failed");
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: {
+        enrich: async () => {
+          await delay(1);
+          throw enrichError;
+        },
+      },
+    })
+      .get("/error", () => "Hello");
+    const app = new Elysia().use(plugin);
+
+    await delay(100);
+    const startedAt = performance.now();
+    const res = await app.handle(new Request("http://localhost/error"));
+
+    const errorLog = logs.find((record) => record.level === "error");
+    assert.strictEqual(res.status, 500);
+    assert.ok(errorLog);
+    assertRecentResponseTime(errorLog.properties.responseTime, startedAt);
+  } finally {
+    await cleanup();
+  }
+});
+
 // ============================================
 // Plugin Scope Tests
 // ============================================
@@ -1055,6 +1097,58 @@ test("elysiaLogger(): local scope builds context for plugin hooks", async () => 
     assert.deepStrictEqual(logs[1].category, ["app"]);
     assert.strictEqual(logs[1].properties.requestId, "local-plugin-hook-1");
     assert.strictEqual(logs[2].properties.requestId, "local-plugin-hook-1");
+    assert.strictEqual(requestIdCount, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope builds context for plugin hooks with options", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const hookLogger = getLogger(["hook"]);
+    let requestIdCount = 0;
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: {
+        requestId: {
+          generate: () => `local-plugin-hook-options-${++requestIdCount}`,
+        },
+      },
+    })
+      .onBeforeHandle({ as: "local" }, () => {
+        hookLogger.info("Handled local plugin hook with options");
+      })
+      .get("/test", () => {
+        appLogger.info("Handled local plugin hook route with options");
+        return "Hello";
+      });
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(new Request("http://localhost/api/test"));
+
+    assert.strictEqual(
+      res.headers.get("x-request-id"),
+      "local-plugin-hook-options-1",
+    );
+    assert.strictEqual(logs.length, 3);
+    assert.deepStrictEqual(logs[0].category, ["hook"]);
+    assert.strictEqual(
+      logs[0].properties.requestId,
+      "local-plugin-hook-options-1",
+    );
+    assert.deepStrictEqual(logs[1].category, ["app"]);
+    assert.strictEqual(
+      logs[1].properties.requestId,
+      "local-plugin-hook-options-1",
+    );
+    assert.strictEqual(
+      logs[2].properties.requestId,
+      "local-plugin-hook-options-1",
+    );
     assert.strictEqual(requestIdCount, 1);
   } finally {
     await cleanup();

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -588,6 +588,37 @@ test("elysiaLogger(): context supports custom options", async () => {
   }
 });
 
+test("elysiaLogger(): context enrich can update response set", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: {
+          requestId: { generate: () => "enrich-set-123" },
+          enrich: (ctx) => {
+            ctx.set.status = 202;
+            ctx.set.headers["x-enriched"] = "yes";
+            return { enriched: true };
+          },
+        },
+      }))
+      .get("/test", () => "Accepted");
+
+    const res = await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(res.status, 202);
+    assert.strictEqual(res.headers.get("x-enriched"), "yes");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "enrich-set-123");
+    assert.strictEqual(logs[0].properties.enriched, true);
+    assert.strictEqual(logs[0].properties.status, 202);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): async context enrich counts in response time", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,
@@ -799,6 +830,28 @@ test("elysiaLogger(): local scope does not wrap parent route context", async () 
     assert.strictEqual(logs.length, 1);
     assert.deepStrictEqual(logs[0].category, ["app"]);
     assert.strictEqual(logs[0].properties.requestId, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope builds context for local routes", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-route-123" } },
+    })
+      .get("/test", () => "Hello");
+    const app = new Elysia().use(plugin);
+
+    const res = await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-route-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "local-route-123");
   } finally {
     await cleanup();
   }

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
 import _test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
-import { configure, type LogRecord, reset } from "@logtape/logtape";
+import { configure, getLogger, type LogRecord, reset } from "@logtape/logtape";
 import { Elysia } from "elysia";
 import { elysiaLogger } from "./mod.ts";
 
@@ -11,14 +12,14 @@ import { elysiaLogger } from "./mod.ts";
 const test = _test;
 
 // Test fixture: Collect log records, filtering out internal LogTape meta logs
-function createTestSink(): {
+function createTestSink(options: { includeMeta?: boolean } = {}): {
   sink: (record: LogRecord) => void;
   logs: LogRecord[];
 } {
   const logs: LogRecord[] = [];
   return {
     sink: (record: LogRecord) => {
-      if (record.category[0] !== "logtape") {
+      if (options.includeMeta || record.category[0] !== "logtape") {
         logs.push(record);
       }
     },
@@ -27,14 +28,22 @@ function createTestSink(): {
 }
 
 // Setup helper
-async function setupLogtape(): Promise<{
+async function setupLogtape(options: {
+  contextLocalStorage?: boolean;
+  includeMeta?: boolean;
+} = {}): Promise<{
   logs: LogRecord[];
   cleanup: () => Promise<void>;
 }> {
-  const { sink, logs } = createTestSink();
+  const { sink, logs } = createTestSink({
+    includeMeta: options.includeMeta,
+  });
   await configure({
     sinks: { test: sink },
     loggers: [{ category: [], sinks: ["test"] }],
+    contextLocalStorage: options.contextLocalStorage
+      ? new AsyncLocalStorage()
+      : undefined,
   });
   return { logs, cleanup: () => reset() };
 }
@@ -476,6 +485,172 @@ test("elysiaLogger(): non-logRequest mode logs after response", async () => {
 
     assert.strictEqual(logs.length, 1);
     assert.ok((logs[0].properties.responseTime as number) >= 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ============================================
+// Request Context Tests
+// ============================================
+
+test("elysiaLogger(): context true uses incoming request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Elysia()
+      .use(elysiaLogger({ context: true }))
+      .get("/test", () => {
+        appLogger.info("Handled request");
+        return "Hello";
+      });
+
+    const res = await app.handle(
+      new Request("http://localhost/test", {
+        headers: {
+          "x-request-id": "request-123",
+          "user-agent": "test-agent/1.0",
+        },
+      }),
+    );
+
+    assert.strictEqual(res.headers.get("x-request-id"), "request-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "request-123");
+    assert.strictEqual(logs[1].properties.requestId, "request-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): context true generates missing request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: { requestId: { generate: () => "generated-123" } },
+      }))
+      .get("/test", () => "Hello");
+
+    const res = await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "generated-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "generated-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): context keeps implicit context when skipped", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: { requestId: { generate: () => "skip-123" } },
+        skip: () => true,
+      }))
+      .get("/test", () => {
+        appLogger.info("Handled skipped request");
+        return "Hello";
+      });
+
+    await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "skip-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): context works with logRequest", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: { requestId: { generate: () => "immediate-123" } },
+        logRequest: true,
+      }))
+      .get("/test", () => "Hello");
+
+    const res = await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "immediate-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "immediate-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): missing context storage still logs request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({ includeMeta: true });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: { requestId: { generate: () => "no-storage-123" } },
+      }))
+      .get("/test", () => {
+        appLogger.info("Handled request");
+        return "Hello";
+      });
+
+    await app.handle(new Request("http://localhost/test"));
+
+    const appLog = logs.find((record) => record.category[0] === "app");
+    const requestLog = logs.find((record) => record.category[0] === "elysia");
+    const metaLog = logs.find((record) =>
+      record.category[0] === "logtape" && record.category[1] === "meta" &&
+      record.level === "warning"
+    );
+    assert.ok(appLog);
+    assert.ok(requestLog);
+    assert.ok(metaLog);
+    assert.strictEqual(appLog.properties.requestId, undefined);
+    assert.strictEqual(requestLog.properties.requestId, "no-storage-123");
+    assert.strictEqual(metaLog.level, "warning");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): context appears on error logs", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: { requestId: { generate: () => "error-123" } },
+      }))
+      .get("/error", () => {
+        appLogger.info("About to fail");
+        throw new Error("Test error");
+      });
+
+    const res = await app.handle(new Request("http://localhost/error"));
+
+    const appLog = logs.find((record) => record.category[0] === "app");
+    const errorLog = logs.find((record) => record.level === "error");
+    assert.strictEqual(res.headers.get("x-request-id"), "error-123");
+    assert.ok(appLog);
+    assert.ok(errorLog);
+    assert.strictEqual(appLog.properties.requestId, "error-123");
+    assert.strictEqual(errorLog.properties.requestId, "error-123");
   } finally {
     await cleanup();
   }

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -891,6 +891,46 @@ test("elysiaLogger(): local scope builds context for prefixed local routes", asy
   }
 });
 
+test("elysiaLogger(): local scope builds context for child plugin routes", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const child = new Elysia()
+      .get("/child", () => {
+        appLogger.info("Handled child plugin route");
+        return "Hello";
+      });
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-child-123" } },
+    }).use(child);
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(new Request("http://localhost/api/child"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-child-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-child-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-child-123");
+
+    logs.length = 0;
+    const otherApp = new Elysia().use(child);
+    const otherRes = await otherApp.handle(
+      new Request("http://localhost/child"),
+    );
+
+    assert.strictEqual(otherRes.headers.get("x-request-id"), null);
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): local scope does not wrap parent routes with the same suffix", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -547,6 +547,47 @@ test("elysiaLogger(): context true generates missing request ID", async () => {
   }
 });
 
+test("elysiaLogger(): context supports custom options", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: {
+          requestId: {
+            property: "correlationId",
+            headerNames: ["x-correlation-id", "x-request-id"],
+            responseHeader: "x-correlation-id",
+            normalize: (value) => value.trim().toUpperCase(),
+          },
+          include: ["requestId", "method", "path", "userAgent"],
+          enrich: (ctx) => ({ route: ctx.path }),
+        },
+      }))
+      .get("/test", () => "Hello");
+
+    const res = await app.handle(
+      new Request("http://localhost/test", {
+        headers: {
+          "x-correlation-id": " custom-123 ",
+          "user-agent": "test-agent/1.0",
+        },
+      }),
+    );
+
+    assert.strictEqual(res.headers.get("x-correlation-id"), "CUSTOM-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.correlationId, "CUSTOM-123");
+    assert.strictEqual(logs[0].properties.method, "GET");
+    assert.strictEqual(logs[0].properties.path, "/test");
+    assert.strictEqual(logs[0].properties.userAgent, "test-agent/1.0");
+    assert.strictEqual(logs[0].properties.route, "/test");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): context keeps implicit context when skipped", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -944,6 +944,39 @@ test("elysiaLogger(): local scope builds context for child plugin routes", async
   }
 });
 
+test("elysiaLogger(): local scope handles circular child plugin defaults", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const child = new Elysia()
+      .get("/child", () => {
+        appLogger.info("Handled circular child plugin route");
+        return "Hello";
+      });
+    Object.defineProperty(child, "default", {
+      configurable: true,
+      value: child,
+    });
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-circular-123" } },
+    }).use(child);
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(new Request("http://localhost/api/child"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-circular-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-circular-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-circular-123");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): local scope builds context for route hooks", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,
@@ -981,6 +1014,47 @@ test("elysiaLogger(): local scope builds context for route hooks", async () => {
     assert.deepStrictEqual(logs[1].category, ["app"]);
     assert.strictEqual(logs[1].properties.requestId, "local-hook-1");
     assert.strictEqual(logs[2].properties.requestId, "local-hook-1");
+    assert.strictEqual(requestIdCount, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope builds context for plugin hooks", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const hookLogger = getLogger(["hook"]);
+    let requestIdCount = 0;
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: {
+        requestId: { generate: () => `local-plugin-hook-${++requestIdCount}` },
+      },
+    })
+      .onBeforeHandle(() => {
+        hookLogger.info("Handled local plugin hook");
+      })
+      .get("/test", () => {
+        appLogger.info("Handled local plugin hook route");
+        return "Hello";
+      });
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(new Request("http://localhost/api/test"));
+
+    assert.strictEqual(
+      res.headers.get("x-request-id"),
+      "local-plugin-hook-1",
+    );
+    assert.strictEqual(logs.length, 3);
+    assert.deepStrictEqual(logs[0].category, ["hook"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-plugin-hook-1");
+    assert.deepStrictEqual(logs[1].category, ["app"]);
+    assert.strictEqual(logs[1].properties.requestId, "local-plugin-hook-1");
+    assert.strictEqual(logs[2].properties.requestId, "local-plugin-hook-1");
     assert.strictEqual(requestIdCount, 1);
   } finally {
     await cleanup();

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -863,6 +863,64 @@ test("elysiaLogger(): local scope builds context for local routes", async () => 
   }
 });
 
+test("elysiaLogger(): local scope builds context for prefixed local routes", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-prefixed-123" } },
+    })
+      .get("/test", () => {
+        appLogger.info("Handled prefixed local route");
+        return "Hello";
+      });
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(new Request("http://localhost/api/test"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-prefixed-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-prefixed-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-prefixed-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope does not wrap parent routes with the same suffix", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-suffix-123" } },
+    })
+      .get("/test", () => "Local");
+    const app = new Elysia()
+      .use(plugin)
+      .get("/api/test", () => {
+        appLogger.info("Handled parent suffix route");
+        return "Parent";
+      });
+
+    const res = await app.handle(new Request("http://localhost/api/test"));
+
+    assert.strictEqual(await res.text(), "Parent");
+    assert.strictEqual(res.headers.get("x-request-id"), null);
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): local scope wraps wildcard ALL routes", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -897,11 +897,20 @@ test("elysiaLogger(): local scope builds context for child plugin routes", async
   });
   try {
     const appLogger = getLogger(["app"]);
+    const childHookLogger = getLogger(["child-hook"]);
     const child = new Elysia()
-      .get("/child", () => {
-        appLogger.info("Handled child plugin route");
-        return "Hello";
-      });
+      .get(
+        "/child",
+        () => {
+          appLogger.info("Handled child plugin route");
+          return "Hello";
+        },
+        {
+          beforeHandle() {
+            childHookLogger.info("Handled child plugin route hook");
+          },
+        },
+      );
     const plugin = elysiaLogger({
       scope: "local",
       context: { requestId: { generate: () => "local-child-123" } },
@@ -911,10 +920,12 @@ test("elysiaLogger(): local scope builds context for child plugin routes", async
     const res = await app.handle(new Request("http://localhost/api/child"));
 
     assert.strictEqual(res.headers.get("x-request-id"), "local-child-123");
-    assert.strictEqual(logs.length, 2);
-    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs.length, 3);
+    assert.deepStrictEqual(logs[0].category, ["child-hook"]);
     assert.strictEqual(logs[0].properties.requestId, "local-child-123");
+    assert.deepStrictEqual(logs[1].category, ["app"]);
     assert.strictEqual(logs[1].properties.requestId, "local-child-123");
+    assert.strictEqual(logs[2].properties.requestId, "local-child-123");
 
     logs.length = 0;
     const otherApp = new Elysia().use(child);
@@ -923,9 +934,54 @@ test("elysiaLogger(): local scope builds context for child plugin routes", async
     );
 
     assert.strictEqual(otherRes.headers.get("x-request-id"), null);
-    assert.strictEqual(logs.length, 1);
-    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["child-hook"]);
     assert.strictEqual(logs[0].properties.requestId, undefined);
+    assert.deepStrictEqual(logs[1].category, ["app"]);
+    assert.strictEqual(logs[1].properties.requestId, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope builds context for route hooks", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const hookLogger = getLogger(["hook"]);
+    let requestIdCount = 0;
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: {
+        requestId: { generate: () => `local-hook-${++requestIdCount}` },
+      },
+    })
+      .get(
+        "/test",
+        () => {
+          appLogger.info("Handled local route with hook");
+          return "Hello";
+        },
+        {
+          beforeHandle() {
+            hookLogger.info("Handled local route hook");
+          },
+        },
+      );
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(new Request("http://localhost/api/test"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-hook-1");
+    assert.strictEqual(logs.length, 3);
+    assert.deepStrictEqual(logs[0].category, ["hook"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-hook-1");
+    assert.deepStrictEqual(logs[1].category, ["app"]);
+    assert.strictEqual(logs[1].properties.requestId, "local-hook-1");
+    assert.strictEqual(logs[2].properties.requestId, "local-hook-1");
+    assert.strictEqual(requestIdCount, 1);
   } finally {
     await cleanup();
   }

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -1061,6 +1061,56 @@ test("elysiaLogger(): local scope builds context for plugin hooks", async () => 
   }
 });
 
+test("elysiaLogger(): local scope builds context for plugin parse hooks", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const hookLogger = getLogger(["hook"]);
+    let requestIdCount = 0;
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: {
+        requestId: { generate: () => `local-parse-hook-${++requestIdCount}` },
+      },
+    })
+      .onParse(({ request }) => {
+        hookLogger.info("Parsed local plugin body");
+        return request.text();
+      })
+      .post("/test", ({ body }) => {
+        appLogger.info("Handled local plugin parse hook route", { body });
+        return String(body);
+      });
+    const app = new Elysia().group("/api", (app) => app.use(plugin));
+
+    const res = await app.handle(
+      new Request("http://localhost/api/test", {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "Hello",
+      }),
+    );
+
+    assert.strictEqual(await res.text(), "Hello");
+    assert.strictEqual(
+      res.headers.get("x-request-id"),
+      "local-parse-hook-1",
+    );
+    assert.strictEqual(logs.length, 3);
+    assert.deepStrictEqual(logs[0].category, ["hook"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-parse-hook-1");
+    assert.deepStrictEqual(logs[1].category, ["app"]);
+    assert.strictEqual(logs[1].properties.requestId, "local-parse-hook-1");
+    assert.strictEqual(logs[1].properties.body, "Hello");
+    assert.strictEqual(logs[2].properties.requestId, "local-parse-hook-1");
+    assert.strictEqual(requestIdCount, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): local scope does not wrap parent routes with the same suffix", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -588,6 +588,35 @@ test("elysiaLogger(): context supports custom options", async () => {
   }
 });
 
+test("elysiaLogger(): async context enrich counts in response time", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Elysia()
+      .use(elysiaLogger({
+        context: {
+          requestId: { generate: () => "async-enrich-123" },
+          enrich: async () => {
+            await delay(25);
+            return { enriched: true };
+          },
+        },
+      }))
+      .get("/test", () => "Hello");
+
+    await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "async-enrich-123");
+    assert.strictEqual(logs[0].properties.enriched, true);
+    assert.strictEqual(typeof logs[0].properties.responseTime, "number");
+    assert.ok((logs[0].properties.responseTime as number) >= 20);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("elysiaLogger(): context keeps implicit context when skipped", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -840,18 +840,84 @@ test("elysiaLogger(): local scope builds context for local routes", async () => 
     contextLocalStorage: true,
   });
   try {
+    const appLogger = getLogger(["app"]);
     const plugin = elysiaLogger({
       scope: "local",
       context: { requestId: { generate: () => "local-route-123" } },
     })
-      .get("/test", () => "Hello");
+      .get("/test", () => {
+        appLogger.info("Handled local route");
+        return "Hello";
+      });
     const app = new Elysia().use(plugin);
 
     const res = await app.handle(new Request("http://localhost/test"));
 
     assert.strictEqual(res.headers.get("x-request-id"), "local-route-123");
-    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
     assert.strictEqual(logs[0].properties.requestId, "local-route-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-route-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope wraps wildcard ALL routes", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-wildcard-123" } },
+    })
+      .all("/files/*", () => {
+        appLogger.info("Handled local wildcard route");
+        return "Hello";
+      });
+    const app = new Elysia().use(plugin);
+
+    const res = await app.handle(
+      new Request("http://localhost/files/a/b", { method: "POST" }),
+    );
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-wildcard-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-wildcard-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-wildcard-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("elysiaLogger(): local scope wraps optional ALL routes", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const plugin = elysiaLogger({
+      scope: "local",
+      context: { requestId: { generate: () => "local-optional-123" } },
+    })
+      .all("/users/:id?", () => {
+        appLogger.info("Handled local optional route");
+        return "Hello";
+      });
+    const app = new Elysia().use(plugin);
+
+    const res = await app.handle(
+      new Request("http://localhost/users", { method: "POST" }),
+    );
+
+    assert.strictEqual(res.headers.get("x-request-id"), "local-optional-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "local-optional-123");
+    assert.strictEqual(logs[1].properties.requestId, "local-optional-123");
   } finally {
     await cleanup();
   }

--- a/packages/elysia/src/mod.test.ts
+++ b/packages/elysia/src/mod.test.ts
@@ -777,6 +777,33 @@ test("elysiaLogger(): scope 'local' works", async () => {
   }
 });
 
+test("elysiaLogger(): local scope does not wrap parent route context", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Elysia()
+      .use(elysiaLogger({
+        scope: "local",
+        context: { requestId: { generate: () => "local-scope-123" } },
+      }))
+      .get("/test", () => {
+        appLogger.info("Handled parent route");
+        return "Hello";
+      });
+
+    const res = await app.handle(new Request("http://localhost/test"));
+
+    assert.strictEqual(res.headers.get("x-request-id"), null);
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
 // ============================================
 // Error Logging Tests
 // ============================================

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -616,6 +616,8 @@ type ElysiaUseRegistrar = (
   ...options: unknown[]
 ) => unknown;
 
+type ElysiaOnRegistrar = (...args: unknown[]) => unknown;
+
 type ElysiaRouteMethod =
   | "all"
   | "connect"
@@ -651,10 +653,22 @@ const elysiaRouteHookKeys = [
   "transform",
 ] as const;
 
+const elysiaPluginLifecycleHookTypes = [
+  "afterHandle",
+  "afterResponse",
+  "beforeHandle",
+  "derive",
+  "error",
+  "mapResponse",
+  "resolve",
+  "transform",
+] as const;
+
 type ElysiaRoutePlugin = Record<ElysiaRouteMethod, ElysiaRouteRegistrar> & {
   readonly router?: {
     readonly history?: Record<string, ElysiaRouteEntry> | ElysiaRouteEntry[];
   };
+  on: ElysiaOnRegistrar;
   route: (
     method: string,
     path: string,
@@ -669,8 +683,13 @@ interface ElysiaRouteEntry {
   hooks?: unknown;
 }
 
-function getElysiaRouteEntries(plugin: unknown): ElysiaRouteEntry[] {
+function getElysiaRouteEntries(
+  plugin: unknown,
+  visited = new Set<object>(),
+): ElysiaRouteEntry[] {
   if (plugin == null || typeof plugin !== "object") return [];
+  if (visited.has(plugin)) return [];
+  visited.add(plugin);
   const routePlugin = plugin as {
     readonly default?: unknown;
     readonly router?: {
@@ -683,14 +702,10 @@ function getElysiaRouteEntries(plugin: unknown): ElysiaRouteEntry[] {
     : history == null
     ? []
     : Object.values(history);
-  return entries.concat(getElysiaRouteEntries(routePlugin.default));
+  return entries.concat(getElysiaRouteEntries(routePlugin.default, visited));
 }
 
-/**
- * Wrap routes registered on a local plugin with implicit LogTape context.
- */
-function wrapLocalRouteHandlers(
-  plugin: ElysiaRoutePlugin,
+function createElysiaRequestWrappers(
   buildAndStoreRequestContext: (
     request: Request,
   ) => Promise<ElysiaRequestContextState | undefined>,
@@ -698,7 +713,7 @@ function wrapLocalRouteHandlers(
     set: ElysiaContext["set"],
     requestContext: ElysiaRequestContextState | undefined,
   ) => void,
-): void {
+) {
   const wrappedHandlers = new WeakSet<ElysiaRequestCallback>();
   const wrappedHandlerCache = new WeakMap<
     ElysiaRequestCallback,
@@ -767,6 +782,27 @@ function wrapLocalRouteHandlers(
     return changed ? wrappedHooks : hooks;
   };
 
+  return { wrapRequestCallback, wrapRouteHookValue, wrapRouteHooks };
+}
+
+/**
+ * Wrap routes registered on a local plugin with implicit LogTape context.
+ */
+function wrapLocalRouteHandlers(
+  plugin: ElysiaRoutePlugin,
+  buildAndStoreRequestContext: (
+    request: Request,
+  ) => Promise<ElysiaRequestContextState | undefined>,
+  applyRequestContextToSet: (
+    set: ElysiaContext["set"],
+    requestContext: ElysiaRequestContextState | undefined,
+  ) => void,
+): void {
+  const { wrapRequestCallback, wrapRouteHooks } = createElysiaRequestWrappers(
+    buildAndStoreRequestContext,
+    applyRequestContextToSet,
+  );
+
   const wrapRouteEntries = (routePlugin: unknown): (() => void)[] => {
     const restore: (() => void)[] = [];
     for (const route of getElysiaRouteEntries(routePlugin)) {
@@ -823,6 +859,44 @@ function wrapLocalRouteHandlers(
       for (const restoreRouteHandler of restore) restoreRouteHandler();
     }
   }) as ElysiaUseRegistrar;
+}
+
+/**
+ * Wrap local plugin lifecycle hooks registered by downstream code.
+ */
+function wrapLocalLifecycleHooks(
+  plugin: ElysiaRoutePlugin,
+  buildAndStoreRequestContext: (
+    request: Request,
+  ) => Promise<ElysiaRequestContextState | undefined>,
+  applyRequestContextToSet: (
+    set: ElysiaContext["set"],
+    requestContext: ElysiaRequestContextState | undefined,
+  ) => void,
+): void {
+  const { wrapRouteHookValue } = createElysiaRequestWrappers(
+    buildAndStoreRequestContext,
+    applyRequestContextToSet,
+  );
+
+  const isLifecycleHookType = (value: unknown): boolean =>
+    typeof value === "string" &&
+    (elysiaPluginLifecycleHookTypes as readonly string[]).includes(value);
+
+  const wrapLifecycleHookArgs = (args: readonly unknown[]): unknown[] => {
+    const wrappedArgs = [...args];
+    if (isLifecycleHookType(args[0]) && args.length > 1) {
+      wrappedArgs[1] = wrapRouteHookValue(args[1]);
+    } else if (isLifecycleHookType(args[1]) && args.length > 2) {
+      wrappedArgs[2] = wrapRouteHookValue(args[2]);
+    }
+    return wrappedArgs;
+  };
+
+  const on = plugin.on.bind(plugin);
+  plugin.on =
+    ((...args: unknown[]) =>
+      on(...wrapLifecycleHookArgs(args))) as ElysiaOnRegistrar;
 }
 
 /**
@@ -1060,6 +1134,14 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
       },
     );
   });
+
+  if (shouldWrapContext && scope === "local") {
+    wrapLocalLifecycleHooks(
+      plugin as unknown as ElysiaRoutePlugin,
+      buildAndStoreRequestContext,
+      applyRequestContextToSet,
+    );
+  }
 
   // Apply scope
   if (scope === "global") {

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -231,6 +231,7 @@ const defaultRequestIdHeader = "x-request-id";
  */
 interface ElysiaRequestContextState {
   readonly context: Record<string, unknown>;
+  readonly startTime?: number;
   readonly responseHeader?: {
     readonly name: string;
     readonly value: string;
@@ -679,11 +680,15 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     // to keep AsyncLocalStorage active for the whole route execution.
     plugin = plugin.wrap((handle) => {
       return async (request: Request) => {
+        const startTime = performance.now();
         const requestContext = await buildRequestContext(
           request,
           contextOptions,
         );
-        requestContextStates.set(request, requestContext);
+        requestContextStates.set(request, {
+          ...requestContext,
+          startTime,
+        });
         return await withContext(
           requestContext.context,
           () => handle(request),
@@ -695,8 +700,9 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   plugin = plugin
     .state("startTime", 0)
     .onRequest(({ request, set, store }) => {
-      (store as LoggerStore).startTime = performance.now();
       const requestContext = requestContextStates.get(request);
+      (store as LoggerStore).startTime = requestContext?.startTime ??
+        performance.now();
       if (requestContext?.responseHeader != null) {
         set.headers[requestContext.responseHeader.name] =
           requestContext.responseHeader.value;

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -618,16 +618,24 @@ function routePathMatches(routePath: string, requestPath: string): boolean {
   if (routePath === requestPath) return true;
   const routeSegments = routePath.split("/");
   const requestSegments = requestPath.split("/");
-  for (let index = 0; index < routeSegments.length; index++) {
-    const segment = routeSegments[index];
-    if (segment === "*") return true;
-    if (index >= requestSegments.length) return false;
-    if (segment === requestSegments[index] || segment.startsWith(":")) {
+  const segmentCount = Math.max(routeSegments.length, requestSegments.length);
+  for (let index = 0; index < segmentCount; index++) {
+    const routeSegment = routeSegments[index];
+    const requestSegment = requestSegments[index];
+    if (routeSegment == null) return false;
+    if (routeSegment === "*") return true;
+    if (requestSegment == null) {
+      if (routeSegment.startsWith(":") && routeSegment.endsWith("?")) {
+        continue;
+      }
+      return false;
+    }
+    if (routeSegment === requestSegment || routeSegment.startsWith(":")) {
       continue;
     }
     return false;
   }
-  return routeSegments.length === requestSegments.length;
+  return true;
 }
 
 /**

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -611,6 +611,11 @@ type ElysiaRouteRegistrar = (
   hook?: unknown,
 ) => unknown;
 
+type ElysiaUseRegistrar = (
+  plugin: unknown,
+  ...options: unknown[]
+) => unknown;
+
 type ElysiaRouteMethod =
   | "all"
   | "connect"
@@ -635,13 +640,38 @@ const elysiaRouteMethods: readonly ElysiaRouteMethod[] = [
 ];
 
 type ElysiaRoutePlugin = Record<ElysiaRouteMethod, ElysiaRouteRegistrar> & {
+  readonly router?: {
+    readonly history?: Record<string, ElysiaRouteEntry> | ElysiaRouteEntry[];
+  };
   route: (
     method: string,
     path: string,
     handler: unknown,
     hook?: unknown,
   ) => unknown;
+  use: ElysiaUseRegistrar;
 };
+
+interface ElysiaRouteEntry {
+  handler?: unknown;
+}
+
+function getElysiaRouteEntries(plugin: unknown): ElysiaRouteEntry[] {
+  if (plugin == null || typeof plugin !== "object") return [];
+  const routePlugin = plugin as {
+    readonly default?: unknown;
+    readonly router?: {
+      readonly history?: Record<string, ElysiaRouteEntry> | ElysiaRouteEntry[];
+    };
+  };
+  const history = routePlugin.router?.history;
+  const entries = Array.isArray(history)
+    ? history
+    : history == null
+    ? []
+    : Object.values(history);
+  return entries.concat(getElysiaRouteEntries(routePlugin.default));
+}
 
 /**
  * Wrap routes registered on a local plugin with implicit LogTape context.
@@ -656,10 +686,18 @@ function wrapLocalRouteHandlers(
     requestContext: ElysiaRequestContextState | undefined,
   ) => void,
 ): void {
+  const wrappedHandlers = new WeakSet<ElysiaRouteHandler>();
+  const wrappedHandlerCache = new WeakMap<
+    ElysiaRouteHandler,
+    ElysiaRouteHandler
+  >();
   const wrapHandler = (handler: unknown): unknown => {
     if (typeof handler !== "function") return handler;
     const routeHandler = handler as ElysiaRouteHandler;
-    return async function (
+    if (wrappedHandlers.has(routeHandler)) return handler;
+    const cached = wrappedHandlerCache.get(routeHandler);
+    if (cached != null) return cached;
+    const wrapped = async function (
       this: unknown,
       ctx: ElysiaRouteContext,
     ): Promise<unknown> {
@@ -672,6 +710,23 @@ function wrapLocalRouteHandlers(
         () => routeHandler.call(this, ctx),
       );
     };
+    wrappedHandlers.add(wrapped);
+    wrappedHandlerCache.set(routeHandler, wrapped);
+    return wrapped;
+  };
+
+  const wrapRouteEntries = (routePlugin: unknown): (() => void)[] => {
+    const restore: (() => void)[] = [];
+    for (const route of getElysiaRouteEntries(routePlugin)) {
+      const handler = route.handler;
+      const wrappedHandler = wrapHandler(handler);
+      if (wrappedHandler === handler) continue;
+      route.handler = wrappedHandler;
+      restore.push(() => {
+        route.handler = handler;
+      });
+    }
+    return restore;
   };
 
   for (const method of elysiaRouteMethods) {
@@ -689,6 +744,16 @@ function wrapLocalRouteHandlers(
   ) => route(method, path, wrapHandler(handler), hook)) as ElysiaRoutePlugin[
     "route"
   ];
+
+  const use = plugin.use.bind(plugin);
+  plugin.use = ((childPlugin: unknown, ...options: unknown[]) => {
+    const restore = wrapRouteEntries(childPlugin);
+    try {
+      return use(childPlugin, ...options);
+    } finally {
+      for (const restoreRouteHandler of restore) restoreRouteHandler();
+    }
+  }) as ElysiaUseRegistrar;
 }
 
 /**

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -1007,6 +1007,15 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     }
   };
 
+  const applyRequestContextToRequest = (
+    store: LoggerStore,
+    set: ElysiaContext["set"],
+    requestContext: ElysiaRequestContextState | undefined,
+  ): void => {
+    store.startTime = requestContext?.startTime ?? performance.now();
+    applyRequestContextToSet(set, requestContext);
+  };
+
   // deno-lint-ignore no-explicit-any
   let plugin: Elysia<any, any, any, any, any, any, any> = new Elysia({
     name: "@logtape/elysia",
@@ -1035,14 +1044,18 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
 
   plugin = plugin
     .state("startTime", 0)
-    .onRequest(async ({ request, set, store }) => {
-      let requestContext = requestContextStates.get(request);
+    .onRequest(({ request, set, store }) => {
+      const requestContext = requestContextStates.get(request);
       if (requestContext == null && shouldWrapAllRoutes) {
-        requestContext = await buildAndStoreRequestContext(request);
+        return buildAndStoreRequestContext(request).then((resolvedContext) => {
+          applyRequestContextToRequest(
+            store as LoggerStore,
+            set,
+            resolvedContext,
+          );
+        });
       }
-      (store as LoggerStore).startTime = requestContext?.startTime ??
-        performance.now();
-      applyRequestContextToSet(set, requestContext);
+      applyRequestContextToRequest(store as LoggerStore, set, requestContext);
     });
 
   if (scope === "local" && (contextOptions != null || logRequest)) {

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -596,77 +596,99 @@ interface LoggerStore {
   startTime: number;
 }
 
+type ElysiaRouteContext = ElysiaContext & {
+  readonly store: LoggerStore;
+};
+
+type ElysiaRouteHandler = (
+  this: unknown,
+  context: ElysiaRouteContext,
+) => unknown;
+
+type ElysiaRouteRegistrar = (
+  path: string,
+  handler: unknown,
+  hook?: unknown,
+) => unknown;
+
+type ElysiaRouteMethod =
+  | "all"
+  | "connect"
+  | "delete"
+  | "get"
+  | "head"
+  | "options"
+  | "patch"
+  | "post"
+  | "put";
+
+const elysiaRouteMethods: readonly ElysiaRouteMethod[] = [
+  "all",
+  "connect",
+  "delete",
+  "get",
+  "head",
+  "options",
+  "patch",
+  "post",
+  "put",
+];
+
+type ElysiaRoutePlugin = Record<ElysiaRouteMethod, ElysiaRouteRegistrar> & {
+  route: (
+    method: string,
+    path: string,
+    handler: unknown,
+    hook?: unknown,
+  ) => unknown;
+};
+
 /**
- * Minimal shape of Elysia's internal route matcher.
+ * Wrap routes registered on a local plugin with implicit LogTape context.
  */
-interface ElysiaRouteMatcher {
-  readonly router?: {
-    readonly http?: {
-      find(method: string, path: string): unknown;
+function wrapLocalRouteHandlers(
+  plugin: ElysiaRoutePlugin,
+  buildAndStoreRequestContext: (
+    request: Request,
+  ) => Promise<ElysiaRequestContextState | undefined>,
+  applyRequestContextToSet: (
+    set: ElysiaContext["set"],
+    requestContext: ElysiaRequestContextState | undefined,
+  ) => void,
+): void {
+  const wrapHandler = (handler: unknown): unknown => {
+    if (typeof handler !== "function") return handler;
+    const routeHandler = handler as ElysiaRouteHandler;
+    return async function (
+      this: unknown,
+      ctx: ElysiaRouteContext,
+    ): Promise<unknown> {
+      const requestContext = await buildAndStoreRequestContext(ctx.request);
+      ctx.store.startTime = requestContext?.startTime ??
+        performance.now();
+      applyRequestContextToSet(ctx.set, requestContext);
+      return await withContext(
+        requestContext?.context ?? {},
+        () => routeHandler.call(this, ctx),
+      );
     };
   };
-  readonly routes?: readonly {
-    readonly method: string;
-    readonly path: string;
-  }[];
-}
 
-/**
- * Check whether an Elysia route path matches a request path.
- */
-function routePathMatches(routePath: string, requestPath: string): boolean {
-  if (routePath === requestPath) return true;
-  const routeSegments = routePath.split("/");
-  const requestSegments = requestPath.split("/");
-  const segmentCount = Math.max(routeSegments.length, requestSegments.length);
-  for (let index = 0; index < segmentCount; index++) {
-    const routeSegment = routeSegments[index];
-    const requestSegment = requestSegments[index];
-    if (routeSegment == null) return false;
-    if (routeSegment === "*") return true;
-    if (requestSegment == null) {
-      if (routeSegment.startsWith(":") && routeSegment.endsWith("?")) {
-        continue;
-      }
-      return false;
-    }
-    if (routeSegment === requestSegment || routeSegment.startsWith(":")) {
-      continue;
-    }
-    return false;
+  for (const method of elysiaRouteMethods) {
+    const register = plugin[method].bind(plugin);
+    plugin[method] = ((path: string, handler: unknown, hook?: unknown) =>
+      register(path, wrapHandler(handler), hook)) as ElysiaRouteRegistrar;
   }
-  return true;
-}
 
-/**
- * Check whether an Elysia route method can handle a request method.
- */
-function routeMethodMatches(
-  routeMethod: string,
-  requestMethod: string,
-): boolean {
-  return routeMethod === requestMethod || routeMethod === "ALL" ||
-    (routeMethod === "GET" && requestMethod === "HEAD");
-}
-
-/**
- * Check whether a request belongs to routes defined on the local plugin.
- */
-function isLocalPluginRoute(
-  plugin: ElysiaRouteMatcher,
-  request: Request,
-): boolean {
-  const path = getPath(request);
-  const httpRouter = plugin.router?.http;
-  if (httpRouter?.find(request.method, path) != null) return true;
-  if (httpRouter?.find("ALL", path) != null) return true;
-  if (request.method === "HEAD" && httpRouter?.find("GET", path) != null) {
-    return true;
-  }
-  return plugin.routes?.some((route) =>
-    routeMethodMatches(route.method, request.method) &&
-    routePathMatches(route.path, path)
-  ) ?? false;
+  const route = plugin.route.bind(plugin);
+  plugin.route = ((
+    method: string,
+    path: string,
+    handler: unknown,
+    hook?: unknown,
+  ) => route(method, path, wrapHandler(handler), hook)) as ElysiaRoutePlugin[
+    "route"
+  ];
 }
 
 /**
@@ -783,14 +805,17 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     seed: options,
   });
 
-  if (shouldWrapContext) {
+  if (shouldWrapContext && scope === "local") {
+    wrapLocalRouteHandlers(
+      plugin as unknown as ElysiaRoutePlugin,
+      buildAndStoreRequestContext,
+      applyRequestContextToSet,
+    );
+  } else if (shouldWrapContext) {
     // Elysia lifecycle hooks cannot wrap downstream handlers, so use wrap()
     // to keep AsyncLocalStorage active for the whole route execution.
     plugin = plugin.wrap((handle) => {
       return async (request: Request) => {
-        if (scope === "local" && !isLocalPluginRoute(plugin, request)) {
-          return await handle(request);
-        }
         const requestContext = await buildAndStoreRequestContext(request);
         return await withContext(
           requestContext?.context ?? {},

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -660,6 +660,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     Request,
     ElysiaRequestContextState
   >();
+  const shouldWrapContext = contextOptions != null && scope !== "local";
 
   // Resolve format function
   const formatFn: FormatFunction = typeof formatOption === "string"
@@ -675,7 +676,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     seed: options,
   });
 
-  if (contextOptions != null) {
+  if (shouldWrapContext) {
     // Elysia lifecycle hooks cannot wrap downstream handlers, so use wrap()
     // to keep AsyncLocalStorage active for the whole route execution.
     plugin = plugin.wrap((handle) => {
@@ -699,8 +700,16 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
 
   plugin = plugin
     .state("startTime", 0)
-    .onRequest(({ request, set, store }) => {
-      const requestContext = requestContextStates.get(request);
+    .onRequest(async ({ request, set, store }) => {
+      let requestContext = requestContextStates.get(request);
+      if (requestContext == null && shouldWrapContext) {
+        const startTime = performance.now();
+        requestContext = {
+          ...await buildRequestContext(request, contextOptions),
+          startTime,
+        };
+        requestContextStates.set(request, requestContext);
+      }
       (store as LoggerStore).startTime = requestContext?.startTime ??
         performance.now();
       if (requestContext?.responseHeader != null) {

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -597,6 +597,71 @@ interface LoggerStore {
 }
 
 /**
+ * Minimal shape of Elysia's internal route matcher.
+ */
+interface ElysiaRouteMatcher {
+  readonly router?: {
+    readonly http?: {
+      find(method: string, path: string): unknown;
+    };
+  };
+  readonly routes?: readonly {
+    readonly method: string;
+    readonly path: string;
+  }[];
+}
+
+/**
+ * Check whether an Elysia route path matches a request path.
+ */
+function routePathMatches(routePath: string, requestPath: string): boolean {
+  if (routePath === requestPath) return true;
+  const routeSegments = routePath.split("/");
+  const requestSegments = requestPath.split("/");
+  for (let index = 0; index < routeSegments.length; index++) {
+    const segment = routeSegments[index];
+    if (segment === "*") return true;
+    if (index >= requestSegments.length) return false;
+    if (segment === requestSegments[index] || segment.startsWith(":")) {
+      continue;
+    }
+    return false;
+  }
+  return routeSegments.length === requestSegments.length;
+}
+
+/**
+ * Check whether an Elysia route method can handle a request method.
+ */
+function routeMethodMatches(
+  routeMethod: string,
+  requestMethod: string,
+): boolean {
+  return routeMethod === requestMethod || routeMethod === "ALL" ||
+    (routeMethod === "GET" && requestMethod === "HEAD");
+}
+
+/**
+ * Check whether a request belongs to routes defined on the local plugin.
+ */
+function isLocalPluginRoute(
+  plugin: ElysiaRouteMatcher,
+  request: Request,
+): boolean {
+  const path = getPath(request);
+  const httpRouter = plugin.router?.http;
+  if (httpRouter?.find(request.method, path) != null) return true;
+  if (httpRouter?.find("ALL", path) != null) return true;
+  if (request.method === "HEAD" && httpRouter?.find("GET", path) != null) {
+    return true;
+  }
+  return plugin.routes?.some((route) =>
+    routeMethodMatches(route.method, request.method) &&
+    routePathMatches(route.path, path)
+  ) ?? false;
+}
+
+/**
  * Creates Elysia plugin for HTTP request logging using LogTape.
  *
  * This plugin provides Morgan-compatible request logging with LogTape
@@ -662,7 +727,8 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     Request,
     ElysiaRequestContextState
   >();
-  const shouldWrapContext = contextOptions != null && scope !== "local";
+  const shouldWrapContext = contextOptions != null;
+  const shouldWrapAllRoutes = contextOptions != null && scope !== "local";
 
   // Resolve format function
   const formatFn: FormatFunction = typeof formatOption === "string"
@@ -714,6 +780,9 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     // to keep AsyncLocalStorage active for the whole route execution.
     plugin = plugin.wrap((handle) => {
       return async (request: Request) => {
+        if (scope === "local" && !isLocalPluginRoute(plugin, request)) {
+          return await handle(request);
+        }
         const requestContext = await buildAndStoreRequestContext(request);
         return await withContext(
           requestContext?.context ?? {},
@@ -727,7 +796,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     .state("startTime", 0)
     .onRequest(async ({ request, set, store }) => {
       let requestContext = requestContextStates.get(request);
-      if (requestContext == null && shouldWrapContext) {
+      if (requestContext == null && shouldWrapAllRoutes) {
         requestContext = await buildAndStoreRequestContext(request);
       }
       (store as LoggerStore).startTime = requestContext?.startTime ??

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -236,6 +236,7 @@ interface ElysiaRequestContextState {
     readonly name: string;
     readonly value: string;
   };
+  readonly set?: ElysiaContext["set"];
 }
 
 /**
@@ -282,7 +283,7 @@ function defaultNormalizeRequestId(value: string): string | null {
  * Resolve a request path from a request URL.
  */
 function getPath(request: Request): string {
-  return new URL(request.url).pathname;
+  return new URL(request.url, "http://localhost").pathname;
 }
 
 /**
@@ -405,8 +406,9 @@ async function buildRequestContext(
   const include = options.include ??
     (resolvedRequestId == null ? [] : ["requestId"] as const);
   const context = buildIncludedContext(request, resolvedRequestId, include);
+  let set: ElysiaContext["set"] | undefined;
   if (options.enrich != null) {
-    const set = { status: 200, headers: {} };
+    set = { status: 200, headers: {} };
     Object.assign(
       context,
       await options.enrich({
@@ -422,7 +424,7 @@ async function buildRequestContext(
       name: resolvedRequestId.responseHeader,
       value: resolvedRequestId.value,
     };
-  return { context, responseHeader };
+  return { context, responseHeader, set };
 }
 
 /**
@@ -670,6 +672,37 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   const logMethod = logger[level].bind(logger);
   const errorLogMethod = logger.error.bind(logger);
 
+  const buildAndStoreRequestContext = async (
+    request: Request,
+  ): Promise<ElysiaRequestContextState | undefined> => {
+    if (contextOptions == null) return undefined;
+    const existingContext = requestContextStates.get(request);
+    if (existingContext != null) return existingContext;
+    const startTime = performance.now();
+    const requestContext = {
+      ...await buildRequestContext(request, contextOptions),
+      startTime,
+    };
+    requestContextStates.set(request, requestContext);
+    return requestContext;
+  };
+
+  const applyRequestContextToSet = (
+    set: ElysiaContext["set"],
+    requestContext: ElysiaRequestContextState | undefined,
+  ): void => {
+    if (requestContext?.responseHeader != null) {
+      set.headers[requestContext.responseHeader.name] =
+        requestContext.responseHeader.value;
+    }
+    if (requestContext?.set != null) {
+      if (requestContext.set.status !== 200) {
+        set.status = requestContext.set.status;
+      }
+      Object.assign(set.headers, requestContext.set.headers);
+    }
+  };
+
   // deno-lint-ignore no-explicit-any
   let plugin: Elysia<any, any, any, any, any, any, any> = new Elysia({
     name: "@logtape/elysia",
@@ -681,17 +714,9 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     // to keep AsyncLocalStorage active for the whole route execution.
     plugin = plugin.wrap((handle) => {
       return async (request: Request) => {
-        const startTime = performance.now();
-        const requestContext = await buildRequestContext(
-          request,
-          contextOptions,
-        );
-        requestContextStates.set(request, {
-          ...requestContext,
-          startTime,
-        });
+        const requestContext = await buildAndStoreRequestContext(request);
         return await withContext(
-          requestContext.context,
+          requestContext?.context ?? {},
           () => handle(request),
         );
       };
@@ -703,38 +728,54 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     .onRequest(async ({ request, set, store }) => {
       let requestContext = requestContextStates.get(request);
       if (requestContext == null && shouldWrapContext) {
-        const startTime = performance.now();
-        requestContext = {
-          ...await buildRequestContext(request, contextOptions),
-          startTime,
-        };
-        requestContextStates.set(request, requestContext);
+        requestContext = await buildAndStoreRequestContext(request);
       }
       (store as LoggerStore).startTime = requestContext?.startTime ??
         performance.now();
-      if (requestContext?.responseHeader != null) {
-        set.headers[requestContext.responseHeader.name] =
-          requestContext.responseHeader.value;
-      }
+      applyRequestContextToSet(set, requestContext);
     });
 
-  if (logRequest) {
-    // Log immediately when request arrives
-    plugin = plugin.onRequest((ctx) => {
-      if (!skip(ctx as unknown as ElysiaContext)) {
-        const requestContext = requestContextStates.get(ctx.request)?.context ??
-          {};
+  if (scope === "local" && (contextOptions != null || logRequest)) {
+    plugin = plugin.onBeforeHandle(async (ctx) => {
+      const requestContext = await buildAndStoreRequestContext(ctx.request);
+      (ctx.store as LoggerStore).startTime = requestContext?.startTime ??
+        performance.now();
+      applyRequestContextToSet(ctx.set, requestContext);
+      if (logRequest && !skip(ctx as unknown as ElysiaContext)) {
+        const context = requestContext?.context ?? {};
         const result = withRequestLogContext(
           formatFn(ctx as unknown as ElysiaContext, 0),
-          requestContext,
+          context,
         );
         if (typeof result === "string") {
-          logMethod(result, requestContext);
+          logMethod(result, context);
         } else {
           logMethod("{method} {url}", result);
         }
       }
     });
+  }
+
+  if (logRequest) {
+    // Log immediately when request arrives
+    if (scope !== "local") {
+      plugin = plugin.onRequest((ctx) => {
+        if (!skip(ctx as unknown as ElysiaContext)) {
+          const requestContext =
+            requestContextStates.get(ctx.request)?.context ??
+              {};
+          const result = withRequestLogContext(
+            formatFn(ctx as unknown as ElysiaContext, 0),
+            requestContext,
+          );
+          if (typeof result === "string") {
+            logMethod(result, requestContext);
+          } else {
+            logMethod("{method} {url}", result);
+          }
+        }
+      });
+    }
   } else {
     // Log after handler completes
     plugin = plugin.onAfterHandle((ctx) => {

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -660,6 +660,7 @@ const elysiaPluginLifecycleHookTypes = [
   "derive",
   "error",
   "mapResponse",
+  "parse",
   "resolve",
   "transform",
 ] as const;

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getLogger, type LogLevel } from "@logtape/logtape";
+import { getLogger, type LogLevel, withContext } from "@logtape/logtape";
 
 export type { LogLevel } from "@logtape/logtape";
 
@@ -64,6 +64,81 @@ export interface RequestLogProperties {
   userAgent: string | undefined;
   /** Referrer header value */
   referrer: string | undefined;
+}
+
+/**
+ * Request fields that can be added to the implicit request context.
+ * @since 2.2.0
+ */
+export type RequestContextField =
+  | "requestId"
+  | "method"
+  | "url"
+  | "path"
+  | "userAgent"
+  | "remoteAddr"
+  | "referrer";
+
+/**
+ * Options for extracting, generating, and propagating a request ID.
+ * @since 2.2.0
+ */
+export interface RequestIdOptions {
+  /**
+   * The property name used in implicit context and request log records.
+   * @default "requestId"
+   */
+  readonly property?: string;
+
+  /**
+   * Incoming request headers to inspect in order.
+   * @default ["x-request-id"]
+   */
+  readonly headerNames?: readonly string[];
+
+  /**
+   * Response header that receives the resolved request ID.
+   * Set to `false` to disable response header propagation.
+   * @default "x-request-id"
+   */
+  readonly responseHeader?: string | false;
+
+  /**
+   * Generates a request ID when no incoming header is present.
+   * @default crypto.randomUUID()
+   */
+  readonly generate?: () => string;
+
+  /**
+   * Normalizes an incoming request ID.  Return `null` to reject the value and
+   * keep looking for another header or generate a new ID.
+   */
+  readonly normalize?: (value: string) => string | null;
+}
+
+/**
+ * Options for request-scoped implicit context.
+ * @since 2.2.0
+ */
+export interface RequestContextOptions {
+  /**
+   * Enables request ID extraction, generation, and response propagation.
+   * @default true
+   */
+  readonly requestId?: boolean | RequestIdOptions;
+
+  /**
+   * Fields to add to the implicit context.
+   * @default ["requestId"]
+   */
+  readonly include?: readonly RequestContextField[];
+
+  /**
+   * Adds application-specific fields to the implicit request context.
+   */
+  readonly enrich?: (
+    ctx: ElysiaContext,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
 }
 
 /**
@@ -134,6 +209,115 @@ export interface ElysiaLogTapeOptions {
    * @default "global"
    */
   readonly scope?: PluginScope;
+
+  /**
+   * Enables request-scoped implicit context and request ID correlation.
+   *
+   * When set to `true`, the plugin reads the `x-request-id` header, generates
+   * one when it is absent, writes it to the `x-request-id` response header,
+   * and adds `requestId` to all LogTape records emitted while handling the
+   * request.
+   *
+   * @default false
+   * @since 2.2.0
+   */
+  readonly context?: boolean | RequestContextOptions;
+}
+
+const defaultRequestIdHeader = "x-request-id";
+
+/**
+ * Per-request context state stored outside Elysia's shared store.
+ */
+interface ElysiaRequestContextState {
+  readonly context: Record<string, unknown>;
+  readonly responseHeader?: {
+    readonly name: string;
+    readonly value: string;
+  };
+}
+
+/**
+ * Normalize request context options.
+ */
+function normalizeRequestContextOptions(
+  options: boolean | RequestContextOptions | undefined,
+): RequestContextOptions | undefined {
+  if (options === true) return {};
+  if (options === false || options == null) return undefined;
+  return options;
+}
+
+/**
+ * Normalize request ID options.
+ */
+function normalizeRequestIdOptions(
+  options: boolean | RequestIdOptions | undefined,
+): RequestIdOptions | undefined {
+  if (options === false) return undefined;
+  if (options === true || options == null) return {};
+  return options;
+}
+
+/**
+ * Generate a request ID with Web Crypto when possible.
+ */
+function generateRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Normalize an incoming request ID.
+ */
+function defaultNormalizeRequestId(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Resolve a request path from a request URL.
+ */
+function getPath(request: Request): string {
+  return new URL(request.url).pathname;
+}
+
+/**
+ * Resolve the request ID for a request.
+ */
+function resolveRequestId(
+  request: Request,
+  options: RequestIdOptions,
+): {
+  readonly property: string;
+  readonly value: string;
+  readonly responseHeader?: string;
+} {
+  const property = options.property ?? "requestId";
+  const normalize = options.normalize ?? defaultNormalizeRequestId;
+  const headerNames = options.headerNames ?? [defaultRequestIdHeader];
+  for (const headerName of headerNames) {
+    const headerValue = request.headers.get(headerName);
+    if (headerValue == null) continue;
+    const normalized = normalize(headerValue);
+    if (normalized != null) {
+      const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+      return {
+        property,
+        value: normalized,
+        responseHeader: responseHeader === false ? undefined : responseHeader,
+      };
+    }
+  }
+  const generated = (options.generate ?? generateRequestId)();
+  const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+  return {
+    property,
+    value: generated,
+    responseHeader: responseHeader === false ? undefined : responseHeader,
+  };
 }
 
 /**
@@ -166,6 +350,81 @@ function getRemoteAddr(request: Request): string | undefined {
 }
 
 /**
+ * Build request context fields from a request.
+ */
+function buildIncludedContext(
+  request: Request,
+  resolvedRequestId:
+    | { readonly property: string; readonly value: string }
+    | undefined,
+  include: readonly RequestContextField[],
+): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const field of include) {
+    switch (field) {
+      case "requestId":
+        if (resolvedRequestId != null) {
+          context[resolvedRequestId.property] = resolvedRequestId.value;
+        }
+        break;
+      case "method":
+        context.method = request.method;
+        break;
+      case "url":
+        context.url = request.url;
+        break;
+      case "path":
+        context.path = getPath(request);
+        break;
+      case "userAgent":
+        context.userAgent = getUserAgent(request);
+        break;
+      case "remoteAddr":
+        context.remoteAddr = getRemoteAddr(request);
+        break;
+      case "referrer":
+        context.referrer = getReferrer(request);
+        break;
+    }
+  }
+  return context;
+}
+
+/**
+ * Build the implicit context for a request.
+ */
+async function buildRequestContext(
+  request: Request,
+  options: RequestContextOptions,
+): Promise<ElysiaRequestContextState> {
+  const requestIdOptions = normalizeRequestIdOptions(options.requestId);
+  const resolvedRequestId = requestIdOptions == null
+    ? undefined
+    : resolveRequestId(request, requestIdOptions);
+  const include = options.include ??
+    (resolvedRequestId == null ? [] : ["requestId"] as const);
+  const context = buildIncludedContext(request, resolvedRequestId, include);
+  if (options.enrich != null) {
+    const set = { status: 200, headers: {} };
+    Object.assign(
+      context,
+      await options.enrich({
+        request,
+        path: getPath(request),
+        set,
+      }),
+    );
+  }
+  const responseHeader = resolvedRequestId?.responseHeader == null
+    ? undefined
+    : {
+      name: resolvedRequestId.responseHeader,
+      value: resolvedRequestId.value,
+    };
+  return { context, responseHeader };
+}
+
+/**
  * Get content length from response headers.
  */
 function getContentLength(
@@ -194,6 +453,17 @@ function buildProperties(
     userAgent: getUserAgent(ctx.request),
     referrer: getReferrer(ctx.request),
   };
+}
+
+/**
+ * Add request context fields to a request log result.
+ */
+function withRequestLogContext(
+  result: string | Record<string, unknown>,
+  context: Record<string, unknown>,
+): string | Record<string, unknown> {
+  if (typeof result === "string") return result;
+  return { ...result, ...context };
 }
 
 /**
@@ -384,6 +654,11 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   const skip = options.skip ?? (() => false);
   const logRequest = options.logRequest ?? false;
   const scope = options.scope ?? "global";
+  const contextOptions = normalizeRequestContextOptions(options.context);
+  const requestContextStates = new WeakMap<
+    Request,
+    ElysiaRequestContextState
+  >();
 
   // Resolve format function
   const formatFn: FormatFunction = typeof formatOption === "string"
@@ -393,22 +668,53 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   const logMethod = logger[level].bind(logger);
   const errorLogMethod = logger.error.bind(logger);
 
-  let plugin = new Elysia({
+  // deno-lint-ignore no-explicit-any
+  let plugin: Elysia<any, any, any, any, any, any, any> = new Elysia({
     name: "@logtape/elysia",
     seed: options,
-  })
+  });
+
+  if (contextOptions != null) {
+    // Elysia lifecycle hooks cannot wrap downstream handlers, so use wrap()
+    // to keep AsyncLocalStorage active for the whole route execution.
+    plugin = plugin.wrap((handle) => {
+      return async (request: Request) => {
+        const requestContext = await buildRequestContext(
+          request,
+          contextOptions,
+        );
+        requestContextStates.set(request, requestContext);
+        return await withContext(
+          requestContext.context,
+          () => handle(request),
+        );
+      };
+    });
+  }
+
+  plugin = plugin
     .state("startTime", 0)
-    .onRequest(({ store }) => {
+    .onRequest(({ request, set, store }) => {
       (store as LoggerStore).startTime = performance.now();
+      const requestContext = requestContextStates.get(request);
+      if (requestContext?.responseHeader != null) {
+        set.headers[requestContext.responseHeader.name] =
+          requestContext.responseHeader.value;
+      }
     });
 
   if (logRequest) {
     // Log immediately when request arrives
     plugin = plugin.onRequest((ctx) => {
       if (!skip(ctx as unknown as ElysiaContext)) {
-        const result = formatFn(ctx as unknown as ElysiaContext, 0);
+        const requestContext = requestContextStates.get(ctx.request)?.context ??
+          {};
+        const result = withRequestLogContext(
+          formatFn(ctx as unknown as ElysiaContext, 0),
+          requestContext,
+        );
         if (typeof result === "string") {
-          logMethod(result);
+          logMethod(result, requestContext);
         } else {
           logMethod("{method} {url}", result);
         }
@@ -421,10 +727,15 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
 
       const store = ctx.store as LoggerStore;
       const responseTime = performance.now() - store.startTime;
-      const result = formatFn(ctx as unknown as ElysiaContext, responseTime);
+      const requestContext = requestContextStates.get(ctx.request)?.context ??
+        {};
+      const result = withRequestLogContext(
+        formatFn(ctx as unknown as ElysiaContext, responseTime),
+        requestContext,
+      );
 
       if (typeof result === "string") {
-        logMethod(result);
+        logMethod(result, requestContext);
       } else {
         logMethod("{method} {url} {status} - {responseTime} ms", result);
       }
@@ -440,6 +751,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     if (skip(elysiaCtx)) return;
 
     const props = buildProperties(elysiaCtx, responseTime);
+    const requestContext = requestContextStates.get(ctx.request)?.context ?? {};
     // Get the correct HTTP status code from error context
     const status = getErrorStatus(ctx.code, ctx.error, elysiaCtx.set.status);
     // Extract error message safely
@@ -449,6 +761,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
       "Error: {method} {url} {status} - {responseTime} ms - {errorMessage}",
       {
         ...props,
+        ...requestContext,
         status,
         errorMessage,
         errorCode: ctx.code,

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -742,9 +742,10 @@ function createElysiaRequestWrappers(
     ): Promise<unknown> {
       const ctx = getRouteContext(args[0]);
       if (ctx == null) return await requestCallback.apply(this, args);
+      ctx.store.startTime = performance.now();
       const requestContext = await buildAndStoreRequestContext(ctx.request);
       ctx.store.startTime = requestContext?.startTime ??
-        performance.now();
+        ctx.store.startTime;
       applyRequestContextToSet(ctx.set, requestContext);
       return await withContext(
         requestContext?.context ?? {},
@@ -886,8 +887,9 @@ function wrapLocalLifecycleHooks(
 
   const wrapLifecycleHookArgs = (args: readonly unknown[]): unknown[] => {
     const wrappedArgs = [...args];
-    if (isLifecycleHookType(args[0]) && args.length > 1) {
-      wrappedArgs[1] = wrapRouteHookValue(args[1]);
+    if (isLifecycleHookType(args[0])) {
+      if (args.length > 1) wrappedArgs[1] = wrapRouteHookValue(args[1]);
+      if (args.length > 2) wrappedArgs[2] = wrapRouteHookValue(args[2]);
     } else if (isLifecycleHookType(args[1]) && args.length > 2) {
       wrappedArgs[2] = wrapRouteHookValue(args[2]);
     }
@@ -1048,6 +1050,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     .onRequest(({ request, set, store }) => {
       const requestContext = requestContextStates.get(request);
       if (requestContext == null && shouldWrapAllRoutes) {
+        (store as LoggerStore).startTime = performance.now();
         return buildAndStoreRequestContext(request).then((resolvedContext) => {
           applyRequestContextToRequest(
             store as LoggerStore,
@@ -1061,9 +1064,10 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
 
   if (scope === "local" && (contextOptions != null || logRequest)) {
     plugin = plugin.onBeforeHandle(async (ctx) => {
+      (ctx.store as LoggerStore).startTime = performance.now();
       const requestContext = await buildAndStoreRequestContext(ctx.request);
       (ctx.store as LoggerStore).startTime = requestContext?.startTime ??
-        performance.now();
+        (ctx.store as LoggerStore).startTime;
       applyRequestContextToSet(ctx.set, requestContext);
       if (logRequest && !skip(ctx as unknown as ElysiaContext)) {
         const context = requestContext?.context ?? {};

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -600,9 +600,9 @@ type ElysiaRouteContext = ElysiaContext & {
   readonly store: LoggerStore;
 };
 
-type ElysiaRouteHandler = (
+type ElysiaRequestCallback = (
   this: unknown,
-  context: ElysiaRouteContext,
+  ...args: unknown[]
 ) => unknown;
 
 type ElysiaRouteRegistrar = (
@@ -639,6 +639,18 @@ const elysiaRouteMethods: readonly ElysiaRouteMethod[] = [
   "put",
 ];
 
+const elysiaRouteHookKeys = [
+  "afterHandle",
+  "afterResponse",
+  "beforeHandle",
+  "derive",
+  "error",
+  "mapResponse",
+  "parse",
+  "resolve",
+  "transform",
+] as const;
+
 type ElysiaRoutePlugin = Record<ElysiaRouteMethod, ElysiaRouteRegistrar> & {
   readonly router?: {
     readonly history?: Record<string, ElysiaRouteEntry> | ElysiaRouteEntry[];
@@ -654,6 +666,7 @@ type ElysiaRoutePlugin = Record<ElysiaRouteMethod, ElysiaRouteRegistrar> & {
 
 interface ElysiaRouteEntry {
   handler?: unknown;
+  hooks?: unknown;
 }
 
 function getElysiaRouteEntries(plugin: unknown): ElysiaRouteEntry[] {
@@ -686,45 +699,93 @@ function wrapLocalRouteHandlers(
     requestContext: ElysiaRequestContextState | undefined,
   ) => void,
 ): void {
-  const wrappedHandlers = new WeakSet<ElysiaRouteHandler>();
+  const wrappedHandlers = new WeakSet<ElysiaRequestCallback>();
   const wrappedHandlerCache = new WeakMap<
-    ElysiaRouteHandler,
-    ElysiaRouteHandler
+    ElysiaRequestCallback,
+    ElysiaRequestCallback
   >();
-  const wrapHandler = (handler: unknown): unknown => {
-    if (typeof handler !== "function") return handler;
-    const routeHandler = handler as ElysiaRouteHandler;
-    if (wrappedHandlers.has(routeHandler)) return handler;
-    const cached = wrappedHandlerCache.get(routeHandler);
+
+  const getRouteContext = (
+    value: unknown,
+  ): ElysiaRouteContext | undefined => {
+    if (value == null || typeof value !== "object") return undefined;
+    const context = value as { readonly request?: unknown };
+    if (!(context.request instanceof Request)) return undefined;
+    return value as ElysiaRouteContext;
+  };
+
+  const wrapRequestCallback = (callback: unknown): unknown => {
+    if (typeof callback !== "function") return callback;
+    const requestCallback = callback as ElysiaRequestCallback;
+    if (wrappedHandlers.has(requestCallback)) return callback;
+    const cached = wrappedHandlerCache.get(requestCallback);
     if (cached != null) return cached;
     const wrapped = async function (
       this: unknown,
-      ctx: ElysiaRouteContext,
+      ...args: unknown[]
     ): Promise<unknown> {
+      const ctx = getRouteContext(args[0]);
+      if (ctx == null) return await requestCallback.apply(this, args);
       const requestContext = await buildAndStoreRequestContext(ctx.request);
       ctx.store.startTime = requestContext?.startTime ??
         performance.now();
       applyRequestContextToSet(ctx.set, requestContext);
       return await withContext(
         requestContext?.context ?? {},
-        () => routeHandler.call(this, ctx),
+        () => requestCallback.apply(this, args),
       );
     };
     wrappedHandlers.add(wrapped);
-    wrappedHandlerCache.set(routeHandler, wrapped);
+    wrappedHandlerCache.set(requestCallback, wrapped);
     return wrapped;
+  };
+
+  const wrapRouteHookValue = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(wrapRouteHookValue);
+    if (typeof value === "function") return wrapRequestCallback(value);
+    if (value == null || typeof value !== "object") return value;
+    const hookContainer = value as { readonly fn?: unknown };
+    if (typeof hookContainer.fn !== "function") return value;
+    return {
+      ...hookContainer,
+      fn: wrapRequestCallback(hookContainer.fn),
+    };
+  };
+
+  const wrapRouteHooks = (hooks: unknown): unknown => {
+    if (hooks == null || typeof hooks !== "object") return hooks;
+    const routeHooks = hooks as Record<string, unknown>;
+    let changed = false;
+    const wrappedHooks = { ...routeHooks };
+    for (const key of elysiaRouteHookKeys) {
+      const value = routeHooks[key];
+      const wrappedValue = wrapRouteHookValue(value);
+      if (wrappedValue === value) continue;
+      wrappedHooks[key] = wrappedValue;
+      changed = true;
+    }
+    return changed ? wrappedHooks : hooks;
   };
 
   const wrapRouteEntries = (routePlugin: unknown): (() => void)[] => {
     const restore: (() => void)[] = [];
     for (const route of getElysiaRouteEntries(routePlugin)) {
       const handler = route.handler;
-      const wrappedHandler = wrapHandler(handler);
-      if (wrappedHandler === handler) continue;
-      route.handler = wrappedHandler;
-      restore.push(() => {
-        route.handler = handler;
-      });
+      const wrappedHandler = wrapRequestCallback(handler);
+      if (wrappedHandler !== handler) {
+        route.handler = wrappedHandler;
+        restore.push(() => {
+          route.handler = handler;
+        });
+      }
+      const hooks = route.hooks;
+      const wrappedHooks = wrapRouteHooks(hooks);
+      if (wrappedHooks !== hooks) {
+        route.hooks = wrappedHooks;
+        restore.push(() => {
+          route.hooks = hooks;
+        });
+      }
     }
     return restore;
   };
@@ -732,7 +793,11 @@ function wrapLocalRouteHandlers(
   for (const method of elysiaRouteMethods) {
     const register = plugin[method].bind(plugin);
     plugin[method] = ((path: string, handler: unknown, hook?: unknown) =>
-      register(path, wrapHandler(handler), hook)) as ElysiaRouteRegistrar;
+      register(
+        path,
+        wrapRequestCallback(handler),
+        wrapRouteHooks(hook),
+      )) as ElysiaRouteRegistrar;
   }
 
   const route = plugin.route.bind(plugin);
@@ -741,9 +806,13 @@ function wrapLocalRouteHandlers(
     path: string,
     handler: unknown,
     hook?: unknown,
-  ) => route(method, path, wrapHandler(handler), hook)) as ElysiaRoutePlugin[
-    "route"
-  ];
+  ) =>
+    route(
+      method,
+      path,
+      wrapRequestCallback(handler),
+      wrapRouteHooks(hook),
+    )) as ElysiaRoutePlugin["route"];
 
   const use = plugin.use.bind(plugin);
   plugin.use = ((childPlugin: unknown, ...options: unknown[]) => {

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -66,6 +66,49 @@ app.use(expressLogger({
   format: "dev",                 // Predefined format (default: "combined")
   skip: (req, res) => res.statusCode < 400,  // Skip successful requests
   immediate: false,              // Log after response (default)
+  context: true,                 // Add requestId to request-scoped logs
+}));
+~~~~
+
+
+Request context
+---------------
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the middleware reads the `x-request-id` request header, generates an ID when
+the header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to the request log record.
+
+To make logs emitted by your route handlers inherit the same `requestId`, also
+configure LogTape with `contextLocalStorage`:
+
+~~~~ typescript
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+
+await configure({
+  // ... sinks and loggers ...
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+app.use(expressLogger({ context: true }));
+~~~~
+
+The context is still established when `skip` suppresses the request log, so
+application logs inside the skipped request can keep the same request ID.
+
+You can customize request ID headers and add more request fields:
+
+~~~~ typescript
+app.use(expressLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "url", "httpVersion"],
+    enrich: (req) => ({ route: req.path }),
+  },
 }));
 ~~~~
 

--- a/packages/express/src/mod.test.ts
+++ b/packages/express/src/mod.test.ts
@@ -1,23 +1,24 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { EventEmitter } from "node:events";
 import test from "node:test";
-import { configure, type LogRecord, reset } from "@logtape/logtape";
+import { configure, getLogger, type LogRecord, reset } from "@logtape/logtape";
 import {
   expressLogger,
   type ExpressNextFunction,
   type ExpressRequest,
   type ExpressResponse,
 } from "./mod.ts";
-import { EventEmitter } from "node:events";
 
 // Test fixture: Collect log records, filtering out internal LogTape meta logs
-function createTestSink(): {
+function createTestSink(options: { includeMeta?: boolean } = {}): {
   sink: (record: LogRecord) => void;
   logs: LogRecord[];
 } {
   const logs: LogRecord[] = [];
   return {
     sink: (record: LogRecord) => {
-      if (record.category[0] !== "logtape") {
+      if (options.includeMeta || record.category[0] !== "logtape") {
         logs.push(record);
       }
     },
@@ -26,14 +27,22 @@ function createTestSink(): {
 }
 
 // Setup helper
-async function setupLogtape(): Promise<{
+async function setupLogtape(options: {
+  contextLocalStorage?: boolean;
+  includeMeta?: boolean;
+} = {}): Promise<{
   logs: LogRecord[];
   cleanup: () => Promise<void>;
 }> {
-  const { sink, logs } = createTestSink();
+  const { sink, logs } = createTestSink({
+    includeMeta: options.includeMeta,
+  });
   await configure({
     sinks: { test: sink },
     loggers: [{ category: [], sinks: ["test"] }],
+    contextLocalStorage: options.contextLocalStorage
+      ? new AsyncLocalStorage()
+      : undefined,
   });
   return { logs, cleanup: () => reset() };
 }
@@ -578,6 +587,145 @@ test("expressLogger(): non-immediate mode logs after response", async () => {
     finishResponse(res);
 
     assert.strictEqual(logs.length, 1); // Now logged
+  } finally {
+    await cleanup();
+  }
+});
+
+// ============================================
+// Request Context Tests
+// ============================================
+
+test("expressLogger(): context true uses incoming request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const middleware = expressLogger({ context: true });
+    const req = createMockRequest({
+      get: (header: string) => {
+        const headers: Record<string, string> = {
+          "x-request-id": "request-123",
+          "user-agent": "test-agent/1.0",
+        };
+        return headers[header.toLowerCase()];
+      },
+    });
+    const res = createMockResponse();
+
+    middleware(req, res, () => {
+      appLogger.info("Handled request");
+    });
+    finishResponse(res);
+
+    assert.strictEqual(res.getHeader("x-request-id"), "request-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "request-123");
+    assert.strictEqual(logs[1].properties.requestId, "request-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("expressLogger(): context true generates missing request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = expressLogger({
+      context: { requestId: { generate: () => "generated-123" } },
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+
+    middleware(req, res, () => {});
+    finishResponse(res);
+
+    assert.strictEqual(res.getHeader("x-request-id"), "generated-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "generated-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("expressLogger(): context keeps implicit context when skipped", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const middleware = expressLogger({
+      context: { requestId: { generate: () => "skip-123" } },
+      skip: () => true,
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+
+    middleware(req, res, () => {
+      appLogger.info("Handled skipped request");
+    });
+    finishResponse(res);
+
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "skip-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("expressLogger(): context works with immediate logging", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = expressLogger({
+      context: { requestId: { generate: () => "immediate-123" } },
+      immediate: true,
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+
+    middleware(req, res, () => {});
+
+    assert.strictEqual(res.getHeader("x-request-id"), "immediate-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "immediate-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("expressLogger(): missing context storage still logs request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({ includeMeta: true });
+  try {
+    const appLogger = getLogger(["app"]);
+    const middleware = expressLogger({
+      context: { requestId: { generate: () => "no-storage-123" } },
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+
+    middleware(req, res, () => {
+      appLogger.info("Handled request");
+    });
+    finishResponse(res);
+
+    const appLog = logs.find((record) => record.category[0] === "app");
+    const requestLog = logs.find((record) => record.category[0] === "express");
+    const metaLog = logs.find((record) =>
+      record.category[0] === "logtape" && record.category[1] === "meta" &&
+      record.level === "warning"
+    );
+    assert.ok(appLog);
+    assert.ok(requestLog);
+    assert.ok(metaLog);
+    assert.strictEqual(appLog.properties.requestId, undefined);
+    assert.strictEqual(requestLog.properties.requestId, "no-storage-123");
+    assert.strictEqual(metaLog.level, "warning");
   } finally {
     await cleanup();
   }

--- a/packages/express/src/mod.test.ts
+++ b/packages/express/src/mod.test.ts
@@ -695,6 +695,38 @@ test("expressLogger(): context supports custom options", async () => {
   }
 });
 
+test("expressLogger(): context enrich allows a callable then field", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = expressLogger({
+      context: {
+        enrich: () => ({
+          route: "/test",
+          then: () => "not a promise",
+        }),
+      },
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+    let nextCalled = false;
+
+    middleware(req, res, () => {
+      nextCalled = true;
+    });
+    await delay(0);
+    finishResponse(res);
+
+    assert.strictEqual(nextCalled, true);
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.route, "/test");
+    assert.strictEqual(typeof logs[0].properties.then, "function");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("expressLogger(): context keeps implicit context when skipped", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/express/src/mod.test.ts
+++ b/packages/express/src/mod.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { EventEmitter } from "node:events";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { configure, getLogger, type LogRecord, reset } from "@logtape/logtape";
 import {
   expressLogger,
@@ -766,6 +767,40 @@ test("expressLogger(): forwards synchronous context enrich errors", async () => 
     });
 
     assert.strictEqual(nextError, enrichError);
+    assert.strictEqual(logs.length, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("expressLogger(): forwards errors after async context enrich", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const formatError = new Error("format failed");
+    const middleware = expressLogger({
+      context: {
+        enrich: async () => {
+          await delay(0);
+          return { enriched: true };
+        },
+      },
+      format: () => {
+        throw formatError;
+      },
+      immediate: true,
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+    let nextError: unknown;
+
+    middleware(req, res, (err) => {
+      nextError = err;
+    });
+    await delay(0);
+
+    assert.strictEqual(nextError, formatError);
     assert.strictEqual(logs.length, 0);
   } finally {
     await cleanup();

--- a/packages/express/src/mod.test.ts
+++ b/packages/express/src/mod.test.ts
@@ -742,6 +742,36 @@ test("expressLogger(): context works with immediate logging", async () => {
   }
 });
 
+test("expressLogger(): forwards synchronous context enrich errors", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const enrichError = new Error("enrich failed");
+    const middleware = expressLogger({
+      context: {
+        enrich: () => {
+          throw enrichError;
+        },
+      },
+    });
+    const req = createMockRequest();
+    const res = createMockResponse();
+    let nextError: unknown;
+
+    assert.doesNotThrow(() => {
+      middleware(req, res, (err) => {
+        nextError = err;
+      });
+    });
+
+    assert.strictEqual(nextError, enrichError);
+    assert.strictEqual(logs.length, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("expressLogger(): missing context storage still logs request ID", async () => {
   const { logs, cleanup } = await setupLogtape({ includeMeta: true });
   try {

--- a/packages/express/src/mod.test.ts
+++ b/packages/express/src/mod.test.ts
@@ -651,6 +651,49 @@ test("expressLogger(): context true generates missing request ID", async () => {
   }
 });
 
+test("expressLogger(): context supports custom options", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = expressLogger({
+      context: {
+        requestId: {
+          property: "correlationId",
+          headerNames: ["x-correlation-id", "x-request-id"],
+          responseHeader: "x-correlation-id",
+          normalize: (value) => value.trim().toUpperCase(),
+        },
+        include: ["requestId", "method", "path", "httpVersion"],
+        enrich: (req) => ({ route: req.path }),
+      },
+    });
+    const req = createMockRequest({
+      path: "/test",
+      get: (header: string) => {
+        const headers: Record<string, string> = {
+          "x-correlation-id": " custom-123 ",
+        };
+        return headers[header.toLowerCase()];
+      },
+    });
+    const res = createMockResponse();
+
+    middleware(req, res, () => {});
+    finishResponse(res);
+
+    assert.strictEqual(res.getHeader("x-correlation-id"), "CUSTOM-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.correlationId, "CUSTOM-123");
+    assert.strictEqual(logs[0].properties.method, "GET");
+    assert.strictEqual(logs[0].properties.path, "/test");
+    assert.strictEqual(logs[0].properties.httpVersion, "1.1");
+    assert.strictEqual(logs[0].properties.route, "/test");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("expressLogger(): context keeps implicit context when skipped", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/express/src/mod.ts
+++ b/packages/express/src/mod.ts
@@ -1,4 +1,4 @@
-import { getLogger, type LogLevel } from "@logtape/logtape";
+import { getLogger, type LogLevel, withContext } from "@logtape/logtape";
 
 export type { LogLevel } from "@logtape/logtape";
 
@@ -28,6 +28,7 @@ export interface ExpressResponse {
   statusCode: number;
   on(event: string, listener: () => void): void;
   getHeader(name: string): string | number | string[] | undefined;
+  setHeader?(name: string, value: string): void;
 }
 
 /**
@@ -93,6 +94,83 @@ export interface RequestLogProperties {
 }
 
 /**
+ * Request fields that can be added to the implicit request context.
+ * @since 2.2.0
+ */
+export type RequestContextField =
+  | "requestId"
+  | "method"
+  | "url"
+  | "path"
+  | "userAgent"
+  | "remoteAddr"
+  | "referrer"
+  | "httpVersion";
+
+/**
+ * Options for extracting, generating, and propagating a request ID.
+ * @since 2.2.0
+ */
+export interface RequestIdOptions {
+  /**
+   * The property name used in implicit context and request log records.
+   * @default "requestId"
+   */
+  readonly property?: string;
+
+  /**
+   * Incoming request headers to inspect in order.
+   * @default ["x-request-id"]
+   */
+  readonly headerNames?: readonly string[];
+
+  /**
+   * Response header that receives the resolved request ID.
+   * Set to `false` to disable response header propagation.
+   * @default "x-request-id"
+   */
+  readonly responseHeader?: string | false;
+
+  /**
+   * Generates a request ID when no incoming header is present.
+   * @default crypto.randomUUID()
+   */
+  readonly generate?: () => string;
+
+  /**
+   * Normalizes an incoming request ID.  Return `null` to reject the value and
+   * keep looking for another header or generate a new ID.
+   */
+  readonly normalize?: (value: string) => string | null;
+}
+
+/**
+ * Options for request-scoped implicit context.
+ * @since 2.2.0
+ */
+export interface RequestContextOptions {
+  /**
+   * Enables request ID extraction, generation, and response propagation.
+   * @default true
+   */
+  readonly requestId?: boolean | RequestIdOptions;
+
+  /**
+   * Fields to add to the implicit context.
+   * @default ["requestId"]
+   */
+  readonly include?: readonly RequestContextField[];
+
+  /**
+   * Adds application-specific fields to the implicit request context.
+   */
+  readonly enrich?: (
+    req: ExpressRequest,
+    res: ExpressResponse,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+}
+
+/**
  * Options for configuring the Express LogTape middleware.
  * @since 1.3.0
  */
@@ -149,6 +227,175 @@ export interface ExpressLogTapeOptions {
    * @default false
    */
   readonly immediate?: boolean;
+
+  /**
+   * Enables request-scoped implicit context and request ID correlation.
+   *
+   * When set to `true`, the middleware reads the `x-request-id` header,
+   * generates one when it is absent, writes it to the `x-request-id` response
+   * header, and adds `requestId` to all LogTape records emitted while handling
+   * the request.
+   *
+   * @default false
+   * @since 2.2.0
+   */
+  readonly context?: boolean | RequestContextOptions;
+}
+
+const defaultRequestIdHeader = "x-request-id";
+
+/**
+ * Normalize request context options.
+ */
+function normalizeRequestContextOptions(
+  options: boolean | RequestContextOptions | undefined,
+): RequestContextOptions | undefined {
+  if (options === true) return {};
+  if (options === false || options == null) return undefined;
+  return options;
+}
+
+/**
+ * Normalize request ID options.
+ */
+function normalizeRequestIdOptions(
+  options: boolean | RequestIdOptions | undefined,
+): RequestIdOptions | undefined {
+  if (options === false) return undefined;
+  if (options === true || options == null) return {};
+  return options;
+}
+
+/**
+ * Generate a request ID with Web Crypto when possible.
+ */
+function generateRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Normalize an incoming request ID.
+ */
+function defaultNormalizeRequestId(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Resolve the request ID for a request.
+ */
+function resolveRequestId(
+  req: ExpressRequest,
+  res: ExpressResponse,
+  options: RequestIdOptions,
+): { property: string; value: string } {
+  const property = options.property ?? "requestId";
+  const normalize = options.normalize ?? defaultNormalizeRequestId;
+  const headerNames = options.headerNames ?? [defaultRequestIdHeader];
+  for (const headerName of headerNames) {
+    const headerValue = req.get(headerName);
+    if (headerValue == null) continue;
+    const normalized = normalize(headerValue);
+    if (normalized != null) {
+      const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+      if (responseHeader !== false) res.setHeader?.(responseHeader, normalized);
+      return { property, value: normalized };
+    }
+  }
+  const generated = (options.generate ?? generateRequestId)();
+  const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+  if (responseHeader !== false) res.setHeader?.(responseHeader, generated);
+  return { property, value: generated };
+}
+
+/**
+ * Build request context fields from a request.
+ */
+function buildIncludedContext(
+  req: ExpressRequest,
+  resolvedRequestId: { property: string; value: string } | undefined,
+  include: readonly RequestContextField[],
+): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const field of include) {
+    switch (field) {
+      case "requestId":
+        if (resolvedRequestId != null) {
+          context[resolvedRequestId.property] = resolvedRequestId.value;
+        }
+        break;
+      case "method":
+        context.method = req.method;
+        break;
+      case "url":
+        context.url = req.originalUrl || req.url;
+        break;
+      case "path":
+        context.path = req.path;
+        break;
+      case "userAgent":
+        context.userAgent = getUserAgent(req);
+        break;
+      case "remoteAddr":
+        context.remoteAddr = getRemoteAddr(req);
+        break;
+      case "referrer":
+        context.referrer = getReferrer(req);
+        break;
+      case "httpVersion":
+        context.httpVersion = req.httpVersion;
+        break;
+    }
+  }
+  return context;
+}
+
+/**
+ * Check whether a value is a promise-like object.
+ */
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return value != null && typeof value === "object" &&
+    typeof (value as PromiseLike<T>).then === "function";
+}
+
+/**
+ * Build the implicit context for a request.
+ */
+function buildRequestContext(
+  req: ExpressRequest,
+  res: ExpressResponse,
+  options: RequestContextOptions,
+): Record<string, unknown> | Promise<Record<string, unknown>> {
+  const requestIdOptions = normalizeRequestIdOptions(options.requestId);
+  const resolvedRequestId = requestIdOptions == null
+    ? undefined
+    : resolveRequestId(req, res, requestIdOptions);
+  const include = options.include ??
+    (resolvedRequestId == null ? [] : ["requestId"] as const);
+  const context = buildIncludedContext(req, resolvedRequestId, include);
+  if (options.enrich == null) return context;
+  const enriched = options.enrich(req, res);
+  if (isPromiseLike<Record<string, unknown>>(enriched)) {
+    return Promise.resolve(enriched).then((extraContext) => ({
+      ...context,
+      ...extraContext,
+    }));
+  }
+  return { ...context, ...enriched };
+}
+
+/**
+ * Add request context fields to a request log result.
+ */
+function withRequestLogContext(
+  result: string | Record<string, unknown>,
+  context: Record<string, unknown>,
+): string | Record<string, unknown> {
+  if (typeof result === "string") return result;
+  return { ...result, ...context };
 }
 
 /**
@@ -360,6 +607,7 @@ export function expressLogger(
   const formatOption = options.format ?? "combined";
   const skip = options.skip ?? (() => false);
   const immediate = options.immediate ?? false;
+  const contextOptions = normalizeRequestContextOptions(options.context);
 
   // Resolve format function
   const formatFn: FormatFunction = typeof formatOption === "string"
@@ -375,37 +623,60 @@ export function expressLogger(
   ): void => {
     const startTime = Date.now();
 
-    // For immediate logging, log when request arrives
-    if (immediate) {
-      if (!skip(req, res)) {
-        const result = formatFn(req, res, 0);
-        if (typeof result === "string") {
-          logMethod(result);
-        } else {
-          logMethod("{method} {url}", result);
+    const handleRequest = (requestContext: Record<string, unknown>): void => {
+      // For immediate logging, log when request arrives
+      if (immediate) {
+        if (!skip(req, res)) {
+          const result = withRequestLogContext(
+            formatFn(req, res, 0),
+            requestContext,
+          );
+          if (typeof result === "string") {
+            logMethod(result, requestContext);
+          } else {
+            logMethod("{method} {url}", result);
+          }
         }
+        next();
+        return;
       }
+
+      // Log after response is sent
+      const logRequest = (): void => {
+        if (skip(req, res)) return;
+
+        const responseTime = Date.now() - startTime;
+        const result = withRequestLogContext(
+          formatFn(req, res, responseTime),
+          requestContext,
+        );
+
+        if (typeof result === "string") {
+          logMethod(result, requestContext);
+        } else {
+          logMethod("{method} {url} {status} - {responseTime} ms", result);
+        }
+      };
+
+      // Listen for response finish event
+      res.on("finish", logRequest);
+
       next();
+    };
+
+    if (contextOptions == null) {
+      handleRequest({});
       return;
     }
 
-    // Log after response is sent
-    const logRequest = (): void => {
-      if (skip(req, res)) return;
+    const requestContext = buildRequestContext(req, res, contextOptions);
+    if (isPromiseLike<Record<string, unknown>>(requestContext)) {
+      Promise.resolve(requestContext).then((resolvedContext) => {
+        withContext(resolvedContext, () => handleRequest(resolvedContext));
+      }, next);
+      return;
+    }
 
-      const responseTime = Date.now() - startTime;
-      const result = formatFn(req, res, responseTime);
-
-      if (typeof result === "string") {
-        logMethod(result);
-      } else {
-        logMethod("{method} {url} {status} - {responseTime} ms", result);
-      }
-    };
-
-    // Listen for response finish event
-    res.on("finish", logRequest);
-
-    next();
+    withContext(requestContext, () => handleRequest(requestContext));
   };
 }

--- a/packages/express/src/mod.ts
+++ b/packages/express/src/mod.ts
@@ -669,7 +669,15 @@ export function expressLogger(
       return;
     }
 
-    const requestContext = buildRequestContext(req, res, contextOptions);
+    let requestContext:
+      | Record<string, unknown>
+      | Promise<Record<string, unknown>>;
+    try {
+      requestContext = buildRequestContext(req, res, contextOptions);
+    } catch (error) {
+      next(error);
+      return;
+    }
     if (isPromiseLike<Record<string, unknown>>(requestContext)) {
       Promise.resolve(requestContext).then((resolvedContext) => {
         withContext(resolvedContext, () => handleRequest(resolvedContext));

--- a/packages/express/src/mod.ts
+++ b/packages/express/src/mod.ts
@@ -679,9 +679,11 @@ export function expressLogger(
       return;
     }
     if (isPromiseLike<Record<string, unknown>>(requestContext)) {
-      Promise.resolve(requestContext).then((resolvedContext) => {
-        withContext(resolvedContext, () => handleRequest(resolvedContext));
-      }, next);
+      Promise.resolve(requestContext)
+        .then((resolvedContext) => {
+          withContext(resolvedContext, () => handleRequest(resolvedContext));
+        })
+        .catch(next);
       return;
     }
 

--- a/packages/express/src/mod.ts
+++ b/packages/express/src/mod.ts
@@ -354,11 +354,12 @@ function buildIncludedContext(
 }
 
 /**
- * Check whether a value is a promise-like object.
+ * Check whether a value is a Promise object.
  */
-function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+function isPromise<T>(value: unknown): value is Promise<T> {
   return value != null && typeof value === "object" &&
-    typeof (value as PromiseLike<T>).then === "function";
+    Object.prototype.toString.call(value) === "[object Promise]" &&
+    typeof (value as Promise<T>).then === "function";
 }
 
 /**
@@ -378,7 +379,7 @@ function buildRequestContext(
   const context = buildIncludedContext(req, resolvedRequestId, include);
   if (options.enrich == null) return context;
   const enriched = options.enrich(req, res);
-  if (isPromiseLike<Record<string, unknown>>(enriched)) {
+  if (isPromise<Record<string, unknown>>(enriched)) {
     return Promise.resolve(enriched).then((extraContext) => ({
       ...context,
       ...extraContext,
@@ -678,7 +679,7 @@ export function expressLogger(
       next(error);
       return;
     }
-    if (isPromiseLike<Record<string, unknown>>(requestContext)) {
+    if (isPromise<Record<string, unknown>>(requestContext)) {
       Promise.resolve(requestContext)
         .then((resolvedContext) => {
           withContext(resolvedContext, () => handleRequest(resolvedContext));

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -66,6 +66,49 @@ app.use(honoLogger({
   format: "dev",                 // Predefined format (default: "combined")
   skip: (c) => c.req.path === "/health",  // Skip logging for specific paths
   logRequest: true,              // Log at request start (default: false)
+  context: true,                 // Add requestId to request-scoped logs
+}));
+~~~~
+
+
+Request context
+---------------
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the middleware reads the `x-request-id` request header, generates an ID when
+the header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to the request log record.
+
+To make logs emitted by your route handlers inherit the same `requestId`, also
+configure LogTape with `contextLocalStorage`:
+
+~~~~ typescript
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+
+await configure({
+  // ... sinks and loggers ...
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+app.use(honoLogger({ context: true }));
+~~~~
+
+The context is still established when `skip` suppresses the request log, so
+application logs inside the skipped request can keep the same request ID.
+
+You can customize request ID headers and add more request fields:
+
+~~~~ typescript
+app.use(honoLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "path", "userAgent"],
+    enrich: (c) => ({ route: c.req.path }),
+  },
 }));
 ~~~~
 

--- a/packages/hono/src/mod.test.ts
+++ b/packages/hono/src/mod.test.ts
@@ -520,6 +520,27 @@ test("honoLogger(): context true generates missing request ID", async () => {
   }
 });
 
+test("honoLogger(): context propagates request ID to raw Response", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "raw-response-123" } },
+    }));
+    app.get("/test", () => new Response("Hello"));
+
+    const res = await app.request("/test");
+
+    assert.strictEqual(res.headers.get("x-request-id"), "raw-response-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "raw-response-123");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("honoLogger(): context supports custom options", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/hono/src/mod.test.ts
+++ b/packages/hono/src/mod.test.ts
@@ -541,6 +541,36 @@ test("honoLogger(): context propagates request ID to raw Response", async () => 
   }
 });
 
+test("honoLogger(): context ignores immutable response header errors", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "immutable-response-123" } },
+    }));
+    app.get("/test", async () => {
+      const response = await fetch("data:text/plain,Hello");
+      await response.text();
+      return response;
+    });
+
+    const res = await app.request("/test");
+
+    assert.strictEqual(res.status, 200);
+    const responseRequestId = res.headers.get("x-request-id");
+    assert.ok(
+      responseRequestId == null ||
+        responseRequestId === "immutable-response-123",
+    );
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "immutable-response-123");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("honoLogger(): context supports custom options", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/hono/src/mod.test.ts
+++ b/packages/hono/src/mod.test.ts
@@ -1,18 +1,19 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
 import test from "node:test";
-import { configure, type LogRecord, reset } from "@logtape/logtape";
+import { configure, getLogger, type LogRecord, reset } from "@logtape/logtape";
 import { Hono } from "hono";
 import { honoLogger } from "./mod.ts";
 
 // Test fixture: Collect log records, filtering out internal LogTape meta logs
-function createTestSink(): {
+function createTestSink(options: { includeMeta?: boolean } = {}): {
   sink: (record: LogRecord) => void;
   logs: LogRecord[];
 } {
   const logs: LogRecord[] = [];
   return {
     sink: (record: LogRecord) => {
-      if (record.category[0] !== "logtape") {
+      if (options.includeMeta || record.category[0] !== "logtape") {
         logs.push(record);
       }
     },
@@ -21,14 +22,22 @@ function createTestSink(): {
 }
 
 // Setup helper
-async function setupLogtape(): Promise<{
+async function setupLogtape(options: {
+  contextLocalStorage?: boolean;
+  includeMeta?: boolean;
+} = {}): Promise<{
   logs: LogRecord[];
   cleanup: () => Promise<void>;
 }> {
-  const { sink, logs } = createTestSink();
+  const { sink, logs } = createTestSink({
+    includeMeta: options.includeMeta,
+  });
   await configure({
     sinks: { test: sink },
     loggers: [{ category: [], sinks: ["test"] }],
+    contextLocalStorage: options.contextLocalStorage
+      ? new AsyncLocalStorage()
+      : undefined,
   });
   return { logs, cleanup: () => reset() };
 }
@@ -451,6 +460,141 @@ test("honoLogger(): non-logRequest mode logs after response", async () => {
 
     assert.strictEqual(logs.length, 1);
     assert.ok((logs[0].properties.responseTime as number) >= 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ============================================
+// Request Context Tests
+// ============================================
+
+test("honoLogger(): context true uses incoming request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Hono();
+    app.use(honoLogger({ context: true }));
+    app.get("/test", (c) => {
+      appLogger.info("Handled request");
+      return c.text("Hello");
+    });
+
+    const res = await app.request("/test", {
+      headers: {
+        "x-request-id": "request-123",
+        "user-agent": "test-agent/1.0",
+      },
+    });
+
+    assert.strictEqual(res.headers.get("x-request-id"), "request-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "request-123");
+    assert.strictEqual(logs[1].properties.requestId, "request-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("honoLogger(): context true generates missing request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "generated-123" } },
+    }));
+    app.get("/test", (c) => c.text("Hello"));
+
+    const res = await app.request("/test");
+
+    assert.strictEqual(res.headers.get("x-request-id"), "generated-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "generated-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("honoLogger(): context keeps implicit context when skipped", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "skip-123" } },
+      skip: () => true,
+    }));
+    app.get("/test", (c) => {
+      appLogger.info("Handled skipped request");
+      return c.text("Hello");
+    });
+
+    await app.request("/test");
+
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "skip-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("honoLogger(): context works with logRequest", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "immediate-123" } },
+      logRequest: true,
+    }));
+    app.get("/test", (c) => c.text("Hello"));
+
+    const res = await app.request("/test");
+
+    assert.strictEqual(res.headers.get("x-request-id"), "immediate-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "immediate-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("honoLogger(): missing context storage still logs request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({ includeMeta: true });
+  try {
+    const appLogger = getLogger(["app"]);
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "no-storage-123" } },
+    }));
+    app.get("/test", (c) => {
+      appLogger.info("Handled request");
+      return c.text("Hello");
+    });
+
+    await app.request("/test");
+
+    const appLog = logs.find((record) => record.category[0] === "app");
+    const requestLog = logs.find((record) => record.category[0] === "hono");
+    const metaLog = logs.find((record) =>
+      record.category[0] === "logtape" && record.category[1] === "meta" &&
+      record.level === "warning"
+    );
+    assert.ok(appLog);
+    assert.ok(requestLog);
+    assert.ok(metaLog);
+    assert.strictEqual(appLog.properties.requestId, undefined);
+    assert.strictEqual(requestLog.properties.requestId, "no-storage-123");
+    assert.strictEqual(metaLog.level, "warning");
   } finally {
     await cleanup();
   }

--- a/packages/hono/src/mod.test.ts
+++ b/packages/hono/src/mod.test.ts
@@ -541,6 +541,33 @@ test("honoLogger(): context propagates request ID to raw Response", async () => 
   }
 });
 
+test("honoLogger(): context sets request ID before immutable final response", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Hono();
+    app.use(honoLogger({
+      context: { requestId: { generate: () => "pre-response-123" } },
+    }));
+    app.use(async (c, next) => {
+      await next();
+      (c as { header: typeof c.header }).header = () => {
+        throw new TypeError("immutable response headers");
+      };
+    });
+    app.get("/test", (c) => c.text("Hello"));
+
+    const res = await app.request("/test");
+
+    assert.strictEqual(res.headers.get("x-request-id"), "pre-response-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "pre-response-123");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("honoLogger(): context ignores immutable response header errors", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/hono/src/mod.test.ts
+++ b/packages/hono/src/mod.test.ts
@@ -520,6 +520,45 @@ test("honoLogger(): context true generates missing request ID", async () => {
   }
 });
 
+test("honoLogger(): context supports custom options", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const app = new Hono();
+    app.use(honoLogger({
+      context: {
+        requestId: {
+          property: "correlationId",
+          headerNames: ["x-correlation-id", "x-request-id"],
+          responseHeader: "x-correlation-id",
+          normalize: (value) => value.trim().toUpperCase(),
+        },
+        include: ["requestId", "method", "path", "userAgent"],
+        enrich: (c) => ({ route: c.req.path }),
+      },
+    }));
+    app.get("/test", (c) => c.text("Hello"));
+
+    const res = await app.request("/test", {
+      headers: {
+        "x-correlation-id": " custom-123 ",
+        "user-agent": "test-agent/1.0",
+      },
+    });
+
+    assert.strictEqual(res.headers.get("x-correlation-id"), "CUSTOM-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.correlationId, "CUSTOM-123");
+    assert.strictEqual(logs[0].properties.method, "GET");
+    assert.strictEqual(logs[0].properties.path, "/test");
+    assert.strictEqual(logs[0].properties.userAgent, "test-agent/1.0");
+    assert.strictEqual(logs[0].properties.route, "/test");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("honoLogger(): context keeps implicit context when skipped", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -601,6 +601,7 @@ export function honoLogger(
       requestContextState: HonoRequestContextState,
     ): Promise<void> => {
       const requestContext = requestContextState.context;
+      applyResponseHeaders(honoContext, requestContextState);
       // For immediate logging, log when request arrives
       if (logRequest) {
         if (!skip(honoContext)) {

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -1,4 +1,4 @@
-import { getLogger, type LogLevel } from "@logtape/logtape";
+import { getLogger, type LogLevel, withContext } from "@logtape/logtape";
 import { createMiddleware } from "hono/factory";
 import type { Context, MiddlewareHandler } from "hono";
 
@@ -58,6 +58,81 @@ export interface RequestLogProperties {
 }
 
 /**
+ * Request fields that can be added to the implicit request context.
+ * @since 2.2.0
+ */
+export type RequestContextField =
+  | "requestId"
+  | "method"
+  | "url"
+  | "path"
+  | "userAgent"
+  | "remoteAddr"
+  | "referrer";
+
+/**
+ * Options for extracting, generating, and propagating a request ID.
+ * @since 2.2.0
+ */
+export interface RequestIdOptions {
+  /**
+   * The property name used in implicit context and request log records.
+   * @default "requestId"
+   */
+  readonly property?: string;
+
+  /**
+   * Incoming request headers to inspect in order.
+   * @default ["x-request-id"]
+   */
+  readonly headerNames?: readonly string[];
+
+  /**
+   * Response header that receives the resolved request ID.
+   * Set to `false` to disable response header propagation.
+   * @default "x-request-id"
+   */
+  readonly responseHeader?: string | false;
+
+  /**
+   * Generates a request ID when no incoming header is present.
+   * @default crypto.randomUUID()
+   */
+  readonly generate?: () => string;
+
+  /**
+   * Normalizes an incoming request ID.  Return `null` to reject the value and
+   * keep looking for another header or generate a new ID.
+   */
+  readonly normalize?: (value: string) => string | null;
+}
+
+/**
+ * Options for request-scoped implicit context.
+ * @since 2.2.0
+ */
+export interface RequestContextOptions {
+  /**
+   * Enables request ID extraction, generation, and response propagation.
+   * @default true
+   */
+  readonly requestId?: boolean | RequestIdOptions;
+
+  /**
+   * Fields to add to the implicit context.
+   * @default ["requestId"]
+   */
+  readonly include?: readonly RequestContextField[];
+
+  /**
+   * Adds application-specific fields to the implicit request context.
+   */
+  readonly enrich?: (
+    c: HonoContext,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+}
+
+/**
  * Options for configuring the Hono LogTape middleware.
  * @since 1.3.0
  */
@@ -114,6 +189,87 @@ export interface HonoLogTapeOptions {
    * @default false
    */
   readonly logRequest?: boolean;
+
+  /**
+   * Enables request-scoped implicit context and request ID correlation.
+   *
+   * When set to `true`, the middleware reads the `x-request-id` header,
+   * generates one when it is absent, writes it to the `x-request-id` response
+   * header, and adds `requestId` to all LogTape records emitted while handling
+   * the request.
+   *
+   * @default false
+   * @since 2.2.0
+   */
+  readonly context?: boolean | RequestContextOptions;
+}
+
+const defaultRequestIdHeader = "x-request-id";
+
+/**
+ * Normalize request context options.
+ */
+function normalizeRequestContextOptions(
+  options: boolean | RequestContextOptions | undefined,
+): RequestContextOptions | undefined {
+  if (options === true) return {};
+  if (options === false || options == null) return undefined;
+  return options;
+}
+
+/**
+ * Normalize request ID options.
+ */
+function normalizeRequestIdOptions(
+  options: boolean | RequestIdOptions | undefined,
+): RequestIdOptions | undefined {
+  if (options === false) return undefined;
+  if (options === true || options == null) return {};
+  return options;
+}
+
+/**
+ * Generate a request ID with Web Crypto when possible.
+ */
+function generateRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Normalize an incoming request ID.
+ */
+function defaultNormalizeRequestId(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Resolve the request ID for a request.
+ */
+function resolveRequestId(
+  c: HonoContext,
+  options: RequestIdOptions,
+): { property: string; value: string } {
+  const property = options.property ?? "requestId";
+  const normalize = options.normalize ?? defaultNormalizeRequestId;
+  const headerNames = options.headerNames ?? [defaultRequestIdHeader];
+  for (const headerName of headerNames) {
+    const headerValue = c.req.header(headerName);
+    if (headerValue == null) continue;
+    const normalized = normalize(headerValue);
+    if (normalized != null) {
+      const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+      if (responseHeader !== false) c.header(responseHeader, normalized);
+      return { property, value: normalized };
+    }
+  }
+  const generated = (options.generate ?? generateRequestId)();
+  const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+  if (responseHeader !== false) c.header(responseHeader, generated);
+  return { property, value: generated };
 }
 
 /**
@@ -128,6 +284,16 @@ function getReferrer(c: HonoContext): string | undefined {
  */
 function getUserAgent(c: HonoContext): string | undefined {
   return c.req.header("user-agent");
+}
+
+/**
+ * Get remote address from X-Forwarded-For header.
+ */
+function getRemoteAddr(c: HonoContext): string | undefined {
+  const forwarded = c.req.header("x-forwarded-for");
+  if (forwarded == null) return undefined;
+  const firstIp = forwarded.split(",")[0].trim();
+  return firstIp || undefined;
 }
 
 /**
@@ -156,6 +322,77 @@ function buildProperties(
     userAgent: getUserAgent(c),
     referrer: getReferrer(c),
   };
+}
+
+/**
+ * Build request context fields from a request.
+ */
+function buildIncludedContext(
+  c: HonoContext,
+  resolvedRequestId: { property: string; value: string } | undefined,
+  include: readonly RequestContextField[],
+): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const field of include) {
+    switch (field) {
+      case "requestId":
+        if (resolvedRequestId != null) {
+          context[resolvedRequestId.property] = resolvedRequestId.value;
+        }
+        break;
+      case "method":
+        context.method = c.req.method;
+        break;
+      case "url":
+        context.url = c.req.url;
+        break;
+      case "path":
+        context.path = c.req.path;
+        break;
+      case "userAgent":
+        context.userAgent = getUserAgent(c);
+        break;
+      case "remoteAddr":
+        context.remoteAddr = getRemoteAddr(c);
+        break;
+      case "referrer":
+        context.referrer = getReferrer(c);
+        break;
+    }
+  }
+  return context;
+}
+
+/**
+ * Build the implicit context for a request.
+ */
+async function buildRequestContext(
+  c: HonoContext,
+  options: RequestContextOptions,
+): Promise<Record<string, unknown>> {
+  const requestIdOptions = normalizeRequestIdOptions(options.requestId);
+  const resolvedRequestId = requestIdOptions == null
+    ? undefined
+    : resolveRequestId(c, requestIdOptions);
+  const include = options.include ??
+    (resolvedRequestId == null ? [] : ["requestId"] as const);
+  const context = buildIncludedContext(c, resolvedRequestId, include);
+  if (options.enrich == null) return context;
+  return {
+    ...context,
+    ...await options.enrich(c),
+  };
+}
+
+/**
+ * Add request context fields to a request log result.
+ */
+function withRequestLogContext(
+  result: string | Record<string, unknown>,
+  context: Record<string, unknown>,
+): string | Record<string, unknown> {
+  if (typeof result === "string") return result;
+  return { ...result, ...context };
 }
 
 /**
@@ -306,6 +543,7 @@ export function honoLogger(
   const formatOption = options.format ?? "combined";
   const skip = options.skip ?? (() => false);
   const logRequest = options.logRequest ?? false;
+  const contextOptions = normalizeRequestContextOptions(options.context);
 
   // Resolve format function
   const formatFn: FormatFunction = typeof formatOption === "string"
@@ -316,33 +554,55 @@ export function honoLogger(
 
   return createMiddleware(async (c, next) => {
     const startTime = Date.now();
+    const honoContext = c as unknown as HonoContext;
 
-    // For immediate logging, log when request arrives
-    if (logRequest) {
-      if (!skip(c as unknown as HonoContext)) {
-        const result = formatFn(c as unknown as HonoContext, 0);
-        if (typeof result === "string") {
-          logMethod(result);
-        } else {
-          logMethod("{method} {url}", result);
+    const handleRequest = async (
+      requestContext: Record<string, unknown>,
+    ): Promise<void> => {
+      // For immediate logging, log when request arrives
+      if (logRequest) {
+        if (!skip(honoContext)) {
+          const result = withRequestLogContext(
+            formatFn(honoContext, 0),
+            requestContext,
+          );
+          if (typeof result === "string") {
+            logMethod(result, requestContext);
+          } else {
+            logMethod("{method} {url}", result);
+          }
         }
+        await next();
+        return;
       }
+
+      // Log after response is sent
       await next();
+
+      if (skip(honoContext)) return;
+
+      const responseTime = Date.now() - startTime;
+      const result = withRequestLogContext(
+        formatFn(honoContext, responseTime),
+        requestContext,
+      );
+
+      if (typeof result === "string") {
+        logMethod(result, requestContext);
+      } else {
+        logMethod("{method} {url} {status} - {responseTime} ms", result);
+      }
+    };
+
+    if (contextOptions == null) {
+      await handleRequest({});
       return;
     }
 
-    // Log after response is sent
-    await next();
-
-    if (skip(c as unknown as HonoContext)) return;
-
-    const responseTime = Date.now() - startTime;
-    const result = formatFn(c as unknown as HonoContext, responseTime);
-
-    if (typeof result === "string") {
-      logMethod(result);
-    } else {
-      logMethod("{method} {url} {status} - {responseTime} ms", result);
-    }
+    const requestContext = await buildRequestContext(
+      honoContext,
+      contextOptions,
+    );
+    await withContext(requestContext, () => handleRequest(requestContext));
   });
 }

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -415,10 +415,14 @@ function applyResponseHeaders(
   requestContext: HonoRequestContextState,
 ): void {
   if (requestContext.responseHeader == null) return;
-  c.header(
-    requestContext.responseHeader.name,
-    requestContext.responseHeader.value,
-  );
+  try {
+    c.header(
+      requestContext.responseHeader.name,
+      requestContext.responseHeader.value,
+    );
+  } catch {
+    // Keep logging middleware from replacing the application's response.
+  }
 }
 
 /**

--- a/packages/hono/src/mod.ts
+++ b/packages/hono/src/mod.ts
@@ -206,6 +206,20 @@ export interface HonoLogTapeOptions {
 
 const defaultRequestIdHeader = "x-request-id";
 
+interface ResolvedRequestId {
+  readonly property: string;
+  readonly value: string;
+  readonly responseHeader?: string;
+}
+
+interface HonoRequestContextState {
+  readonly context: Record<string, unknown>;
+  readonly responseHeader?: {
+    readonly name: string;
+    readonly value: string;
+  };
+}
+
 /**
  * Normalize request context options.
  */
@@ -252,7 +266,7 @@ function defaultNormalizeRequestId(value: string): string | null {
 function resolveRequestId(
   c: HonoContext,
   options: RequestIdOptions,
-): { property: string; value: string } {
+): ResolvedRequestId {
   const property = options.property ?? "requestId";
   const normalize = options.normalize ?? defaultNormalizeRequestId;
   const headerNames = options.headerNames ?? [defaultRequestIdHeader];
@@ -262,14 +276,20 @@ function resolveRequestId(
     const normalized = normalize(headerValue);
     if (normalized != null) {
       const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
-      if (responseHeader !== false) c.header(responseHeader, normalized);
-      return { property, value: normalized };
+      return {
+        property,
+        value: normalized,
+        responseHeader: responseHeader === false ? undefined : responseHeader,
+      };
     }
   }
   const generated = (options.generate ?? generateRequestId)();
   const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
-  if (responseHeader !== false) c.header(responseHeader, generated);
-  return { property, value: generated };
+  return {
+    property,
+    value: generated,
+    responseHeader: responseHeader === false ? undefined : responseHeader,
+  };
 }
 
 /**
@@ -329,7 +349,7 @@ function buildProperties(
  */
 function buildIncludedContext(
   c: HonoContext,
-  resolvedRequestId: { property: string; value: string } | undefined,
+  resolvedRequestId: ResolvedRequestId | undefined,
   include: readonly RequestContextField[],
 ): Record<string, unknown> {
   const context: Record<string, unknown> = {};
@@ -369,7 +389,7 @@ function buildIncludedContext(
 async function buildRequestContext(
   c: HonoContext,
   options: RequestContextOptions,
-): Promise<Record<string, unknown>> {
+): Promise<HonoRequestContextState> {
   const requestIdOptions = normalizeRequestIdOptions(options.requestId);
   const resolvedRequestId = requestIdOptions == null
     ? undefined
@@ -377,11 +397,28 @@ async function buildRequestContext(
   const include = options.include ??
     (resolvedRequestId == null ? [] : ["requestId"] as const);
   const context = buildIncludedContext(c, resolvedRequestId, include);
-  if (options.enrich == null) return context;
-  return {
-    ...context,
-    ...await options.enrich(c),
-  };
+  if (options.enrich != null) Object.assign(context, await options.enrich(c));
+  const responseHeader = resolvedRequestId?.responseHeader == null
+    ? undefined
+    : {
+      name: resolvedRequestId.responseHeader,
+      value: resolvedRequestId.value,
+    };
+  return { context, responseHeader };
+}
+
+/**
+ * Apply deferred context response headers to the final Hono response.
+ */
+function applyResponseHeaders(
+  c: HonoContext,
+  requestContext: HonoRequestContextState,
+): void {
+  if (requestContext.responseHeader == null) return;
+  c.header(
+    requestContext.responseHeader.name,
+    requestContext.responseHeader.value,
+  );
 }
 
 /**
@@ -557,8 +594,9 @@ export function honoLogger(
     const honoContext = c as unknown as HonoContext;
 
     const handleRequest = async (
-      requestContext: Record<string, unknown>,
+      requestContextState: HonoRequestContextState,
     ): Promise<void> => {
+      const requestContext = requestContextState.context;
       // For immediate logging, log when request arrives
       if (logRequest) {
         if (!skip(honoContext)) {
@@ -573,11 +611,13 @@ export function honoLogger(
           }
         }
         await next();
+        applyResponseHeaders(honoContext, requestContextState);
         return;
       }
 
       // Log after response is sent
       await next();
+      applyResponseHeaders(honoContext, requestContextState);
 
       if (skip(honoContext)) return;
 
@@ -595,14 +635,17 @@ export function honoLogger(
     };
 
     if (contextOptions == null) {
-      await handleRequest({});
+      await handleRequest({ context: {} });
       return;
     }
 
-    const requestContext = await buildRequestContext(
+    const requestContextState = await buildRequestContext(
       honoContext,
       contextOptions,
     );
-    await withContext(requestContext, () => handleRequest(requestContext));
+    await withContext(
+      requestContextState.context,
+      () => handleRequest(requestContextState),
+    );
   });
 }

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -69,6 +69,49 @@ app.use(koaLogger({
   format: "dev",                 // Predefined format (default: "combined")
   skip: (ctx) => ctx.path === "/health",  // Skip health check endpoint
   logRequest: false,             // Log after response (default: false)
+  context: true,                 // Add requestId to request-scoped logs
+}));
+~~~~
+
+
+Request context
+---------------
+
+Set `context: true` to add request-scoped correlation fields.  By default,
+the middleware reads the `x-request-id` request header, generates an ID when
+the header is missing, writes the resolved ID to the `x-request-id` response
+header, and adds `requestId` to the request log record.
+
+To make logs emitted by your route handlers inherit the same `requestId`, also
+configure LogTape with `contextLocalStorage`:
+
+~~~~ typescript
+import { AsyncLocalStorage } from "node:async_hooks";
+import { configure } from "@logtape/logtape";
+
+await configure({
+  // ... sinks and loggers ...
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+app.use(koaLogger({ context: true }));
+~~~~
+
+The context is still established when `skip` suppresses the request log, so
+application logs inside the skipped request can keep the same request ID.
+
+You can customize request ID headers and add more request fields:
+
+~~~~ typescript
+app.use(koaLogger({
+  context: {
+    requestId: {
+      headerNames: ["x-correlation-id", "x-request-id"],
+      responseHeader: "x-request-id",
+    },
+    include: ["requestId", "method", "path", "remoteAddr"],
+    enrich: (ctx) => ({ route: ctx.path }),
+  },
 }));
 ~~~~
 

--- a/packages/koa/src/mod.test.ts
+++ b/packages/koa/src/mod.test.ts
@@ -1,17 +1,18 @@
 import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
 import test from "node:test";
-import { configure, type LogRecord, reset } from "@logtape/logtape";
+import { configure, getLogger, type LogRecord, reset } from "@logtape/logtape";
 import { type KoaContext, koaLogger, type KoaMiddleware } from "./mod.ts";
 
 // Test fixture: Collect log records, filtering out internal LogTape meta logs
-function createTestSink(): {
+function createTestSink(options: { includeMeta?: boolean } = {}): {
   sink: (record: LogRecord) => void;
   logs: LogRecord[];
 } {
   const logs: LogRecord[] = [];
   return {
     sink: (record: LogRecord) => {
-      if (record.category[0] !== "logtape") {
+      if (options.includeMeta || record.category[0] !== "logtape") {
         logs.push(record);
       }
     },
@@ -20,20 +21,35 @@ function createTestSink(): {
 }
 
 // Setup helper
-async function setupLogtape(): Promise<{
+async function setupLogtape(options: {
+  contextLocalStorage?: boolean;
+  includeMeta?: boolean;
+} = {}): Promise<{
   logs: LogRecord[];
   cleanup: () => Promise<void>;
 }> {
-  const { sink, logs } = createTestSink();
+  const { sink, logs } = createTestSink({
+    includeMeta: options.includeMeta,
+  });
   await configure({
     sinks: { test: sink },
     loggers: [{ category: [], sinks: ["test"] }],
+    contextLocalStorage: options.contextLocalStorage
+      ? new AsyncLocalStorage()
+      : undefined,
   });
   return { logs, cleanup: () => reset() };
 }
 
+interface MockKoaContext extends KoaContext {
+  readonly responseHeaders: Record<string, string>;
+}
+
 // Mock Koa context
-function createMockContext(overrides: Partial<KoaContext> = {}): KoaContext {
+function createMockContext(
+  overrides: Partial<KoaContext> = {},
+): MockKoaContext {
+  const responseHeaders: Record<string, string> = {};
   return {
     method: "GET",
     url: "/test",
@@ -51,6 +67,10 @@ function createMockContext(overrides: Partial<KoaContext> = {}): KoaContext {
       };
       return headers[field.toLowerCase()] ?? "";
     },
+    set: (field: string, value: string) => {
+      responseHeaders[field.toLowerCase()] = value;
+    },
+    responseHeaders,
     ...overrides,
   };
 }
@@ -456,6 +476,139 @@ test("koaLogger(): non-logRequest mode logs after response", async () => {
 
     assert.strictEqual(logs.length, 1);
     assert.ok((logs[0].properties.responseTime as number) >= 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+// ============================================
+// Request Context Tests
+// ============================================
+
+test("koaLogger(): context true uses incoming request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const middleware = koaLogger({ context: true });
+    const ctx = createMockContext({
+      get: (field: string) => {
+        const headers: Record<string, string> = {
+          "x-request-id": "request-123",
+          "user-agent": "test-agent/1.0",
+        };
+        return headers[field.toLowerCase()] ?? "";
+      },
+    });
+
+    await runMiddleware(middleware, ctx, () => {
+      appLogger.info("Handled request");
+      return Promise.resolve();
+    });
+
+    assert.strictEqual(ctx.responseHeaders["x-request-id"], "request-123");
+    assert.strictEqual(logs.length, 2);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "request-123");
+    assert.strictEqual(logs[1].properties.requestId, "request-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("koaLogger(): context true generates missing request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = koaLogger({
+      context: { requestId: { generate: () => "generated-123" } },
+    });
+    const ctx = createMockContext();
+
+    await runMiddleware(middleware, ctx);
+
+    assert.strictEqual(ctx.responseHeaders["x-request-id"], "generated-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "generated-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("koaLogger(): context keeps implicit context when skipped", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const appLogger = getLogger(["app"]);
+    const middleware = koaLogger({
+      context: { requestId: { generate: () => "skip-123" } },
+      skip: () => true,
+    });
+    const ctx = createMockContext();
+
+    await runMiddleware(middleware, ctx, () => {
+      appLogger.info("Handled skipped request");
+      return Promise.resolve();
+    });
+
+    assert.strictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["app"]);
+    assert.strictEqual(logs[0].properties.requestId, "skip-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("koaLogger(): context works with logRequest", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = koaLogger({
+      context: { requestId: { generate: () => "immediate-123" } },
+      logRequest: true,
+    });
+    const ctx = createMockContext();
+
+    await runMiddleware(middleware, ctx);
+
+    assert.strictEqual(ctx.responseHeaders["x-request-id"], "immediate-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.requestId, "immediate-123");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("koaLogger(): missing context storage still logs request ID", async () => {
+  const { logs, cleanup } = await setupLogtape({ includeMeta: true });
+  try {
+    const appLogger = getLogger(["app"]);
+    const middleware = koaLogger({
+      context: { requestId: { generate: () => "no-storage-123" } },
+    });
+    const ctx = createMockContext();
+
+    await runMiddleware(middleware, ctx, () => {
+      appLogger.info("Handled request");
+      return Promise.resolve();
+    });
+
+    const appLog = logs.find((record) => record.category[0] === "app");
+    const requestLog = logs.find((record) => record.category[0] === "koa");
+    const metaLog = logs.find((record) =>
+      record.category[0] === "logtape" && record.category[1] === "meta" &&
+      record.level === "warning"
+    );
+    assert.ok(appLog);
+    assert.ok(requestLog);
+    assert.ok(metaLog);
+    assert.strictEqual(appLog.properties.requestId, undefined);
+    assert.strictEqual(requestLog.properties.requestId, "no-storage-123");
+    assert.strictEqual(metaLog.level, "warning");
   } finally {
     await cleanup();
   }

--- a/packages/koa/src/mod.test.ts
+++ b/packages/koa/src/mod.test.ts
@@ -537,6 +537,47 @@ test("koaLogger(): context true generates missing request ID", async () => {
   }
 });
 
+test("koaLogger(): context supports custom options", async () => {
+  const { logs, cleanup } = await setupLogtape({
+    contextLocalStorage: true,
+  });
+  try {
+    const middleware = koaLogger({
+      context: {
+        requestId: {
+          property: "correlationId",
+          headerNames: ["x-correlation-id", "x-request-id"],
+          responseHeader: "x-correlation-id",
+          normalize: (value) => value.trim().toUpperCase(),
+        },
+        include: ["requestId", "method", "path", "remoteAddr"],
+        enrich: (ctx) => ({ route: ctx.path }),
+      },
+    });
+    const ctx = createMockContext({
+      ip: "203.0.113.1",
+      get: (field: string) => {
+        const headers: Record<string, string> = {
+          "x-correlation-id": " custom-123 ",
+        };
+        return headers[field.toLowerCase()] ?? "";
+      },
+    });
+
+    await runMiddleware(middleware, ctx);
+
+    assert.strictEqual(ctx.responseHeaders["x-correlation-id"], "CUSTOM-123");
+    assert.strictEqual(logs.length, 1);
+    assert.strictEqual(logs[0].properties.correlationId, "CUSTOM-123");
+    assert.strictEqual(logs[0].properties.method, "GET");
+    assert.strictEqual(logs[0].properties.path, "/test");
+    assert.strictEqual(logs[0].properties.remoteAddr, "203.0.113.1");
+    assert.strictEqual(logs[0].properties.route, "/test");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("koaLogger(): context keeps implicit context when skipped", async () => {
   const { logs, cleanup } = await setupLogtape({
     contextLocalStorage: true,

--- a/packages/koa/src/mod.ts
+++ b/packages/koa/src/mod.ts
@@ -1,4 +1,4 @@
-import { getLogger, type LogLevel } from "@logtape/logtape";
+import { getLogger, type LogLevel, withContext } from "@logtape/logtape";
 
 export type { LogLevel } from "@logtape/logtape";
 
@@ -31,6 +31,12 @@ export interface KoaContext {
    * @returns The header value, or an empty string if not present.
    */
   get(field: string): string;
+  /**
+   * Set a response header field value.
+   * @param field The header field name.
+   * @param value The header field value.
+   */
+  set?(field: string, value: string): void;
 }
 
 /**
@@ -84,6 +90,81 @@ export interface RequestLogProperties {
   userAgent: string | undefined;
   /** Referrer header value */
   referrer: string | undefined;
+}
+
+/**
+ * Request fields that can be added to the implicit request context.
+ * @since 2.2.0
+ */
+export type RequestContextField =
+  | "requestId"
+  | "method"
+  | "url"
+  | "path"
+  | "userAgent"
+  | "remoteAddr"
+  | "referrer";
+
+/**
+ * Options for extracting, generating, and propagating a request ID.
+ * @since 2.2.0
+ */
+export interface RequestIdOptions {
+  /**
+   * The property name used in implicit context and request log records.
+   * @default "requestId"
+   */
+  readonly property?: string;
+
+  /**
+   * Incoming request headers to inspect in order.
+   * @default ["x-request-id"]
+   */
+  readonly headerNames?: readonly string[];
+
+  /**
+   * Response header that receives the resolved request ID.
+   * Set to `false` to disable response header propagation.
+   * @default "x-request-id"
+   */
+  readonly responseHeader?: string | false;
+
+  /**
+   * Generates a request ID when no incoming header is present.
+   * @default crypto.randomUUID()
+   */
+  readonly generate?: () => string;
+
+  /**
+   * Normalizes an incoming request ID.  Return `null` to reject the value and
+   * keep looking for another header or generate a new ID.
+   */
+  readonly normalize?: (value: string) => string | null;
+}
+
+/**
+ * Options for request-scoped implicit context.
+ * @since 2.2.0
+ */
+export interface RequestContextOptions {
+  /**
+   * Enables request ID extraction, generation, and response propagation.
+   * @default true
+   */
+  readonly requestId?: boolean | RequestIdOptions;
+
+  /**
+   * Fields to add to the implicit context.
+   * @default ["requestId"]
+   */
+  readonly include?: readonly RequestContextField[];
+
+  /**
+   * Adds application-specific fields to the implicit request context.
+   */
+  readonly enrich?: (
+    ctx: KoaContext,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
 }
 
 /**
@@ -143,6 +224,87 @@ export interface KoaLogTapeOptions {
    * @default false
    */
   readonly logRequest?: boolean;
+
+  /**
+   * Enables request-scoped implicit context and request ID correlation.
+   *
+   * When set to `true`, the middleware reads the `x-request-id` header,
+   * generates one when it is absent, writes it to the `x-request-id` response
+   * header, and adds `requestId` to all LogTape records emitted while handling
+   * the request.
+   *
+   * @default false
+   * @since 2.2.0
+   */
+  readonly context?: boolean | RequestContextOptions;
+}
+
+const defaultRequestIdHeader = "x-request-id";
+
+/**
+ * Normalize request context options.
+ */
+function normalizeRequestContextOptions(
+  options: boolean | RequestContextOptions | undefined,
+): RequestContextOptions | undefined {
+  if (options === true) return {};
+  if (options === false || options == null) return undefined;
+  return options;
+}
+
+/**
+ * Normalize request ID options.
+ */
+function normalizeRequestIdOptions(
+  options: boolean | RequestIdOptions | undefined,
+): RequestIdOptions | undefined {
+  if (options === false) return undefined;
+  if (options === true || options == null) return {};
+  return options;
+}
+
+/**
+ * Generate a request ID with Web Crypto when possible.
+ */
+function generateRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Normalize an incoming request ID.
+ */
+function defaultNormalizeRequestId(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Resolve the request ID for a request.
+ */
+function resolveRequestId(
+  ctx: KoaContext,
+  options: RequestIdOptions,
+): { property: string; value: string } {
+  const property = options.property ?? "requestId";
+  const normalize = options.normalize ?? defaultNormalizeRequestId;
+  const headerNames = options.headerNames ?? [defaultRequestIdHeader];
+  for (const headerName of headerNames) {
+    const headerValue = ctx.get(headerName);
+    if (headerValue === "") continue;
+    const normalized = normalize(headerValue);
+    if (normalized != null) {
+      const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+      if (responseHeader !== false) ctx.set?.(responseHeader, normalized);
+      return { property, value: normalized };
+    }
+  }
+  const generated = (options.generate ?? generateRequestId)();
+  const responseHeader = options.responseHeader ?? defaultRequestIdHeader;
+  if (responseHeader !== false) ctx.set?.(responseHeader, generated);
+  return { property, value: generated };
 }
 
 /**
@@ -196,6 +358,77 @@ function buildProperties(
     userAgent: getUserAgent(ctx),
     referrer: getReferrer(ctx),
   };
+}
+
+/**
+ * Build request context fields from a request.
+ */
+function buildIncludedContext(
+  ctx: KoaContext,
+  resolvedRequestId: { property: string; value: string } | undefined,
+  include: readonly RequestContextField[],
+): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const field of include) {
+    switch (field) {
+      case "requestId":
+        if (resolvedRequestId != null) {
+          context[resolvedRequestId.property] = resolvedRequestId.value;
+        }
+        break;
+      case "method":
+        context.method = ctx.method;
+        break;
+      case "url":
+        context.url = ctx.url;
+        break;
+      case "path":
+        context.path = ctx.path;
+        break;
+      case "userAgent":
+        context.userAgent = getUserAgent(ctx);
+        break;
+      case "remoteAddr":
+        context.remoteAddr = getRemoteAddr(ctx);
+        break;
+      case "referrer":
+        context.referrer = getReferrer(ctx);
+        break;
+    }
+  }
+  return context;
+}
+
+/**
+ * Build the implicit context for a request.
+ */
+async function buildRequestContext(
+  ctx: KoaContext,
+  options: RequestContextOptions,
+): Promise<Record<string, unknown>> {
+  const requestIdOptions = normalizeRequestIdOptions(options.requestId);
+  const resolvedRequestId = requestIdOptions == null
+    ? undefined
+    : resolveRequestId(ctx, requestIdOptions);
+  const include = options.include ??
+    (resolvedRequestId == null ? [] : ["requestId"] as const);
+  const context = buildIncludedContext(ctx, resolvedRequestId, include);
+  if (options.enrich == null) return context;
+  return {
+    ...context,
+    ...await options.enrich(ctx),
+  };
+}
+
+/**
+ * Add request context fields to a request log result.
+ */
+function withRequestLogContext(
+  result: string | Record<string, unknown>,
+  context: Record<string, unknown>,
+): string | Record<string, unknown> {
+  if (typeof result === "string") return result;
+  return { ...result, ...context };
 }
 
 /**
@@ -350,6 +583,7 @@ export function koaLogger(
   const formatOption = options.format ?? "combined";
   const skip = options.skip ?? (() => false);
   const logRequest = options.logRequest ?? false;
+  const contextOptions = normalizeRequestContextOptions(options.context);
 
   // Resolve format function
   const formatFn: FormatFunction = typeof formatOption === "string"
@@ -361,32 +595,50 @@ export function koaLogger(
   return async (ctx: KoaContext, next: () => Promise<void>): Promise<void> => {
     const startTime = Date.now();
 
-    // For immediate logging, log when request arrives
-    if (logRequest) {
-      if (!skip(ctx)) {
-        const result = formatFn(ctx, 0);
-        if (typeof result === "string") {
-          logMethod(result);
-        } else {
-          logMethod("{method} {url}", result);
+    const handleRequest = async (
+      requestContext: Record<string, unknown>,
+    ): Promise<void> => {
+      // For immediate logging, log when request arrives
+      if (logRequest) {
+        if (!skip(ctx)) {
+          const result = withRequestLogContext(
+            formatFn(ctx, 0),
+            requestContext,
+          );
+          if (typeof result === "string") {
+            logMethod(result, requestContext);
+          } else {
+            logMethod("{method} {url}", result);
+          }
         }
+        await next();
+        return;
       }
+
+      // Log after response is sent
       await next();
+
+      if (skip(ctx)) return;
+
+      const responseTime = Date.now() - startTime;
+      const result = withRequestLogContext(
+        formatFn(ctx, responseTime),
+        requestContext,
+      );
+
+      if (typeof result === "string") {
+        logMethod(result, requestContext);
+      } else {
+        logMethod("{method} {url} {status} - {responseTime} ms", result);
+      }
+    };
+
+    if (contextOptions == null) {
+      await handleRequest({});
       return;
     }
 
-    // Log after response is sent
-    await next();
-
-    if (skip(ctx)) return;
-
-    const responseTime = Date.now() - startTime;
-    const result = formatFn(ctx, responseTime);
-
-    if (typeof result === "string") {
-      logMethod(result);
-    } else {
-      logMethod("{method} {url} {status} - {responseTime} ms", result);
-    }
+    const requestContext = await buildRequestContext(ctx, contextOptions);
+    await withContext(requestContext, () => handleRequest(requestContext));
   };
 }


### PR DESCRIPTION
This adds opt-in request context support to the Express, Hono, Koa, and Elysia integrations.  `context: true` resolves a request ID from `x-request-id` or `crypto.randomUUID()`, propagates it through the response header, adds `requestId` to request completion logs, and shares the same value with application logs when `contextLocalStorage` is configured.

The new `RequestContextOptions` surface lets callers customize request ID lookup/normalization, response header propagation, included request fields, and async enrichment.  The implementation preserves existing `skip` behavior, keeps Elysia's local scope isolated, and handles Hono handlers that return raw `Response` objects.

Documentation was updated in *docs/manual/contexts.md*, *docs/manual/integrations.md*, *packages/express/README.md*, *packages/hono/README.md*, *packages/koa/README.md*, *packages/elysia/README.md*, and *CHANGES.md*.

Closes #172.