### PR TITLE
Official LogTape testing utilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,8 +33,6 @@ To be released.
         timestamp, and regular expression matcher values match string property
         values.
      -  Added `PropertyMatcher` type for custom property matching.
-     -  Improved failure diagnostics for `Map` and `Set` property values so
-        they show collection sizes and serializable contents.
 
 [#173]: https://github.com/dahlia/logtape/issues/173
 [#175]: https://github.com/dahlia/logtape/pull/175

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,8 @@ To be released.
         `assertNotLogged()`.
      -  Added `LogRecordMatch` interface for matching category, category
         prefix, level, rendered message, raw message, structured properties,
-        and custom predicates.
+        and custom predicates.  `Date` property values are matched by
+        timestamp.
      -  Added `PropertyMatcher` type for custom property matching.
 
 [#173]: https://github.com/dahlia/logtape/issues/173

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,23 @@ To be released.
 
 [implicit context]: https://logtape.org/manual/contexts#implicit-contexts
 
+### @logtape/testing
+
+ -  New package *@logtape/testing* providing testing utilities for collecting
+    and asserting LogTape records in memory.  [[#173], [#175]]
+
+     -  Added `createLogRecorder(): LogRecorder`.
+     -  Added `LogRecorder` interface with `sink`, `records`, `clear()`,
+        `take()`, `find()`, `filter()`, `assertLogged()`, and
+        `assertNotLogged()`.
+     -  Added `LogRecordMatch` interface for matching category, category
+        prefix, level, rendered message, raw message, structured properties,
+        and custom predicates.
+     -  Added `PropertyMatcher` type for custom property matching.
+
+[#173]: https://github.com/dahlia/logtape/issues/173
+[#175]: https://github.com/dahlia/logtape/pull/175
+
 ### @logtape/elysia, @logtape/express, @logtape/hono, and @logtape/koa
 
  -  Added opt-in request-scoped context support to `elysiaLogger()`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@ To be released.
         timestamp, and regular expression matcher values match string property
         values.
      -  Added `PropertyMatcher` type for custom property matching.
+     -  Improved failure diagnostics for `Map` and `Set` property values so
+        they show collection sizes and serializable contents.
 
 [#173]: https://github.com/dahlia/logtape/issues/173
 [#175]: https://github.com/dahlia/logtape/pull/175

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,8 @@ To be released.
      -  Added `LogRecordMatch` interface for matching category, category
         prefix, level, rendered message, raw message, structured properties,
         and custom predicates.  `Date` property values are matched by
-        timestamp.
+        timestamp, and regular expression matcher values match string property
+        values.
      -  Added `PropertyMatcher` type for custom property matching.
 
 [#173]: https://github.com/dahlia/logtape/issues/173

--- a/deno.json
+++ b/deno.json
@@ -18,6 +18,7 @@
     "./packages/redaction",
     "./packages/sentry",
     "./packages/syslog",
+    "./packages/testing",
     "./packages/cloudwatch-logs",
     "./packages/config",
     "./packages/windows-eventlog",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,6 +36,7 @@ const jsrRefPackages: readonly (readonly [string, string])[] = [
   ["@logtape/redaction", ".jsr-cache-redaction.json"],
   ["@logtape/sentry", ".jsr-cache-sentry.json"],
   ["@logtape/syslog", ".jsr-cache-syslog.json"],
+  ["@logtape/testing", ".jsr-cache-testing.json"],
   ["@logtape/windows-eventlog", ".jsr-cache-windows-eventlog.json"],
 ];
 
@@ -183,6 +184,10 @@ const REFERENCES = {
     },
     { text: "@logtape/sentry", link: "https://jsr.io/@logtape/sentry/doc" },
     { text: "@logtape/syslog", link: "https://jsr.io/@logtape/syslog/doc" },
+    {
+      text: "@logtape/testing",
+      link: "https://jsr.io/@logtape/testing/doc",
+    },
     {
       text: "@logtape/windows-eventlog",
       link: "https://jsr.io/@logtape/windows-eventlog/doc",

--- a/docs/manual/library.md
+++ b/docs/manual/library.md
@@ -95,6 +95,48 @@ export class Database {
 }
 ~~~~
 
+### Testing library logs
+
+When logs are part of your library's observable behavior, test them alongside
+the public API with [*@logtape/testing*]:
+
+~~~~ typescript twoslash
+// @noErrors: 2307
+import { configure, reset } from "@logtape/logtape";
+import { createLogRecorder } from "@logtape/testing";
+import { Database } from "my-awesome-lib";
+
+const recorder = createLogRecorder();
+
+try {
+  await configure({
+    sinks: { recorder: recorder.sink },
+    loggers: [
+      {
+        category: ["my-awesome-lib"],
+        lowestLevel: "debug",
+        sinks: ["recorder"],
+      },
+      { category: ["logtape", "meta"], sinks: [] },
+    ],
+  });
+
+  const db = new Database("localhost", 5432, "user");
+  db.query("SELECT * FROM users");
+
+  recorder.assertLogged({
+    categoryPrefix: ["my-awesome-lib"],
+    level: "debug",
+    message: /Executing query/,
+    properties: { sql: "SELECT * FROM users" },
+  });
+} finally {
+  await reset();
+}
+~~~~
+
+[*@logtape/testing*]: ./testing.md
+
 
 For application developers
 --------------------------

--- a/docs/manual/library.md
+++ b/docs/manual/library.md
@@ -97,6 +97,8 @@ export class Database {
 
 ### Testing library logs
 
+*This API is available since LogTape 2.2.0.*
+
 When logs are part of your library's observable behavior, test them alongside
 the public API with [*@logtape/testing*]:
 

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -106,10 +106,11 @@ The recorder stores records in sink call order.  It provides `records`,
 `clear()`, `take()`, `find()`, `filter()`, `assertLogged()`, and
 `assertNotLogged()`.  Matchers can check category, category prefix, level,
 rendered message, raw message, and a shallow partial set of structured
-properties.  Most property values are compared with `Object.is()`, while
-`Date` values are compared by timestamp.  Rendered message matching uses the
-same value rendering as LogTape's default text formatter.  Use a property
-predicate when a test needs absence checks or deep matching.
+properties.  Most property values are compared with `Object.is()`, `Date`
+values are compared by timestamp, and regular expression matcher values match
+string property values.  Rendered message matching uses the same value
+rendering as LogTape's default text formatter.  Use a property predicate when
+a test needs absence checks or deep matching.
 
 `createLogRecorder()` is a synchronous sink.  If a log call uses async lazy
 properties, await the log call before asserting.  If your test also uses async

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -59,6 +59,8 @@ describe("my test", async (t) => {
 Log recorder
 ------------
 
+*This API is available since LogTape 2.2.0.*
+
 For testing purposes, you may want to collect log records in memory and assert
 on them.  The [*@logtape/testing*] package provides `createLogRecorder()` for
 this:

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -106,9 +106,10 @@ The recorder stores records in sink call order.  It provides `records`,
 `clear()`, `take()`, `find()`, `filter()`, `assertLogged()`, and
 `assertNotLogged()`.  Matchers can check category, category prefix, level,
 rendered message, raw message, and a shallow partial set of structured
-properties.  Rendered message matching uses the same value rendering as
-LogTape's default text formatter.  Use a property predicate when a test needs
-absence checks or deep matching.
+properties.  Most property values are compared with `Object.is()`, while
+`Date` values are compared by timestamp.  Rendered message matching uses the
+same value rendering as LogTape's default text formatter.  Use a property
+predicate when a test needs absence checks or deep matching.
 
 `createLogRecorder()` is a synchronous sink.  If a log call uses async lazy
 properties, await the log call before asserting.  If your test also uses async

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -56,11 +56,69 @@ describe("my test", async (t) => {
 :::
 
 
+Log recorder
+------------
+
+For testing purposes, you may want to collect log records in memory and assert
+on them.  The [*@logtape/testing*] package provides `createLogRecorder()` for
+this:
+
+~~~~ typescript twoslash
+// @noErrors: 2345
+import { configure, getLogger, reset } from "@logtape/logtape";
+import { createLogRecorder } from "@logtape/testing";
+
+const recorder = createLogRecorder();
+
+try {
+  await configure({
+    sinks: {
+      recorder: recorder.sink,  // [!code highlight]
+    },
+    loggers: [
+      {
+        category: ["my-lib"],
+        lowestLevel: "debug",
+        sinks: ["recorder"],
+      },
+      { category: ["logtape", "meta"], sinks: [] },
+    ],
+  });
+
+  getLogger(["my-lib"]).info("User {userId} logged in.", {
+    userId: "u-123",
+  });
+
+  recorder.assertLogged({  // [!code highlight]
+    category: ["my-lib"],
+    level: "info",
+    message: "User u-123 logged in.",
+    properties: { userId: "u-123" },
+  });
+} finally {
+  await reset();
+}
+~~~~
+
+The recorder stores records in sink call order.  It provides `records`,
+`clear()`, `take()`, `find()`, `filter()`, `assertLogged()`, and
+`assertNotLogged()`.  Matchers can check category, category prefix, level,
+rendered message, raw message, and a shallow partial set of structured
+properties.  Use a property predicate when a test needs absence checks or deep
+matching.
+
+`createLogRecorder()` is a synchronous sink.  If a log call uses async lazy
+properties, await the log call before asserting.  If your test also uses async
+sinks, still call `await dispose()` or `await reset()` as usual.
+
+[*@logtape/testing*]: https://jsr.io/@logtape/testing
+
+
 Buffer sink
 -----------
 
-For testing purposes, you may want to collect log messages in memory.  Although
-LogTape does not provide a built-in buffer sink, you can easily implement it:
+For very small tests that only need raw `LogRecord` objects, you can still
+implement a buffer sink directly:
 
 ~~~~ typescript twoslash
 // @noErrors: 2345

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -102,16 +102,17 @@ try {
 }
 ~~~~
 
-The recorder stores records in sink call order.  The `records` property
-returns a snapshot, and the recorder also provides `clear()`, `take()`,
-`find()`, `filter()`, `assertLogged()`, and `assertNotLogged()`.  Matchers can
-check category, category prefix, level, rendered message, raw message, and a
-shallow partial set of structured properties.  Most property values are
-compared with `Object.is()`, `Date` values are compared by timestamp, and
-regular expression matcher values match string property values.  Rendered
-message matching uses the same value rendering as LogTape's default text
-formatter.  Use a property predicate when a test needs absence checks or deep
-matching.
+The recorder stores records in sink call order.  It snapshots lazy callback
+messages when the sink receives them, so assertions see the same message a
+normal sink would observe at emit time.  The `records` property returns a
+snapshot, and the recorder also provides `clear()`, `take()`, `find()`,
+`filter()`, `assertLogged()`, and `assertNotLogged()`.  Matchers can check
+category, category prefix, level, rendered message, raw message, and a shallow
+partial set of structured properties.  Most property values are compared with
+`Object.is()`, `Date` values are compared by timestamp, and regular expression
+matcher values match string property values.  Rendered message matching uses
+the same value rendering as LogTape's default text formatter.  Use a property
+predicate when a test needs absence checks or deep matching.
 
 `createLogRecorder()` is a synchronous sink.  If a log call uses async lazy
 properties, await the log call before asserting.  If your test also uses async

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -66,7 +66,7 @@ on them.  The [*@logtape/testing*] package provides `createLogRecorder()` for
 this:
 
 ~~~~ typescript twoslash
-// @noErrors: 2345
+// @noErrors: 2307
 import { configure, getLogger, reset } from "@logtape/logtape";
 import { createLogRecorder } from "@logtape/testing";
 
@@ -88,14 +88,14 @@ try {
   });
 
   getLogger(["my-lib"]).info("User {userId} logged in.", {
-    userId: "u-123",
+    userId: 123,
   });
 
   recorder.assertLogged({  // [!code highlight]
     category: ["my-lib"],
     level: "info",
-    message: "User u-123 logged in.",
-    properties: { userId: "u-123" },
+    message: "User 123 logged in.",
+    properties: { userId: 123 },
   });
 } finally {
   await reset();
@@ -106,8 +106,9 @@ The recorder stores records in sink call order.  It provides `records`,
 `clear()`, `take()`, `find()`, `filter()`, `assertLogged()`, and
 `assertNotLogged()`.  Matchers can check category, category prefix, level,
 rendered message, raw message, and a shallow partial set of structured
-properties.  Use a property predicate when a test needs absence checks or deep
-matching.
+properties.  Rendered message matching uses the same value rendering as
+LogTape's default text formatter.  Use a property predicate when a test needs
+absence checks or deep matching.
 
 `createLogRecorder()` is a synchronous sink.  If a log call uses async lazy
 properties, await the log call before asserting.  If your test also uses async

--- a/docs/manual/testing.md
+++ b/docs/manual/testing.md
@@ -102,15 +102,16 @@ try {
 }
 ~~~~
 
-The recorder stores records in sink call order.  It provides `records`,
-`clear()`, `take()`, `find()`, `filter()`, `assertLogged()`, and
-`assertNotLogged()`.  Matchers can check category, category prefix, level,
-rendered message, raw message, and a shallow partial set of structured
-properties.  Most property values are compared with `Object.is()`, `Date`
-values are compared by timestamp, and regular expression matcher values match
-string property values.  Rendered message matching uses the same value
-rendering as LogTape's default text formatter.  Use a property predicate when
-a test needs absence checks or deep matching.
+The recorder stores records in sink call order.  The `records` property
+returns a snapshot, and the recorder also provides `clear()`, `take()`,
+`find()`, `filter()`, `assertLogged()`, and `assertNotLogged()`.  Matchers can
+check category, category prefix, level, rendered message, raw message, and a
+shallow partial set of structured properties.  Most property values are
+compared with `Object.is()`, `Date` values are compared by timestamp, and
+regular expression matcher values match string property values.  Rendered
+message matching uses the same value rendering as LogTape's default text
+formatter.  Use a property predicate when a test needs absence checks or deep
+matching.
 
 `createLogRecorder()` is a synchronous sink.  If a log call uses async lazy
 properties, await the log call before asserting.  If your test also uses async

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "@logtape/redaction": "workspace:",
     "@logtape/sentry": "workspace:",
     "@logtape/syslog": "workspace:",
+    "@logtape/testing": "workspace:",
     "@logtape/windows-eventlog": "workspace:",
     "@opentelemetry/exporter-logs-otlp-http": "catalog:",
     "@opentelemetry/resources": "catalog:",

--- a/packages/logtape/README.md
+++ b/packages/logtape/README.md
@@ -125,6 +125,7 @@ list of the packages in the LogTape monorepo:
 | [*@logtape/redaction*](/packages/redaction/)               | [JSR][jsr:@logtape/redaction]        | [npm][npm:@logtape/redaction]        | Data redaction                |
 | [*@logtape/sentry*](/packages/sentry/)                     | [JSR][jsr:@logtape/sentry]           | [npm][npm:@logtape/sentry]           | [Sentry] sink                 |
 | [*@logtape/syslog*](/packages/syslog/)                     | [JSR][jsr:@logtape/syslog]           | [npm][npm:@logtape/syslog]           | Syslog sink                   |
+| [*@logtape/testing*](/packages/testing/)                   | [JSR][jsr:@logtape/testing]          | [npm][npm:@logtape/testing]          | Testing utilities             |
 | [*@logtape/windows-eventlog*](/packages/windows-eventlog/) | [JSR][jsr:@logtape/windows-eventlog] | [npm][npm:@logtape/windows-eventlog] | Windows Event Log sink        |
 
 [jsr:@logtape/logtape]: https://jsr.io/@logtape/logtape
@@ -175,6 +176,8 @@ list of the packages in the LogTape monorepo:
 [Sentry]: https://sentry.io/
 [jsr:@logtape/syslog]: https://jsr.io/@logtape/syslog
 [npm:@logtape/syslog]: https://www.npmjs.com/package/@logtape/syslog
+[jsr:@logtape/testing]: https://jsr.io/@logtape/testing
+[npm:@logtape/testing]: https://www.npmjs.com/package/@logtape/testing
 [jsr:@logtape/windows-eventlog]: https://jsr.io/@logtape/windows-eventlog
 [npm:@logtape/windows-eventlog]: https://www.npmjs.com/package/@logtape/windows-eventlog
 

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -503,7 +503,7 @@ try {
   recorder.assertLogged({
     category: "test",
     level: "info",
-    message: "User u-123 logged in.",
+    message: /^User .+ logged in\.$/,
     properties: { userId: "u-123" },
   });
 } finally {

--- a/packages/logtape/skills/logtape/SKILL.md
+++ b/packages/logtape/skills/logtape/SKILL.md
@@ -480,26 +480,35 @@ See <https://logtape.org/manual/adaptors.md> for details.
 Testing
 -------
 
-For tests, configure a buffer sink and assert on collected records:
+For tests, use `@logtape/testing` and assert on collected records:
 
 ~~~~ typescript
-import { configure, getLogger, reset, type LogRecord } from "@logtape/logtape";
+import { configure, getLogger, reset } from "@logtape/logtape";
+import { createLogRecorder } from "@logtape/testing";
 
-const buffer: LogRecord[] = [];
+const recorder = createLogRecorder();
 
-await configure({
-  sinks: { buffer: buffer.push.bind(buffer) },
-  loggers: [{ category: "test", sinks: ["buffer"] }],
-});
+try {
+  await configure({
+    sinks: { recorder: recorder.sink },
+    loggers: [
+      { category: "test", sinks: ["recorder"] },
+      { category: ["logtape", "meta"], sinks: [] },
+    ],
+  });
 
-const logger = getLogger(["test"]);
-logger.info("hello");
+  const logger = getLogger(["test"]);
+  logger.info("User {userId} logged in.", { userId: "u-123" });
 
-// Assert
-assert(buffer.length === 1);
-assert(buffer[0].level === "info");
-
-await reset();
+  recorder.assertLogged({
+    category: "test",
+    level: "info",
+    message: "User u-123 logged in.",
+    properties: { userId: "u-123" },
+  });
+} finally {
+  await reset();
+}
 ~~~~
 
 If using `configureSync()`, reset with `resetSync()`:
@@ -549,6 +558,12 @@ Available packages
 | -------------------- | ------------------------ |
 | `@logtape/pretty`    | Pretty console formatter |
 | `@logtape/redaction` | Sensitive data redaction |
+
+### Testing
+
+| Package            | Description                  |
+| ------------------ | ---------------------------- |
+| `@logtape/testing` | Log recording and assertions |
 
 ### Adaptors (for existing loggers)
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -68,7 +68,9 @@ try {
 }
 ~~~~
 
-The `records` property returns a snapshot, and the recorder also provides
+The recorder snapshots lazy callback messages when its sink receives them, so
+assertions see the same message a normal sink would observe at emit time.  The
+`records` property returns a snapshot, and the recorder also provides
 `clear()`, `take()`, `find()`, `filter()`, and `assertNotLogged()` for tests
 that need lower-level access.  Most property values are compared with
 `Object.is()`, `Date` values are compared by timestamp, and regular expression

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -54,14 +54,14 @@ try {
   });
 
   getLogger(["my-lib"]).info("User {userId} logged in.", {
-    userId: "u-123",
+    userId: 123,
   });
 
   recorder.assertLogged({
     category: ["my-lib"],
     level: "info",
-    message: "User u-123 logged in.",
-    properties: { userId: "u-123" },
+    message: "User 123 logged in.",
+    properties: { userId: 123 },
   });
 } finally {
   await reset();
@@ -70,6 +70,8 @@ try {
 
 The recorder also provides `records`, `clear()`, `take()`, `find()`,
 `filter()`, and `assertNotLogged()` for tests that need lower-level access.
+Rendered message matching uses the same value rendering as LogTape's default
+text formatter.
 
 
 Docs

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -70,8 +70,9 @@ try {
 
 The recorder also provides `records`, `clear()`, `take()`, `find()`,
 `filter()`, and `assertNotLogged()` for tests that need lower-level access.
-Rendered message matching uses the same value rendering as LogTape's default
-text formatter.
+Most property values are compared with `Object.is()`, while `Date` values are
+compared by timestamp.  Rendered message matching uses the same value rendering
+as LogTape's default text formatter.
 
 
 Docs

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -68,12 +68,12 @@ try {
 }
 ~~~~
 
-The recorder also provides `records`, `clear()`, `take()`, `find()`,
-`filter()`, and `assertNotLogged()` for tests that need lower-level access.
-Most property values are compared with `Object.is()`, `Date` values are
-compared by timestamp, and regular expression matcher values match string
-property values.  Rendered message matching uses the same value rendering as
-LogTape's default text formatter.
+The `records` property returns a snapshot, and the recorder also provides
+`clear()`, `take()`, `find()`, `filter()`, and `assertNotLogged()` for tests
+that need lower-level access.  Most property values are compared with
+`Object.is()`, `Date` values are compared by timestamp, and regular expression
+matcher values match string property values.  Rendered message matching uses
+the same value rendering as LogTape's default text formatter.
 
 
 Docs

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -70,9 +70,10 @@ try {
 
 The recorder also provides `records`, `clear()`, `take()`, `find()`,
 `filter()`, and `assertNotLogged()` for tests that need lower-level access.
-Most property values are compared with `Object.is()`, while `Date` values are
-compared by timestamp.  Rendered message matching uses the same value rendering
-as LogTape's default text formatter.
+Most property values are compared with `Object.is()`, `Date` values are
+compared by timestamp, and regular expression matcher values match string
+property values.  Rendered message matching uses the same value rendering as
+LogTape's default text formatter.
 
 
 Docs

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,80 @@
+<!-- deno-fmt-ignore-file -->
+
+Testing utilities for LogTape
+=============================
+
+[![JSR][JSR badge]][JSR]
+[![npm][npm badge]][npm]
+
+This package provides testing utilities for [LogTape].  It includes a log
+recorder that collects `LogRecord` values in memory and provides matcher-based
+assertions for category, level, rendered message, raw message, and structured
+properties.
+
+[JSR badge]: https://jsr.io/badges/@logtape/testing
+[JSR]: https://jsr.io/@logtape/testing
+[npm badge]: https://img.shields.io/npm/v/@logtape/testing?logo=npm
+[npm]: https://www.npmjs.com/package/@logtape/testing
+[LogTape]: https://logtape.org/
+
+
+Installation
+------------
+
+This package is available on [JSR] and [npm].  You can install it for various
+JavaScript runtimes and package managers:
+
+~~~~ sh
+deno add jsr:@logtape/testing  # for Deno
+npm  add     @logtape/testing  # for npm
+pnpm add     @logtape/testing  # for pnpm
+yarn add     @logtape/testing  # for Yarn
+bun  add     @logtape/testing  # for Bun
+~~~~
+
+
+Usage
+-----
+
+Use `createLogRecorder()` as a sink in tests:
+
+~~~~ typescript
+import { configure, getLogger, reset } from "@logtape/logtape";
+import { createLogRecorder } from "@logtape/testing";
+
+const recorder = createLogRecorder();
+
+try {
+  await configure({
+    sinks: { recorder: recorder.sink },
+    loggers: [
+      { category: ["my-lib"], lowestLevel: "debug", sinks: ["recorder"] },
+      { category: ["logtape", "meta"], sinks: [] },
+    ],
+  });
+
+  getLogger(["my-lib"]).info("User {userId} logged in.", {
+    userId: "u-123",
+  });
+
+  recorder.assertLogged({
+    category: ["my-lib"],
+    level: "info",
+    message: "User u-123 logged in.",
+    properties: { userId: "u-123" },
+  });
+} finally {
+  await reset();
+}
+~~~~
+
+The recorder also provides `records`, `clear()`, `take()`, `find()`,
+`filter()`, and `assertNotLogged()` for tests that need lower-level access.
+
+
+Docs
+----
+
+The docs of this package is available at
+<https://logtape.org/manual/testing>. For the API references, see
+<https://jsr.io/@logtape/testing>.

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -1,0 +1,29 @@
+{
+  "name": "@logtape/testing",
+  "version": "2.2.0",
+  "license": "MIT",
+  "exports": "./src/mod.ts",
+  "tasks": {
+    "build": "pnpm build",
+    "test": "deno test",
+    "test:node": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "node --experimental-transform-types --test"
+    },
+    "test:bun": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "bun test"
+    },
+    "test-all": {
+      "dependencies": [
+        "test",
+        "test:node",
+        "test:bun"
+      ]
+    }
+  }
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@logtape/testing",
+  "version": "2.2.0",
+  "description": "Testing utilities for collecting and asserting LogTape records",
+  "keywords": [
+    "logging",
+    "log",
+    "logger",
+    "logtape",
+    "testing",
+    "test"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "Hong Minhee",
+    "email": "hong@minhee.org",
+    "url": "https://hongminhee.org/"
+  },
+  "homepage": "https://logtape.org/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dahlia/logtape.git",
+    "directory": "packages/testing/"
+  },
+  "bugs": {
+    "url": "https://github.com/dahlia/logtape/issues"
+  },
+  "funding": [
+    "https://github.com/sponsors/dahlia"
+  ],
+  "type": "module",
+  "module": "./dist/mod.js",
+  "main": "./dist/mod.cjs",
+  "types": "./dist/mod.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/mod.d.ts",
+        "require": "./dist/mod.d.cts"
+      },
+      "import": "./dist/mod.js",
+      "require": "./dist/mod.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist/"
+  ],
+  "peerDependencies": {
+    "@logtape/logtape": "workspace:^"
+  },
+  "devDependencies": {
+    "@logtape/redaction": "workspace:^",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "tsdown",
+    "prepublish": "tsdown",
+    "test": "tsdown && node --experimental-transform-types --test",
+    "test:bun": "tsdown && bun test",
+    "test:deno": "deno test",
+    "test-all": "tsdown && node --experimental-transform-types --test && bun test && deno test"
+  }
+}

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -170,6 +170,30 @@ test("LogRecorder handles nullish record properties", () => {
   );
 });
 
+test("LogRecorder diagnostics handle null-prototype circular values", () => {
+  const recorder = createLogRecorder();
+  const recordedValue = circularNullPrototypeObject();
+  const matcherValue = circularNullPrototypeObject();
+  recorder.sink(logRecord({
+    message: ["circular diagnostic value"],
+    properties: { recordedValue },
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ properties: { matcherValue } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Expected a LogTape record matching:/);
+      assert.match(
+        error.message,
+        /properties\.matcherValue: \[object Object\]/,
+      );
+      assert.match(error.message, /recordedValue: \[object Object\]/);
+      return true;
+    },
+  );
+});
+
 test("LogRecorder matches rendered object message values", () => {
   const recorder = createLogRecorder();
   const payload = { foo: "bar" };
@@ -416,4 +440,10 @@ function renderMessageWithCoreFormatter(record: LogRecord): string {
 
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function circularNullPrototypeObject(): Record<string, unknown> {
+  const value = Object.create(null) as Record<string, unknown>;
+  value.self = value;
+  return value;
 }

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -194,6 +194,31 @@ test("LogRecorder diagnostics handle null-prototype circular values", () => {
   );
 });
 
+test("LogRecorder diagnostics preserve non-finite numbers", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({
+    message: ["non-finite numbers"],
+    properties: { value: -Infinity },
+  }));
+
+  assert.throws(
+    () =>
+      recorder.assertLogged({
+        properties: { actual: NaN, expected: Infinity },
+      }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /properties\.actual: NaN/);
+      assert.match(error.message, /properties\.expected: Infinity/);
+      assert.match(error.message, /value: -Infinity/);
+      assert.doesNotMatch(error.message, /properties\.actual: null/);
+      assert.doesNotMatch(error.message, /properties\.expected: null/);
+      assert.doesNotMatch(error.message, /value: null/);
+      return true;
+    },
+  );
+});
+
 test("LogRecorder matches rendered object message values", () => {
   const recorder = createLogRecorder();
   const payload = { foo: "bar" };

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -284,6 +284,66 @@ test("LogRecorder diagnostics render nested BigInt and circular values", () => {
   );
 });
 
+test("LogRecorder diagnostics render nested Error values", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({
+    message: ["nested error diagnostic value"],
+    properties: {
+      payload: { error: new TypeError("Bad input") },
+      failuresById: new Map<unknown, unknown>([
+        ["job-1", new Error("Boom")],
+      ]),
+      failures: new Set<unknown>([new RangeError("Too high")]),
+    },
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ properties: { missing: true } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /payload: {"error":"TypeError: Bad input"}/,
+      );
+      assert.match(
+        error.message,
+        /failuresById: Map\(1\) {"job-1":"Error: Boom"}/,
+      );
+      assert.match(
+        error.message,
+        /failures: Set\(1\) \["RangeError: Too high"\]/,
+      );
+      assert.doesNotMatch(error.message, /payload: {"error":{}}/);
+      return true;
+    },
+  );
+});
+
+test("LogRecorder diagnostics handle throwing property getters", () => {
+  const recorder = createLogRecorder();
+  const properties: Record<string, unknown> = {};
+  Object.defineProperty(properties, "unstable", {
+    enumerable: true,
+    get() {
+      throw new Error("getter failed");
+    },
+  });
+  recorder.sink(logRecord({
+    message: ["throwing getter diagnostic value"],
+    properties,
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ properties: { missing: true } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Expected a LogTape record matching:/);
+      assert.match(error.message, /unstable: <error: getter failed>/);
+      return true;
+    },
+  );
+});
+
 test("LogRecorder diagnostics render Map and Set values", () => {
   const recorder = createLogRecorder();
   recorder.sink(logRecord({

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -167,6 +167,30 @@ test("LogRecorder matches Date property values by time", () => {
   );
 });
 
+test("LogRecorder matches string property values with regular expressions", () => {
+  const recorder = createLogRecorder();
+  const record = logRecord({
+    properties: { status: "completed", userId: "user-123" },
+  });
+  recorder.sink(record);
+
+  const userPattern = /^user-\d+$/g;
+  assert.strictEqual(userPattern.test("user-123"), true);
+  assert.strictEqual(
+    recorder.find({
+      properties: { userId: userPattern },
+    }),
+    record,
+  );
+  assert.strictEqual(userPattern.lastIndex, "user-123".length);
+  assert.strictEqual(
+    recorder.find({
+      properties: { status: /^failed$/ },
+    }),
+    undefined,
+  );
+});
+
 test("LogRecorder handles nullish record properties", () => {
   const recorder = createLogRecorder();
   const record = {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -733,6 +733,42 @@ test("LogRecorder snapshots lazy callback messages in the sink", async () => {
   }
 });
 
+test("LogRecorder preserves extra fields when snapshotting lazy messages", () => {
+  const recorder = createLogRecorder();
+  const contextKey = Symbol("context");
+  let userId = "alice";
+  const record = {
+    ...logRecord({
+      properties: { userId },
+      rawMessage: "User {userId} logged in.",
+    }),
+    requestId: "req-123",
+    [contextKey]: { traceId: "trace-123" },
+    get message(): readonly unknown[] {
+      return ["User ", userId, " logged in."];
+    },
+  } as LogRecord & {
+    readonly requestId: string;
+    readonly [contextKey]: { readonly traceId: string };
+  };
+
+  recorder.sink(record);
+  userId = "bob";
+
+  const snapshot = recorder.records[0] as LogRecord & {
+    readonly requestId?: string;
+    readonly [contextKey]?: { readonly traceId: string };
+  };
+  assert.notStrictEqual(snapshot, record);
+  assert.deepStrictEqual(snapshot.message, [
+    "User ",
+    "alice",
+    " logged in.",
+  ]);
+  assert.strictEqual(snapshot.requestId, "req-123");
+  assert.deepStrictEqual(snapshot[contextKey], { traceId: "trace-123" });
+});
+
 test("LogRecorder observes resolved lazy and redacted properties", async () => {
   const recorder = createLogRecorder();
   const sink = redactByField(recorder.sink, {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -37,6 +37,22 @@ test("createLogRecorder() stores records in order", () => {
   assert.deepStrictEqual(recorder.records, [first, second]);
 });
 
+test("LogRecorder.records returns snapshots", () => {
+  const recorder = createLogRecorder();
+  const record = logRecord({ message: ["snapshot"] });
+  recorder.sink(record);
+
+  const snapshot = recorder.records;
+  (recorder.records as LogRecord[]).pop();
+
+  assert.deepStrictEqual(recorder.records, [record]);
+
+  recorder.clear();
+
+  assert.deepStrictEqual(snapshot, [record]);
+  assert.deepStrictEqual(recorder.records, []);
+});
+
 test("LogRecorder.clear()", () => {
   const recorder = createLogRecorder();
   recorder.sink(logRecord({ message: ["before clear"] }));

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -290,6 +290,47 @@ test("LogRecorder diagnostics render Map and Set values", () => {
   );
 });
 
+test("LogRecorder diagnostics preserve Map entries with object keys", () => {
+  const recorder = createLogRecorder();
+  const nullPrototypeKey = Object.create(null) as Record<string, unknown>;
+  nullPrototypeKey.id = "primary";
+  const firstObjectKey = { id: "first" };
+  const secondObjectKey = { id: "second" };
+  recorder.sink(logRecord({
+    message: ["object key diagnostics"],
+    properties: {
+      distinctKeyMap: new Map<unknown, string>([
+        [nullPrototypeKey, "visible"],
+      ]),
+      collidingKeyMap: new Map<unknown, string>([
+        [firstObjectKey, "first"],
+        [secondObjectKey, "second"],
+      ]),
+    },
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ properties: { missing: true } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /distinctKeyMap: Map\(1\) {"\[object Object\]":"visible"}/,
+      );
+      assert.match(
+        error.message,
+        /collidingKeyMap: Map\(2\) \[\["\[object Object\]","first"\],\["\[object Object\]","second"\]\]/,
+      );
+      assert.doesNotMatch(error.message, /distinctKeyMap: Map\(1\)(?! )/);
+      assert.doesNotMatch(
+        error.message,
+        /collidingKeyMap: Map\(2\) {"\[object Object\]":"second"}/,
+      );
+      return true;
+    },
+  );
+});
+
 test("LogRecorder diagnostics preserve non-finite numbers", () => {
   const recorder = createLogRecorder();
   recorder.sink(logRecord({

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -1,3 +1,6 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
 import {
   configure,
   getLogger,
@@ -7,8 +10,7 @@ import {
   type Sink,
 } from "@logtape/logtape";
 import { redactByField } from "@logtape/redaction";
-import assert from "node:assert/strict";
-import test from "node:test";
+
 import {
   createLogRecorder,
   type LogRecordMatch,
@@ -100,6 +102,17 @@ test("LogRecorder.find() and LogRecorder.filter()", () => {
     dbRecord,
   ]);
   assert.deepStrictEqual(recorder.filter({ category: /^app\.d/ }), [dbRecord]);
+
+  const categoryPattern = /app\.auth/g;
+  assert.strictEqual(categoryPattern.test("app.auth"), true);
+  assert.strictEqual(recorder.find({ category: categoryPattern }), authRecord);
+
+  const stickyMessagePattern = /User/y;
+  stickyMessagePattern.lastIndex = 1;
+  assert.strictEqual(
+    recorder.find({ message: stickyMessagePattern }),
+    authRecord,
+  );
 });
 
 test("LogRecorder supports predicate matchers", () => {
@@ -120,6 +133,21 @@ test("LogRecorder supports predicate matchers", () => {
   recorder.sink(record);
 
   assert.strictEqual(recorder.find(match), record);
+});
+
+test("LogRecorder matches rendered RegExp and Date message values", () => {
+  const recorder = createLogRecorder();
+  const pattern = /failed login/i;
+  const timestamp = new Date("2026-06-09T00:00:00.000Z");
+  const record = logRecord({
+    message: ["Pattern ", pattern, " matched at ", timestamp, "."],
+    rawMessage: "Pattern {pattern} matched at {timestamp}.",
+  });
+  recorder.sink(record);
+
+  recorder.assertLogged({
+    message: "Pattern /failed login/i matched at 2026-06-09T00:00:00.000Z.",
+  });
 });
 
 test("LogRecorder.assertLogged()", () => {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -72,8 +72,15 @@ test("LogRecorder.find() and LogRecorder.filter()", () => {
     rawMessage: "Query failed.",
     properties: { durationMs: 1200 },
   });
+  const rootRecord = logRecord({
+    category: [],
+    level: "info",
+    message: ["Root record."],
+    rawMessage: "Root record.",
+  });
   recorder.sink(authRecord);
   recorder.sink(dbRecord);
+  recorder.sink(rootRecord);
 
   assert.strictEqual(
     recorder.find({
@@ -86,6 +93,8 @@ test("LogRecorder.find() and LogRecorder.filter()", () => {
     authRecord,
   );
   assert.strictEqual(recorder.find({ category: "app.auth" }), authRecord);
+  assert.strictEqual(recorder.find({ category: "" }), rootRecord);
+  assert.deepStrictEqual(recorder.filter({ category: /^$/ }), [rootRecord]);
   assert.deepStrictEqual(recorder.filter({ categoryPrefix: ["app"] }), [
     authRecord,
     dbRecord,

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -244,6 +244,52 @@ test("LogRecorder diagnostics handle null-prototype circular values", () => {
   );
 });
 
+test("LogRecorder diagnostics render Map and Set values", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({
+    message: ["collection diagnostics"],
+    properties: {
+      roles: new Set(["admin", "operator"]),
+      tags: new Map<string, unknown>([
+        ["environment", "production"],
+        ["retries", 3],
+      ]),
+    },
+  }));
+
+  assert.throws(
+    () =>
+      recorder.assertLogged({
+        properties: {
+          expectedRoles: new Set(["admin"]),
+          expectedTags: new Map([["environment", "staging"]]),
+        },
+      }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /properties\.expectedRoles: Set\(1\) \["admin"\]/,
+      );
+      assert.match(
+        error.message,
+        /properties\.expectedTags: Map\(1\) {"environment":"staging"}/,
+      );
+      assert.match(
+        error.message,
+        /roles: Set\(2\) \["admin","operator"\]/,
+      );
+      assert.match(
+        error.message,
+        /tags: Map\(2\) {"environment":"production","retries":3}/,
+      );
+      assert.doesNotMatch(error.message, /roles: {}/);
+      assert.doesNotMatch(error.message, /tags: {}/);
+      return true;
+    },
+  );
+});
+
 test("LogRecorder diagnostics preserve non-finite numbers", () => {
   const recorder = createLogRecorder();
   recorder.sink(logRecord({

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -236,9 +236,49 @@ test("LogRecorder diagnostics handle null-prototype circular values", () => {
       assert.match(error.message, /Expected a LogTape record matching:/);
       assert.match(
         error.message,
-        /properties\.matcherValue: \[object Object\]/,
+        /properties\.matcherValue: {"self":"\[Circular\]"}/,
       );
-      assert.match(error.message, /recordedValue: \[object Object\]/);
+      assert.match(error.message, /recordedValue: {"self":"\[Circular\]"}/);
+      return true;
+    },
+  );
+});
+
+test("LogRecorder diagnostics render nested BigInt and circular values", () => {
+  const recorder = createLogRecorder();
+  const circularValue: Record<string, unknown> = { id: "payload" };
+  circularValue.self = circularValue;
+  recorder.sink(logRecord({
+    message: ["nested diagnostic value"],
+    properties: {
+      payload: { attempts: 3n, pattern: /retry/g, self: circularValue },
+      statusById: new Map<unknown, unknown>([
+        ["job-1", { attempts: 2n }],
+      ]),
+      flags: new Set<unknown>([1n, /ready/i]),
+    },
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ properties: { expected: { count: 1n } } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /properties\.expected: {"count":"1n"}/,
+      );
+      assert.match(
+        error.message,
+        /payload: {"attempts":"3n","pattern":"\/retry\/g","self":{"id":"payload","self":"\[Circular\]"}}/,
+      );
+      assert.match(
+        error.message,
+        /statusById: Map\(1\) {"job-1":{"attempts":"2n"}}/,
+      );
+      assert.match(error.message, /flags: Set\(2\) \["1n","\/ready\/i"\]/);
+      assert.doesNotMatch(error.message, /payload: \[object Object\]/);
+      assert.doesNotMatch(error.message, /statusById: Map\(1\)(?! )/);
+      assert.doesNotMatch(error.message, /flags: Set\(2\)(?! )/);
       return true;
     },
   );

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -141,6 +141,32 @@ test("LogRecorder supports predicate matchers", () => {
   assert.strictEqual(recorder.find(match), record);
 });
 
+test("LogRecorder matches Date property values by time", () => {
+  const recorder = createLogRecorder();
+  const occurredAt = new Date("2026-06-09T00:00:00.000Z");
+  const record = logRecord({
+    properties: { occurredAt },
+  });
+  recorder.sink(record);
+
+  assert.strictEqual(
+    recorder.find({
+      properties: {
+        occurredAt: new Date("2026-06-09T00:00:00.000Z"),
+      },
+    }),
+    record,
+  );
+  assert.strictEqual(
+    recorder.find({
+      properties: {
+        occurredAt: new Date("2026-06-10T00:00:00.000Z"),
+      },
+    }),
+    undefined,
+  );
+});
+
 test("LogRecorder handles nullish record properties", () => {
   const recorder = createLogRecorder();
   const record = {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -183,6 +183,33 @@ test("LogRecorder matches Date property values by time", () => {
   );
 });
 
+test("LogRecorder matches properties without Object.hasOwn", () => {
+  const recorder = createLogRecorder();
+  const record = logRecord({
+    properties: { userId: "u-123" },
+  });
+  recorder.sink(record);
+  const hasOwnDescriptor = Object.getOwnPropertyDescriptor(Object, "hasOwn");
+  try {
+    Object.defineProperty(Object, "hasOwn", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    assert.strictEqual(
+      recorder.find({ properties: { userId: "u-123" } }),
+      record,
+    );
+  } finally {
+    if (hasOwnDescriptor == null) {
+      delete (Object as { hasOwn?: typeof Object.hasOwn }).hasOwn;
+    } else {
+      Object.defineProperty(Object, "hasOwn", hasOwnDescriptor);
+    }
+  }
+});
+
 test("LogRecorder matches string property values with regular expressions", () => {
   const recorder = createLogRecorder();
   const record = logRecord({
@@ -737,27 +764,38 @@ test("LogRecorder preserves extra fields when snapshotting lazy messages", () =>
   const recorder = createLogRecorder();
   const contextKey = Symbol("context");
   let userId = "alice";
+  let traceId = "trace-123";
+  let spanId = "span-123";
   const record = {
     ...logRecord({
       properties: { userId },
       rawMessage: "User {userId} logged in.",
     }),
     requestId: "req-123",
-    [contextKey]: { traceId: "trace-123" },
+    get traceId(): string {
+      return traceId;
+    },
+    get [contextKey](): { readonly spanId: string } {
+      return { spanId };
+    },
     get message(): readonly unknown[] {
       return ["User ", userId, " logged in."];
     },
   } as LogRecord & {
     readonly requestId: string;
-    readonly [contextKey]: { readonly traceId: string };
+    readonly traceId: string;
+    readonly [contextKey]: { readonly spanId: string };
   };
 
   recorder.sink(record);
   userId = "bob";
+  traceId = "trace-456";
+  spanId = "span-456";
 
   const snapshot = recorder.records[0] as LogRecord & {
     readonly requestId?: string;
-    readonly [contextKey]?: { readonly traceId: string };
+    readonly traceId?: string;
+    readonly [contextKey]?: { readonly spanId: string };
   };
   assert.notStrictEqual(snapshot, record);
   assert.deepStrictEqual(snapshot.message, [
@@ -766,7 +804,8 @@ test("LogRecorder preserves extra fields when snapshotting lazy messages", () =>
     " logged in.",
   ]);
   assert.strictEqual(snapshot.requestId, "req-123");
-  assert.deepStrictEqual(snapshot[contextKey], { traceId: "trace-123" });
+  assert.strictEqual(snapshot.traceId, "trace-123");
+  assert.deepStrictEqual(snapshot[contextKey], { spanId: "span-123" });
 });
 
 test("LogRecorder observes resolved lazy and redacted properties", async () => {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   configure,
   getLogger,
+  getTextFormatter,
   lazy,
   type LogRecord,
   reset,
@@ -88,7 +89,7 @@ test("LogRecorder.find() and LogRecorder.filter()", () => {
     recorder.find({
       category: ["app", "auth"],
       level: "warning",
-      message: "User u-123 failed login.",
+      message: renderMessageWithCoreFormatter(authRecord),
       rawMessage: /userId/,
       properties: { userId: "u-123" },
     }),
@@ -171,6 +172,67 @@ test("LogRecorder handles nullish record properties", () => {
 
 test("LogRecorder matches rendered object message values", () => {
   const recorder = createLogRecorder();
+  const payload = { foo: "bar" };
+  const values = ["one", "two"];
+  const error = new TypeError("Bad input");
+  const pattern = /failed login/i;
+  const timestamp = new Date("2026-06-09T00:00:00.000Z");
+  const record = logRecord({
+    message: [
+      "Payload ",
+      payload,
+      " values ",
+      values,
+      "; pattern ",
+      pattern,
+      " failed with ",
+      error,
+      " at ",
+      timestamp,
+      ".",
+    ],
+    rawMessage:
+      "Payload {payload} values {values}; pattern {pattern} failed with {error} at {timestamp}.",
+  });
+  recorder.sink(record);
+
+  recorder.assertLogged({
+    message: renderMessageWithCoreFormatter(record),
+  });
+  assert.ok(
+    !renderMessageWithCoreFormatter(record).includes(
+      JSON.stringify(payload),
+    ),
+  );
+});
+
+test("LogRecorder diagnostics render messages like the core formatter", () => {
+  const recorder = createLogRecorder();
+  const record = logRecord({
+    message: [
+      "Payload ",
+      { foo: "bar" },
+      ".",
+    ],
+    rawMessage: "Payload {payload}.",
+  });
+  recorder.sink(record);
+
+  assert.throws(
+    () => recorder.assertLogged({ message: "missing" }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        new RegExp(escapeRegExp(renderMessageWithCoreFormatter(record))),
+      );
+      return true;
+    },
+  );
+});
+
+test("LogRecorder matches rendered special object message values", () => {
+  const recorder = createLogRecorder();
   const error = new TypeError("Bad input");
   const pattern = /failed login/i;
   const timestamp = new Date("2026-06-09T00:00:00.000Z");
@@ -189,20 +251,20 @@ test("LogRecorder matches rendered object message values", () => {
   recorder.sink(record);
 
   recorder.assertLogged({
-    message:
-      "Pattern /failed login/i failed with TypeError: Bad input at 2026-06-09T00:00:00.000Z.",
+    message: renderMessageWithCoreFormatter(record),
   });
 });
 
 test("LogRecorder.assertLogged()", () => {
   const recorder = createLogRecorder();
-  recorder.sink(logRecord({
+  const authRecord = logRecord({
     category: ["app", "auth"],
     level: "warning",
     message: ["User ", "u-123", " failed login."],
     rawMessage: "User {userId} failed login.",
     properties: { userId: "u-123" },
-  }));
+  });
+  recorder.sink(authRecord);
 
   recorder.assertLogged({ level: "warning", properties: { userId: "u-123" } });
 
@@ -216,7 +278,9 @@ test("LogRecorder.assertLogged()", () => {
       assert.match(error.message, /Recorded 1 record:/);
       assert.match(
         error.message,
-        /\[warning\] app\.auth: User u-123 failed login\./,
+        new RegExp(escapeRegExp(
+          `[warning] app.auth: ${renderMessageWithCoreFormatter(authRecord)}`,
+        )),
       );
       return true;
     },
@@ -225,13 +289,14 @@ test("LogRecorder.assertLogged()", () => {
 
 test("LogRecorder.assertNotLogged()", () => {
   const recorder = createLogRecorder();
-  recorder.sink(logRecord({
+  const authRecord = logRecord({
     category: ["app", "auth"],
     level: "warning",
     message: ["User ", "u-123", " failed login."],
     rawMessage: "User {userId} failed login.",
     properties: { userId: "u-123" },
-  }));
+  });
+  recorder.sink(authRecord);
 
   recorder.assertNotLogged({ level: "error" });
 
@@ -243,7 +308,9 @@ test("LogRecorder.assertNotLogged()", () => {
       assert.match(error.message, /Found 1 matching record:/);
       assert.match(
         error.message,
-        /\[warning\] app\.auth: User u-123 failed login\./,
+        new RegExp(escapeRegExp(
+          `[warning] app.auth: ${renderMessageWithCoreFormatter(authRecord)}`,
+        )),
       );
       return true;
     },
@@ -272,12 +339,12 @@ test("LogRecorder works with configure()", async () => {
     recorder.assertLogged({
       category: ["my-lib"],
       level: "info",
-      message: "User u-123 logged in.",
+      message: /^User .+ logged in\.$/,
       properties: { userId: "u-123" },
     });
     recorder.assertLogged({
       category: ["my-lib"],
-      message: "Tagged value record.",
+      message: /^Tagged .+ record\.$/,
       rawMessage: /Tagged/,
     });
   } finally {
@@ -314,7 +381,7 @@ test("LogRecorder observes resolved lazy and redacted properties", async () => {
     });
 
     recorder.assertLogged({
-      message: "Login failed for alice with [redacted].",
+      message: /^Login failed for .+ with .+\.$/,
       properties: { password: "[redacted]", userId: "alice" },
     });
     recorder.assertNotLogged({
@@ -337,4 +404,16 @@ function logRecord(record: Partial<LogRecord> = {}): LogRecord {
     timestamp: 1700000000000,
     ...record,
   };
+}
+
+function renderMessageWithCoreFormatter(record: LogRecord): string {
+  return getTextFormatter({
+    format: ({ message }) => message,
+    lineEnding: "lf",
+    timestamp: "none",
+  })(record).slice(0, -1);
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -327,6 +327,33 @@ test("LogRecorder diagnostics render nested BigInt and circular values", () => {
   );
 });
 
+test("LogRecorder diagnostics preserve repeated non-circular references", () => {
+  const recorder = createLogRecorder();
+  const sharedValue = { id: "user-123" };
+  recorder.sink(logRecord({
+    message: ["shared reference diagnostics"],
+    properties: {
+      payload: {
+        before: sharedValue,
+        after: sharedValue,
+      },
+    },
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ properties: { missing: true } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(
+        error.message,
+        /payload: {"before":{"id":"user-123"},"after":{"id":"user-123"}}/,
+      );
+      assert.doesNotMatch(error.message, /"after":"\[Circular\]"/);
+      return true;
+    },
+  );
+});
+
 test("LogRecorder diagnostics render nested Error values", () => {
   const recorder = createLogRecorder();
   recorder.sink(logRecord({

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -695,6 +695,44 @@ test("LogRecorder works with configure()", async () => {
   }
 });
 
+test("LogRecorder snapshots lazy callback messages in the sink", async () => {
+  const recorder = createLogRecorder();
+  try {
+    await configure({
+      sinks: { recorder: recorder.sink },
+      loggers: [
+        { category: ["logtape", "meta"], sinks: [] },
+        {
+          category: ["my-lib"],
+          lowestLevel: "debug",
+          sinks: ["recorder"],
+        },
+      ],
+    });
+
+    let userId = "alice";
+    let evaluations = 0;
+    getLogger(["my-lib"]).info((log) => {
+      evaluations++;
+      return log`User ${userId} logged in.`;
+    });
+    userId = "bob";
+
+    assert.strictEqual(evaluations, 1);
+    assert.deepStrictEqual(recorder.records[0]?.message, [
+      "User ",
+      "alice",
+      " logged in.",
+    ]);
+    assert.strictEqual(
+      renderRawMessage(recorder.records[0]?.rawMessage),
+      "User  logged in.",
+    );
+  } finally {
+    await reset();
+  }
+});
+
 test("LogRecorder observes resolved lazy and redacted properties", async () => {
   const recorder = createLogRecorder();
   const sink = redactByField(recorder.sink, {
@@ -759,6 +797,10 @@ function renderMessageWithCoreFormatter(record: LogRecord): string {
 
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function renderRawMessage(rawMessage: LogRecord["rawMessage"]): string {
+  return typeof rawMessage === "string" ? rawMessage : rawMessage.join("");
 }
 
 function circularNullPrototypeObject(): Record<string, unknown> {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -1,0 +1,259 @@
+import {
+  configure,
+  getLogger,
+  lazy,
+  type LogRecord,
+  reset,
+  type Sink,
+} from "@logtape/logtape";
+import { redactByField } from "@logtape/redaction";
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createLogRecorder,
+  type LogRecordMatch,
+  type PropertyMatcher,
+} from "./mod.ts";
+
+test("createLogRecorder() stores records in order", () => {
+  const recorder = createLogRecorder();
+  const first = logRecord({
+    level: "info",
+    message: ["first"],
+    rawMessage: "first",
+  });
+  const second = logRecord({
+    level: "warning",
+    message: ["second"],
+    rawMessage: "second",
+  });
+
+  recorder.sink(first);
+  recorder.sink(second);
+
+  assert.deepStrictEqual(recorder.records, [first, second]);
+});
+
+test("LogRecorder.clear()", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({ message: ["before clear"] }));
+
+  recorder.clear();
+
+  assert.deepStrictEqual(recorder.records, []);
+});
+
+test("LogRecorder.take()", () => {
+  const recorder = createLogRecorder();
+  const first = logRecord({ message: ["first"] });
+  const second = logRecord({ message: ["second"] });
+  recorder.sink(first);
+  recorder.sink(second);
+
+  const records = recorder.take();
+
+  assert.deepStrictEqual(records, [first, second]);
+  assert.deepStrictEqual(recorder.records, []);
+});
+
+test("LogRecorder.find() and LogRecorder.filter()", () => {
+  const recorder = createLogRecorder();
+  const authRecord = logRecord({
+    category: ["app", "auth"],
+    level: "warning",
+    message: ["User ", "u-123", " failed login."],
+    rawMessage: "User {userId} failed login.",
+    properties: { reason: "password-expired", userId: "u-123" },
+  });
+  const dbRecord = logRecord({
+    category: ["app", "db"],
+    level: "error",
+    message: ["Query failed."],
+    rawMessage: "Query failed.",
+    properties: { durationMs: 1200 },
+  });
+  recorder.sink(authRecord);
+  recorder.sink(dbRecord);
+
+  assert.strictEqual(
+    recorder.find({
+      category: ["app", "auth"],
+      level: "warning",
+      message: "User u-123 failed login.",
+      rawMessage: /userId/,
+      properties: { userId: "u-123" },
+    }),
+    authRecord,
+  );
+  assert.strictEqual(recorder.find({ category: "app.auth" }), authRecord);
+  assert.deepStrictEqual(recorder.filter({ categoryPrefix: ["app"] }), [
+    authRecord,
+    dbRecord,
+  ]);
+  assert.deepStrictEqual(recorder.filter({ category: /^app\.d/ }), [dbRecord]);
+});
+
+test("LogRecorder supports predicate matchers", () => {
+  const recorder = createLogRecorder();
+  const record = logRecord({
+    level: "info",
+    message: ["User ", "u-123", " logged in."],
+    rawMessage: "User {userId} logged in.",
+    properties: { userId: "u-123", sessionId: "s-456" },
+  });
+  const properties: PropertyMatcher = (props) =>
+    props.userId === "u-123" && typeof props.sessionId === "string";
+  const match: LogRecordMatch = {
+    message: (candidate) => candidate.rawMessage === "User {userId} logged in.",
+    properties,
+    predicate: (candidate) => candidate.timestamp === record.timestamp,
+  };
+  recorder.sink(record);
+
+  assert.strictEqual(recorder.find(match), record);
+});
+
+test("LogRecorder.assertLogged()", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({
+    category: ["app", "auth"],
+    level: "warning",
+    message: ["User ", "u-123", " failed login."],
+    rawMessage: "User {userId} failed login.",
+    properties: { userId: "u-123" },
+  }));
+
+  recorder.assertLogged({ level: "warning", properties: { userId: "u-123" } });
+
+  assert.throws(
+    () => recorder.assertLogged({ category: ["app", "db"], level: "error" }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Expected a LogTape record matching:/);
+      assert.match(error.message, /level: "error"/);
+      assert.match(error.message, /category: \["app", "db"\]/);
+      assert.match(error.message, /Recorded 1 record:/);
+      assert.match(
+        error.message,
+        /\[warning\] app\.auth: User u-123 failed login\./,
+      );
+      return true;
+    },
+  );
+});
+
+test("LogRecorder.assertNotLogged()", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({
+    category: ["app", "auth"],
+    level: "warning",
+    message: ["User ", "u-123", " failed login."],
+    rawMessage: "User {userId} failed login.",
+    properties: { userId: "u-123" },
+  }));
+
+  recorder.assertNotLogged({ level: "error" });
+
+  assert.throws(
+    () => recorder.assertNotLogged({ level: "warning" }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Expected no LogTape record matching:/);
+      assert.match(error.message, /Found 1 matching record:/);
+      assert.match(
+        error.message,
+        /\[warning\] app\.auth: User u-123 failed login\./,
+      );
+      return true;
+    },
+  );
+});
+
+test("LogRecorder works with configure()", async () => {
+  const recorder = createLogRecorder();
+  try {
+    await configure({
+      sinks: { recorder: recorder.sink },
+      loggers: [
+        { category: ["logtape", "meta"], sinks: [] },
+        {
+          category: ["my-lib"],
+          lowestLevel: "debug",
+          sinks: ["recorder"],
+        },
+      ],
+    });
+
+    const logger = getLogger(["my-lib"]);
+    logger.info("User {userId} logged in.", { userId: "u-123" });
+    logger.info`Tagged ${"value"} record.`;
+
+    recorder.assertLogged({
+      category: ["my-lib"],
+      level: "info",
+      message: "User u-123 logged in.",
+      properties: { userId: "u-123" },
+    });
+    recorder.assertLogged({
+      category: ["my-lib"],
+      message: "Tagged value record.",
+      rawMessage: /Tagged/,
+    });
+  } finally {
+    await reset();
+  }
+});
+
+test("LogRecorder observes resolved lazy and redacted properties", async () => {
+  const recorder = createLogRecorder();
+  const sink = redactByField(recorder.sink, {
+    action: () => "[redacted]",
+    fieldPatterns: ["password"],
+  }) as Sink;
+  try {
+    await configure({
+      sinks: { recorder: sink },
+      loggers: [
+        { category: ["logtape", "meta"], sinks: [] },
+        {
+          category: ["security"],
+          lowestLevel: "debug",
+          sinks: ["recorder"],
+        },
+      ],
+    });
+
+    let currentUser = "nobody";
+    const logger = getLogger(["security"]).with({
+      userId: lazy(() => currentUser),
+    });
+    currentUser = "alice";
+    logger.warning("Login failed for {userId} with {password}.", {
+      password: "secret",
+    });
+
+    recorder.assertLogged({
+      message: "Login failed for alice with [redacted].",
+      properties: { password: "[redacted]", userId: "alice" },
+    });
+    recorder.assertNotLogged({
+      properties: (props) => props.password === "secret",
+    });
+  } finally {
+    await reset();
+  }
+});
+
+// Helpers
+
+function logRecord(record: Partial<LogRecord> = {}): LogRecord {
+  return {
+    category: ["app"],
+    level: "info",
+    message: ["message"],
+    properties: {},
+    rawMessage: "message",
+    timestamp: 1700000000000,
+    ...record,
+  };
+}

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -101,6 +101,11 @@ test("LogRecorder.find() and LogRecorder.filter()", () => {
     authRecord,
     dbRecord,
   ]);
+  assert.deepStrictEqual(recorder.filter({ categoryPrefix: "" }), [
+    authRecord,
+    dbRecord,
+    rootRecord,
+  ]);
   assert.deepStrictEqual(recorder.filter({ category: /^app\.d/ }), [dbRecord]);
 
   const categoryPattern = /app\.auth/g;
@@ -135,18 +140,57 @@ test("LogRecorder supports predicate matchers", () => {
   assert.strictEqual(recorder.find(match), record);
 });
 
-test("LogRecorder matches rendered RegExp and Date message values", () => {
+test("LogRecorder handles nullish record properties", () => {
   const recorder = createLogRecorder();
+  const record = {
+    ...logRecord({ message: ["nullish properties"] }),
+    properties: null,
+  } as unknown as LogRecord;
+  recorder.sink(record);
+
+  assert.strictEqual(
+    recorder.find({ properties: { userId: "u-123" } }),
+    undefined,
+  );
+  assert.strictEqual(
+    recorder.find({
+      properties: (props) => Object.keys(props).length === 0,
+    }),
+    record,
+  );
+  assert.throws(
+    () => recorder.assertLogged({ properties: { userId: "u-123" } }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Expected a LogTape record matching:/);
+      assert.match(error.message, /\[info\] app: nullish properties/);
+      return true;
+    },
+  );
+});
+
+test("LogRecorder matches rendered object message values", () => {
+  const recorder = createLogRecorder();
+  const error = new TypeError("Bad input");
   const pattern = /failed login/i;
   const timestamp = new Date("2026-06-09T00:00:00.000Z");
   const record = logRecord({
-    message: ["Pattern ", pattern, " matched at ", timestamp, "."],
-    rawMessage: "Pattern {pattern} matched at {timestamp}.",
+    message: [
+      "Pattern ",
+      pattern,
+      " failed with ",
+      error,
+      " at ",
+      timestamp,
+      ".",
+    ],
+    rawMessage: "Pattern {pattern} failed with {error} at {timestamp}.",
   });
   recorder.sink(record);
 
   recorder.assertLogged({
-    message: "Pattern /failed login/i matched at 2026-06-09T00:00:00.000Z.",
+    message:
+      "Pattern /failed login/i failed with TypeError: Bad input at 2026-06-09T00:00:00.000Z.",
   });
 });
 

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -835,6 +835,50 @@ test("LogRecorder preserves extra fields when snapshotting lazy messages", () =>
   assert.deepStrictEqual(snapshot[contextKey], { spanId: "span-123" });
 });
 
+test("LogRecorder preserves extra accessors when messages are eager", () => {
+  const recorder = createLogRecorder();
+  const contextKey = Symbol("context");
+  let traceId = "trace-123";
+  let spanId = "span-123";
+  const record = {
+    ...logRecord({
+      message: ["User ", "alice", " logged in."],
+      properties: { userId: "alice" },
+      rawMessage: "User {userId} logged in.",
+    }),
+    requestId: "req-123",
+    get traceId(): string {
+      return traceId;
+    },
+    get [contextKey](): { readonly spanId: string } {
+      return { spanId };
+    },
+  } as LogRecord & {
+    readonly requestId: string;
+    readonly traceId: string;
+    readonly [contextKey]: { readonly spanId: string };
+  };
+
+  recorder.sink(record);
+  traceId = "trace-456";
+  spanId = "span-456";
+
+  const snapshot = recorder.records[0] as LogRecord & {
+    readonly requestId?: string;
+    readonly traceId?: string;
+    readonly [contextKey]?: { readonly spanId: string };
+  };
+  assert.notStrictEqual(snapshot, record);
+  assert.deepStrictEqual(snapshot.message, [
+    "User ",
+    "alice",
+    " logged in.",
+  ]);
+  assert.strictEqual(snapshot.requestId, "req-123");
+  assert.strictEqual(snapshot.traceId, "trace-123");
+  assert.deepStrictEqual(snapshot[contextKey], { spanId: "span-123" });
+});
+
 test("LogRecorder observes resolved lazy and redacted properties", async () => {
   const recorder = createLogRecorder();
   const sink = redactByField(recorder.sink, {

--- a/packages/testing/src/mod.test.ts
+++ b/packages/testing/src/mod.test.ts
@@ -517,6 +517,47 @@ test("LogRecorder diagnostics render messages like the core formatter", () => {
   );
 });
 
+test("LogRecorder message predicates do not render messages", () => {
+  const recorder = createLogRecorder();
+  const value = throwingInspectValue();
+  const record = logRecord({
+    message: ["Value ", value, "."],
+    rawMessage: "Value {value}.",
+  });
+  recorder.sink(record);
+
+  let seenRecord: LogRecord | undefined;
+  assert.strictEqual(
+    recorder.find({
+      message: (candidate) => {
+        seenRecord = candidate;
+        return candidate.message[1] === value;
+      },
+    }),
+    record,
+  );
+  assert.strictEqual(seenRecord, record);
+});
+
+test("LogRecorder diagnostics guard message rendering errors", () => {
+  const recorder = createLogRecorder();
+  recorder.sink(logRecord({
+    message: ["Value ", throwingInspectValue(), "."],
+    rawMessage: "Value {value}.",
+  }));
+
+  assert.throws(
+    () => recorder.assertLogged({ level: "error" }),
+    (error) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Expected a LogTape record matching:/);
+      assert.match(error.message, /level: "error"/);
+      assert.match(error.message, /<error: inspect failed>/);
+      return true;
+    },
+  );
+});
+
 test("LogRecorder matches rendered special object message values", () => {
   const recorder = createLogRecorder();
   const error = new TypeError("Bad input");
@@ -708,4 +749,15 @@ function circularNullPrototypeObject(): Record<string, unknown> {
   const value = Object.create(null) as Record<string, unknown>;
   value.self = value;
   return value;
+}
+
+function throwingInspectValue(): unknown {
+  return {
+    [Symbol.for("Deno.customInspect")](): string {
+      throw new Error("inspect failed");
+    },
+    [Symbol.for("nodejs.util.inspect.custom")](): string {
+      throw new Error("inspect failed");
+    },
+  };
 }

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -1,0 +1,458 @@
+import type { LogLevel, LogRecord, Sink } from "@logtape/logtape";
+
+/**
+ * A predicate that matches log record properties.
+ *
+ * The first argument is the resolved properties object.  The second argument
+ * is the full log record for cases where the predicate needs category, level,
+ * or message context.
+ *
+ * @since 2.2.0
+ */
+export type PropertyMatcher = (
+  properties: Readonly<Record<string, unknown>>,
+  record: LogRecord,
+) => boolean;
+
+/**
+ * A matcher for records collected by a {@link LogRecorder}.
+ *
+ * Object property matching is shallow: every own string key in the matcher
+ * must exist on the record properties and have the same value according to
+ * `Object.is()`.  Use a {@link PropertyMatcher} when a test needs absence
+ * checks or deeper matching.
+ *
+ * @since 2.2.0
+ */
+export interface LogRecordMatch {
+  /**
+   * Exact category matcher.  A string is matched against the dot-joined
+   * category, while an array is matched segment by segment.  A regular
+   * expression is tested against the dot-joined category.
+   */
+  readonly category?: string | readonly string[] | RegExp;
+
+  /**
+   * Category prefix matcher.  A string is split on dots, while an array is
+   * matched segment by segment.
+   */
+  readonly categoryPrefix?: string | readonly string[];
+
+  /**
+   * Exact severity level matcher.
+   */
+  readonly level?: LogLevel;
+
+  /**
+   * Rendered message matcher.  String and regular expression matchers are
+   * applied to the rendered message.  A predicate receives the full record.
+   */
+  readonly message?: string | RegExp | ((record: LogRecord) => boolean);
+
+  /**
+   * Raw message matcher.  A string record is matched directly.  A tagged
+   * template record is matched against the concatenated template strings.
+   */
+  readonly rawMessage?: string | RegExp;
+
+  /**
+   * Shallow property matcher or predicate.
+   */
+  readonly properties?: Readonly<Record<string, unknown>> | PropertyMatcher;
+
+  /**
+   * Full-record predicate for custom checks.
+   */
+  readonly predicate?: (record: LogRecord) => boolean;
+}
+
+/**
+ * A test recorder for LogTape records.
+ *
+ * @since 2.2.0
+ */
+export interface LogRecorder {
+  /**
+   * A sink that appends each received record to {@link LogRecorder.records}.
+   */
+  readonly sink: Sink;
+
+  /**
+   * Records collected so far, in sink call order.
+   */
+  readonly records: readonly LogRecord[];
+
+  /**
+   * Removes all collected records.
+   */
+  clear(): void;
+
+  /**
+   * Returns collected records and clears the recorder.
+   */
+  take(): readonly LogRecord[];
+
+  /**
+   * Finds the first collected record matching the given matcher.
+   *
+   * @param match The matcher to apply.
+   * @returns The first matching record, or `undefined`.
+   */
+  find(match: LogRecordMatch): LogRecord | undefined;
+
+  /**
+   * Finds all collected records matching the given matcher.
+   *
+   * @param match The matcher to apply.
+   * @returns All matching records in collection order.
+   */
+  filter(match: LogRecordMatch): readonly LogRecord[];
+
+  /**
+   * Asserts that at least one collected record matches the given matcher.
+   *
+   * @param match The matcher to apply.
+   * @throws {Error} If no matching record exists.
+   */
+  assertLogged(match: LogRecordMatch): void;
+
+  /**
+   * Asserts that no collected record matches the given matcher.
+   *
+   * @param match The matcher to apply.
+   * @throws {Error} If a matching record exists.
+   */
+  assertNotLogged(match: LogRecordMatch): void;
+}
+
+/**
+ * Creates a LogTape test recorder.
+ *
+ * @example
+ * ```ts
+ * import { configure, getLogger, reset } from "@logtape/logtape";
+ * import { createLogRecorder } from "@logtape/testing";
+ *
+ * const recorder = createLogRecorder();
+ *
+ * try {
+ *   await configure({
+ *     sinks: { recorder: recorder.sink },
+ *     loggers: [
+ *       { category: ["my-lib"], lowestLevel: "debug", sinks: ["recorder"] },
+ *     ],
+ *   });
+ *
+ *   getLogger(["my-lib"]).info("User {userId} logged in.", {
+ *     userId: "u-123",
+ *   });
+ *
+ *   recorder.assertLogged({
+ *     category: ["my-lib"],
+ *     level: "info",
+ *     message: "User u-123 logged in.",
+ *     properties: { userId: "u-123" },
+ *   });
+ * } finally {
+ *   await reset();
+ * }
+ * ```
+ *
+ * @returns A recorder with a sink and assertion helpers.
+ * @since 2.2.0
+ */
+export function createLogRecorder(): LogRecorder {
+  const records: LogRecord[] = [];
+  const sink: Sink = (record: LogRecord): void => {
+    records.push(record);
+  };
+
+  return {
+    sink,
+    get records(): readonly LogRecord[] {
+      return records;
+    },
+    clear(): void {
+      records.length = 0;
+    },
+    take(): readonly LogRecord[] {
+      return records.splice(0);
+    },
+    find(match: LogRecordMatch): LogRecord | undefined {
+      return records.find((record) => matchesLogRecord(record, match));
+    },
+    filter(match: LogRecordMatch): readonly LogRecord[] {
+      return records.filter((record) => matchesLogRecord(record, match));
+    },
+    assertLogged(match: LogRecordMatch): void {
+      if (records.some((record) => matchesLogRecord(record, match))) return;
+
+      throw new Error(
+        [
+          "Expected a LogTape record matching:",
+          formatMatcher(match),
+          "",
+          `Recorded ${formatCount(records.length, "record")}:`,
+          formatRecords(records),
+        ].join("\n"),
+      );
+    },
+    assertNotLogged(match: LogRecordMatch): void {
+      const matching = records.filter((record) =>
+        matchesLogRecord(record, match)
+      );
+      if (matching.length < 1) return;
+
+      throw new Error(
+        [
+          "Expected no LogTape record matching:",
+          formatMatcher(match),
+          "",
+          `Found ${formatCount(matching.length, "matching record")}:`,
+          formatRecords(matching),
+        ].join("\n"),
+      );
+    },
+  };
+}
+
+function matchesLogRecord(record: LogRecord, match: LogRecordMatch): boolean {
+  if (
+    match.category != null &&
+    !matchesCategory(record.category, match.category)
+  ) {
+    return false;
+  }
+  if (
+    match.categoryPrefix != null &&
+    !matchesCategoryPrefix(record.category, match.categoryPrefix)
+  ) {
+    return false;
+  }
+  if (match.level != null && record.level !== match.level) return false;
+  if (
+    match.message != null &&
+    !matchesMessage(renderMessage(record.message), record, match.message)
+  ) {
+    return false;
+  }
+  if (
+    match.rawMessage != null &&
+    !matchesText(renderRawMessage(record.rawMessage), match.rawMessage)
+  ) {
+    return false;
+  }
+  if (
+    match.properties != null &&
+    !matchesProperties(record.properties, record, match.properties)
+  ) {
+    return false;
+  }
+  if (match.predicate != null && !match.predicate(record)) return false;
+  return true;
+}
+
+function matchesCategory(
+  category: readonly string[],
+  expected: string | readonly string[] | RegExp,
+): boolean {
+  if (expected instanceof RegExp) {
+    return testRegExp(expected, formatCategory(category));
+  }
+  if (typeof expected === "string") {
+    return formatCategory(category) === expected;
+  }
+  const expectedCategory = parseCategory(expected);
+  return category.length === expectedCategory.length &&
+    category.every((part, index) => part === expectedCategory[index]);
+}
+
+function matchesCategoryPrefix(
+  category: readonly string[],
+  prefix: string | readonly string[],
+): boolean {
+  const expectedPrefix = parseCategory(prefix);
+  return expectedPrefix.length <= category.length &&
+    expectedPrefix.every((part, index) => part === category[index]);
+}
+
+function parseCategory(
+  category: string | readonly string[],
+): readonly string[] {
+  return typeof category === "string" ? category.split(".") : category;
+}
+
+function matchesMessage(
+  renderedMessage: string,
+  record: LogRecord,
+  matcher: string | RegExp | ((record: LogRecord) => boolean),
+): boolean {
+  if (typeof matcher === "function") return matcher(record);
+  return matchesText(renderedMessage, matcher);
+}
+
+function matchesText(text: string, matcher: string | RegExp): boolean {
+  return typeof matcher === "string"
+    ? text === matcher
+    : testRegExp(matcher, text);
+}
+
+function matchesProperties(
+  properties: Readonly<Record<string, unknown>>,
+  record: LogRecord,
+  matcher: Readonly<Record<string, unknown>> | PropertyMatcher,
+): boolean {
+  if (typeof matcher === "function") return matcher(properties, record);
+  for (const key of Object.keys(matcher)) {
+    if (!Object.hasOwn(properties, key)) return false;
+    if (!Object.is(properties[key], matcher[key])) return false;
+  }
+  return true;
+}
+
+function testRegExp(pattern: RegExp, text: string): boolean {
+  const flags = pattern.flags;
+  const clone = new RegExp(pattern.source, flags);
+  clone.lastIndex = pattern.lastIndex;
+  return clone.test(text);
+}
+
+function renderRawMessage(rawMessage: string | TemplateStringsArray): string {
+  return typeof rawMessage === "string" ? rawMessage : [...rawMessage].join("");
+}
+
+function renderMessage(message: readonly unknown[]): string {
+  let rendered = "";
+  for (const part of message) {
+    rendered += renderMessagePart(part);
+  }
+  return rendered;
+}
+
+function renderMessagePart(part: unknown): string {
+  if (typeof part === "string") return part;
+  if (typeof part === "bigint") return `${part}n`;
+  if (part instanceof Error) return part.message;
+  if (part == null) return String(part);
+  if (typeof part === "object") {
+    try {
+      return JSON.stringify(part) ?? String(part);
+    } catch {
+      return String(part);
+    }
+  }
+  return String(part);
+}
+
+function formatMatcher(match: LogRecordMatch): string {
+  const lines: string[] = [];
+  if (match.category != null) {
+    lines.push(`  category: ${formatCategoryMatcher(match.category)}`);
+  }
+  if (match.categoryPrefix != null) {
+    lines.push(
+      `  categoryPrefix: ${
+        formatCategoryValue(parseCategory(match.categoryPrefix))
+      }`,
+    );
+  }
+  if (match.level != null) lines.push(`  level: ${formatValue(match.level)}`);
+  if (match.message != null) {
+    lines.push(`  message: ${formatMessageMatcher(match.message)}`);
+  }
+  if (match.rawMessage != null) {
+    lines.push(`  rawMessage: ${formatTextMatcher(match.rawMessage)}`);
+  }
+  if (match.properties != null) {
+    lines.push(...formatPropertiesMatcher(match.properties));
+  }
+  if (match.predicate != null) lines.push("  predicate: <predicate>");
+  return lines.length < 1 ? "  <any record>" : lines.join("\n");
+}
+
+function formatCategoryMatcher(
+  category: string | readonly string[] | RegExp,
+): string {
+  return category instanceof RegExp
+    ? String(category)
+    : typeof category === "string"
+    ? formatValue(category)
+    : formatCategoryValue(category);
+}
+
+function formatCategoryValue(category: readonly string[]): string {
+  return `[${category.map((part) => formatValue(part)).join(", ")}]`;
+}
+
+function formatMessageMatcher(
+  matcher: string | RegExp | ((record: LogRecord) => boolean),
+): string {
+  return typeof matcher === "function" ? "<predicate>" : formatTextMatcher(
+    matcher,
+  );
+}
+
+function formatTextMatcher(matcher: string | RegExp): string {
+  return typeof matcher === "string" ? formatValue(matcher) : String(matcher);
+}
+
+function formatPropertiesMatcher(
+  matcher: Readonly<Record<string, unknown>> | PropertyMatcher,
+): string[] {
+  if (typeof matcher === "function") return ["  properties: <predicate>"];
+  const lines = Object.keys(matcher).map((key) =>
+    `  properties.${key}: ${formatValue(matcher[key])}`
+  );
+  return lines.length < 1 ? ["  properties: {}"] : lines;
+}
+
+function formatRecords(records: readonly LogRecord[]): string {
+  if (records.length < 1) return "  <none>";
+  const lines = records.slice(0, 3).map(formatRecord);
+  if (records.length > 3) {
+    lines.push(`  ... ${records.length - 3} more`);
+  }
+  return lines.join("\n");
+}
+
+function formatRecord(record: LogRecord): string {
+  const category = formatCategory(record.category);
+  return `  [${record.level}] ${category}: ${renderMessage(record.message)}${
+    formatProperties(record.properties)
+  }`;
+}
+
+function formatCategory(category: readonly string[]): string {
+  return category.length < 1 ? "<root>" : category.join(".");
+}
+
+function formatProperties(
+  properties: Readonly<Record<string, unknown>>,
+): string {
+  const entries = Object.keys(properties);
+  if (entries.length < 1) return "";
+  const summary = entries.slice(0, 3).map((key) =>
+    `${key}: ${formatValue(properties[key])}`
+  );
+  if (entries.length > 3) summary.push(`... ${entries.length - 3} more`);
+  return ` {${summary.join(", ")}}`;
+}
+
+function formatCount(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "bigint") return `${value}n`;
+  if (typeof value === "symbol") return String(value);
+  if (value instanceof RegExp) return String(value);
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}`;
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -233,26 +233,63 @@ export function createLogRecorder(): LogRecorder {
 function materializeLogRecord(record: LogRecord): LogRecord {
   const message = record.message;
   const rawMessage = record.rawMessage;
-  const messageDescriptor = Object.getOwnPropertyDescriptor(record, "message");
-  const rawMessageDescriptor = Object.getOwnPropertyDescriptor(
+  const descriptors = Object.getOwnPropertyDescriptors(
     record,
-    "rawMessage",
-  );
+  ) as PropertyDescriptorMap;
+  const messageDescriptor = descriptors.message;
+  const rawMessageDescriptor = descriptors.rawMessage;
   if (
-    messageDescriptor != null &&
-    "value" in messageDescriptor &&
-    rawMessageDescriptor != null &&
-    "value" in rawMessageDescriptor
+    isDataDescriptor(messageDescriptor) &&
+    isDataDescriptor(rawMessageDescriptor)
   ) {
     return record;
   }
+  const snapshotDescriptors = Object.create(null) as PropertyDescriptorMap;
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (isLogRecordKey(key)) continue;
+    snapshotDescriptors[key] = descriptors[key];
+  }
+  Object.assign(snapshotDescriptors, {
+    category: materializedDescriptor(record.category, descriptors.category),
+    level: materializedDescriptor(record.level, descriptors.level),
+    message: materializedDescriptor(message, messageDescriptor),
+    rawMessage: materializedDescriptor(rawMessage, rawMessageDescriptor),
+    timestamp: materializedDescriptor(record.timestamp, descriptors.timestamp),
+    properties: materializedDescriptor(
+      record.properties,
+      descriptors.properties,
+    ),
+  });
+  return Object.defineProperties(
+    Object.create(Object.getPrototypeOf(record)),
+    snapshotDescriptors,
+  ) as LogRecord;
+}
+
+function isDataDescriptor(
+  descriptor: PropertyDescriptor | undefined,
+): descriptor is PropertyDescriptor & { readonly value: unknown } {
+  return descriptor != null && "value" in descriptor;
+}
+
+function isLogRecordKey(key: PropertyKey): key is keyof LogRecord {
+  return key === "category" ||
+    key === "level" ||
+    key === "message" ||
+    key === "rawMessage" ||
+    key === "timestamp" ||
+    key === "properties";
+}
+
+function materializedDescriptor(
+  value: unknown,
+  descriptor: PropertyDescriptor | undefined,
+): PropertyDescriptor {
   return {
-    category: record.category,
-    level: record.level,
-    message,
-    rawMessage,
-    timestamp: record.timestamp,
-    properties: record.properties,
+    configurable: descriptor?.configurable ?? true,
+    enumerable: descriptor?.enumerable ?? true,
+    value,
+    writable: isDataDescriptor(descriptor) ? descriptor.writable : true,
   };
 }
 

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -584,14 +584,24 @@ function formatSet(value: ReadonlySet<unknown>): string {
 }
 
 function safeJsonStringify(value: unknown): string | undefined {
-  const seen = new WeakSet<object>();
-  return JSON.stringify(value, (_key, item: unknown) => {
+  const ancestors: object[] = [];
+  return JSON.stringify(value, function (
+    this: unknown,
+    _key: string,
+    item: unknown,
+  ): unknown {
     if (typeof item === "bigint") return `${item}n`;
     if (item instanceof RegExp) return String(item);
     if (item instanceof Error) return `${item.name}: ${item.message}`;
     if (typeof item === "object" && item != null) {
-      if (seen.has(item)) return "[Circular]";
-      seen.add(item);
+      while (
+        ancestors.length > 0 &&
+        ancestors[ancestors.length - 1] !== this
+      ) {
+        ancestors.pop();
+      }
+      if (ancestors.includes(item)) return "[Circular]";
+      ancestors.push(item);
       if (item instanceof Map) return formatMapContents(item);
       if (item instanceof Set) return Array.from(item);
     }

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -3,9 +3,10 @@ import {
   type LogLevel,
   type LogRecord,
   type Sink,
+  type TextFormatter,
 } from "@logtape/logtape";
 
-const messageFormatter = getTextFormatter({
+const messageFormatter: TextFormatter = getTextFormatter({
   format: ({ message }) => message,
   lineEnding: "lf",
   timestamp: "none",
@@ -317,7 +318,7 @@ function matchesProperties(
   record: LogRecord,
   matcher: Readonly<Record<string, unknown>> | PropertyMatcher,
 ): boolean {
-  const props = properties ?? {};
+  const props: Readonly<Record<string, unknown>> = properties ?? {};
   if (typeof matcher === "function") return matcher(props, record);
   for (const key of Object.keys(matcher)) {
     if (!Object.hasOwn(props, key)) return false;
@@ -434,7 +435,7 @@ function formatCategory(category: readonly string[]): string {
 function formatProperties(
   properties: Readonly<Record<string, unknown>> | null | undefined,
 ): string {
-  const props = properties ?? {};
+  const props: Readonly<Record<string, unknown>> = properties ?? {};
   const entries = Object.keys(props);
   if (entries.length < 1) return "";
   const summary = entries.slice(0, 3).map((key) =>

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -280,7 +280,8 @@ function matchesCategoryPrefix(
 function parseCategory(
   category: string | readonly string[],
 ): readonly string[] {
-  return typeof category === "string" ? category.split(".") : category;
+  if (typeof category !== "string") return category;
+  return category === "" ? [] : category.split(".");
 }
 
 function matchesMessage(
@@ -299,21 +300,24 @@ function matchesText(text: string, matcher: string | RegExp): boolean {
 }
 
 function matchesProperties(
-  properties: Readonly<Record<string, unknown>>,
+  properties: Readonly<Record<string, unknown>> | null | undefined,
   record: LogRecord,
   matcher: Readonly<Record<string, unknown>> | PropertyMatcher,
 ): boolean {
-  if (typeof matcher === "function") return matcher(properties, record);
+  const props = properties ?? {};
+  if (typeof matcher === "function") return matcher(props, record);
   for (const key of Object.keys(matcher)) {
-    if (!Object.hasOwn(properties, key)) return false;
-    if (!Object.is(properties[key], matcher[key])) return false;
+    if (!Object.hasOwn(props, key)) return false;
+    if (!Object.is(props[key], matcher[key])) return false;
   }
   return true;
 }
 
 function testRegExp(pattern: RegExp, text: string): boolean {
-  const flags = pattern.flags;
-  const clone = new RegExp(pattern.source, flags);
+  if (!pattern.global && !pattern.sticky) {
+    return pattern.test(text);
+  }
+  const clone = new RegExp(pattern.source, pattern.flags);
   return clone.test(text);
 }
 
@@ -332,7 +336,7 @@ function renderMessage(message: readonly unknown[]): string {
 function renderMessagePart(part: unknown): string {
   if (typeof part === "string") return part;
   if (typeof part === "bigint") return `${part}n`;
-  if (part instanceof Error) return part.message;
+  if (part instanceof Error) return `${part.name}: ${part.message}`;
   if (part instanceof RegExp) return String(part);
   if (part instanceof Date) {
     try {
@@ -435,12 +439,13 @@ function formatCategory(category: readonly string[]): string {
 }
 
 function formatProperties(
-  properties: Readonly<Record<string, unknown>>,
+  properties: Readonly<Record<string, unknown>> | null | undefined,
 ): string {
-  const entries = Object.keys(properties);
+  const props = properties ?? {};
+  const entries = Object.keys(props);
   if (entries.length < 1) return "";
   const summary = entries.slice(0, 3).map((key) =>
-    `${key}: ${formatValue(properties[key])}`
+    `${key}: ${formatValue(props[key])}`
   );
   if (entries.length > 3) summary.push(`... ${entries.length - 3} more`);
   return ` {${summary.join(", ")}}`;

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -463,10 +463,31 @@ function formatValue(value: unknown): string {
   if (value instanceof Error) {
     return `${value.name}: ${value.message}`;
   }
+  if (value instanceof Map) return formatMap(value);
+  if (value instanceof Set) return formatSet(value);
   try {
     return JSON.stringify(value) ?? safeString(value);
   } catch {
     return safeString(value);
+  }
+}
+
+function formatMap(value: ReadonlyMap<unknown, unknown>): string {
+  const label = `Map(${value.size})`;
+  try {
+    const entries = value as Iterable<readonly [PropertyKey, unknown]>;
+    return `${label} ${JSON.stringify(Object.fromEntries(entries))}`;
+  } catch {
+    return label;
+  }
+}
+
+function formatSet(value: ReadonlySet<unknown>): string {
+  const label = `Set(${value.size})`;
+  try {
+    return `${label} ${JSON.stringify(Array.from(value))}`;
+  } catch {
+    return label;
   }
 }
 

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -442,6 +442,9 @@ function formatCount(count: number, noun: string): string {
 
 function formatValue(value: unknown): string {
   if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return String(value);
+  }
   if (typeof value === "bigint") return `${value}n`;
   if (typeof value === "symbol") return String(value);
   if (value instanceof RegExp) return String(value);

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -247,7 +247,11 @@ function materializeLogRecord(record: LogRecord): LogRecord {
   const snapshotDescriptors = Object.create(null) as PropertyDescriptorMap;
   for (const key of Reflect.ownKeys(descriptors)) {
     if (isLogRecordKey(key)) continue;
-    snapshotDescriptors[key] = descriptors[key];
+    const descriptor = descriptors[key];
+    if (descriptor == null) continue;
+    snapshotDescriptors[key] = isDataDescriptor(descriptor)
+      ? descriptor
+      : materializedDescriptor(Reflect.get(record, key), descriptor);
   }
   Object.assign(snapshotDescriptors, {
     category: materializedDescriptor(record.category, descriptors.category),
@@ -383,7 +387,7 @@ function matchesProperties(
   const props: Readonly<Record<string, unknown>> = properties ?? {};
   if (typeof matcher === "function") return matcher(props, record);
   for (const key of Object.keys(matcher)) {
-    if (!Object.hasOwn(props, key)) return false;
+    if (!Object.prototype.hasOwnProperty.call(props, key)) return false;
     if (!matchesPropertyValue(props[key], matcher[key])) return false;
   }
   return true;

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -410,7 +410,7 @@ function formatPropertiesMatcher(
 ): string[] {
   if (typeof matcher === "function") return ["  properties: <predicate>"];
   const lines = Object.keys(matcher).map((key) =>
-    `  properties.${key}: ${formatValue(matcher[key])}`
+    `  properties.${key}: ${formatPropertyValue(matcher, key)}`
   );
   return lines.length < 1 ? ["  properties: {}"] : lines;
 }
@@ -442,10 +442,27 @@ function formatProperties(
   const entries = Object.keys(props);
   if (entries.length < 1) return "";
   const summary = entries.slice(0, 3).map((key) =>
-    `${key}: ${formatValue(props[key])}`
+    `${key}: ${formatPropertyValue(props, key)}`
   );
   if (entries.length > 3) summary.push(`... ${entries.length - 3} more`);
   return ` {${summary.join(", ")}}`;
+}
+
+function formatPropertyValue(
+  properties: Readonly<Record<string, unknown>>,
+  key: string,
+): string {
+  try {
+    return formatValue(properties[key]);
+  } catch (error) {
+    return formatAccessError(error);
+  }
+}
+
+function formatAccessError(error: unknown): string {
+  return `<error: ${
+    error instanceof Error ? error.message : safeString(error)
+  }>`;
 }
 
 function formatCount(count: number, noun: string): string {
@@ -497,6 +514,7 @@ function safeJsonStringify(value: unknown): string | undefined {
   return JSON.stringify(value, (_key, item: unknown) => {
     if (typeof item === "bigint") return `${item}n`;
     if (item instanceof RegExp) return String(item);
+    if (item instanceof Error) return `${item.name}: ${item.message}`;
     if (typeof item === "object" && item != null) {
       if (seen.has(item)) return "[Circular]";
       seen.add(item);

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -246,7 +246,7 @@ function matchesLogRecord(record: LogRecord, match: LogRecordMatch): boolean {
   if (match.level != null && record.level !== match.level) return false;
   if (
     match.message != null &&
-    !matchesMessage(renderMessage(record), record, match.message)
+    !matchesMessage(record, match.message)
   ) {
     return false;
   }
@@ -299,12 +299,11 @@ function parseCategory(
 }
 
 function matchesMessage(
-  renderedMessage: string,
   record: LogRecord,
   matcher: string | RegExp | ((record: LogRecord) => boolean),
 ): boolean {
   if (typeof matcher === "function") return matcher(record);
-  return matchesText(renderedMessage, matcher);
+  return matchesText(renderMessage(record), matcher);
 }
 
 function matchesText(text: string, matcher: string | RegExp): boolean {
@@ -426,9 +425,17 @@ function formatRecords(records: readonly LogRecord[]): string {
 
 function formatRecord(record: LogRecord): string {
   const category = formatCategory(record.category);
-  return `  [${record.level}] ${category}: ${renderMessage(record)}${
+  return `  [${record.level}] ${category}: ${formatMessage(record)}${
     formatProperties(record.properties)
   }`;
+}
+
+function formatMessage(record: LogRecord): string {
+  try {
+    return renderMessage(record);
+  } catch (error) {
+    return formatAccessError(error);
+  }
 }
 
 function formatCategory(category: readonly string[]): string {

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -334,7 +334,7 @@ function testRegExp(pattern: RegExp, text: string): boolean {
 }
 
 function renderRawMessage(rawMessage: string | TemplateStringsArray): string {
-  return typeof rawMessage === "string" ? rawMessage : [...rawMessage].join("");
+  return typeof rawMessage === "string" ? rawMessage : rawMessage.join("");
 }
 
 function renderMessage(record: LogRecord): string {

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -178,7 +178,7 @@ export interface LogRecorder {
 export function createLogRecorder(): LogRecorder {
   const records: LogRecord[] = [];
   const sink: Sink = (record: LogRecord): void => {
-    records.push(record);
+    records.push(materializeLogRecord(record));
   };
 
   return {
@@ -227,6 +227,32 @@ export function createLogRecorder(): LogRecorder {
         ].join("\n"),
       );
     },
+  };
+}
+
+function materializeLogRecord(record: LogRecord): LogRecord {
+  const message = record.message;
+  const rawMessage = record.rawMessage;
+  const messageDescriptor = Object.getOwnPropertyDescriptor(record, "message");
+  const rawMessageDescriptor = Object.getOwnPropertyDescriptor(
+    record,
+    "rawMessage",
+  );
+  if (
+    messageDescriptor != null &&
+    "value" in messageDescriptor &&
+    rawMessageDescriptor != null &&
+    "value" in rawMessageDescriptor
+  ) {
+    return record;
+  }
+  return {
+    category: record.category,
+    level: record.level,
+    message,
+    rawMessage,
+    timestamp: record.timestamp,
+    properties: record.properties,
   };
 }
 

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -92,7 +92,7 @@ export interface LogRecorder {
   readonly sink: Sink;
 
   /**
-   * Records collected so far, in sink call order.
+   * A snapshot of records collected so far, in sink call order.
    */
   readonly records: readonly LogRecord[];
 
@@ -184,7 +184,7 @@ export function createLogRecorder(): LogRecorder {
   return {
     sink,
     get records(): readonly LogRecord[] {
-      return records;
+      return records.slice();
     },
     clear(): void {
       records.length = 0;

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -256,11 +256,12 @@ function matchesCategory(
   category: readonly string[],
   expected: string | readonly string[] | RegExp,
 ): boolean {
+  const joinedCategory = category.join(".");
   if (expected instanceof RegExp) {
-    return testRegExp(expected, formatCategory(category));
+    return testRegExp(expected, joinedCategory);
   }
   if (typeof expected === "string") {
-    return formatCategory(category) === expected;
+    return joinedCategory === expected;
   }
   const expectedCategory = parseCategory(expected);
   return category.length === expectedCategory.length &&

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -236,14 +236,11 @@ function materializeLogRecord(record: LogRecord): LogRecord {
   const descriptors = Object.getOwnPropertyDescriptors(
     record,
   ) as PropertyDescriptorMap;
-  const messageDescriptor = descriptors.message;
-  const rawMessageDescriptor = descriptors.rawMessage;
-  if (
-    isDataDescriptor(messageDescriptor) &&
-    isDataDescriptor(rawMessageDescriptor)
-  ) {
+  if (!hasStringAccessorDescriptor(descriptors)) {
     return record;
   }
+  const messageDescriptor = descriptors.message;
+  const rawMessageDescriptor = descriptors.rawMessage;
   const snapshotDescriptors = Object.create(null) as PropertyDescriptorMap;
   for (const key of Reflect.ownKeys(descriptors)) {
     if (isLogRecordKey(key)) continue;
@@ -268,6 +265,16 @@ function materializeLogRecord(record: LogRecord): LogRecord {
     Object.create(Object.getPrototypeOf(record)),
     snapshotDescriptors,
   ) as LogRecord;
+}
+
+function hasStringAccessorDescriptor(
+  descriptors: PropertyDescriptorMap,
+): boolean {
+  for (const key of Object.getOwnPropertyNames(descriptors)) {
+    const descriptor = descriptors[key];
+    if (descriptor != null && !isDataDescriptor(descriptor)) return true;
+  }
+  return false;
 }
 
 function isDataDescriptor(

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -449,8 +449,16 @@ function formatValue(value: unknown): string {
     return `${value.name}: ${value.message}`;
   }
   try {
-    return JSON.stringify(value) ?? String(value);
+    return JSON.stringify(value) ?? safeString(value);
   } catch {
+    return safeString(value);
+  }
+}
+
+function safeString(value: unknown): string {
+  try {
     return String(value);
+  } catch {
+    return Object.prototype.toString.call(value);
   }
 }

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -314,7 +314,6 @@ function matchesProperties(
 function testRegExp(pattern: RegExp, text: string): boolean {
   const flags = pattern.flags;
   const clone = new RegExp(pattern.source, flags);
-  clone.lastIndex = pattern.lastIndex;
   return clone.test(text);
 }
 
@@ -334,6 +333,14 @@ function renderMessagePart(part: unknown): string {
   if (typeof part === "string") return part;
   if (typeof part === "bigint") return `${part}n`;
   if (part instanceof Error) return part.message;
+  if (part instanceof RegExp) return String(part);
+  if (part instanceof Date) {
+    try {
+      return part.toISOString();
+    } catch {
+      return String(part);
+    }
+  }
   if (part == null) return String(part);
   if (typeof part === "object") {
     try {

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -475,8 +475,16 @@ function formatValue(value: unknown): string {
 function formatMap(value: ReadonlyMap<unknown, unknown>): string {
   const label = `Map(${value.size})`;
   try {
-    const entries = value as Iterable<readonly [PropertyKey, unknown]>;
-    return `${label} ${JSON.stringify(Object.fromEntries(entries))}`;
+    const entries = Array.from(
+      value,
+      ([key, entryValue]) => [safeString(key), entryValue] as const,
+    );
+    const keys = entries.map(([key]) => key);
+    const uniqueKeys = new Set(keys);
+    const contents = uniqueKeys.size === keys.length
+      ? Object.fromEntries(entries)
+      : entries;
+    return `${label} ${JSON.stringify(contents)}`;
   } catch {
     return label;
   }

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -466,7 +466,7 @@ function formatValue(value: unknown): string {
   if (value instanceof Map) return formatMap(value);
   if (value instanceof Set) return formatSet(value);
   try {
-    return JSON.stringify(value) ?? safeString(value);
+    return safeJsonStringify(value) ?? safeString(value);
   } catch {
     return safeString(value);
   }
@@ -475,16 +475,8 @@ function formatValue(value: unknown): string {
 function formatMap(value: ReadonlyMap<unknown, unknown>): string {
   const label = `Map(${value.size})`;
   try {
-    const entries = Array.from(
-      value,
-      ([key, entryValue]) => [safeString(key), entryValue] as const,
-    );
-    const keys = entries.map(([key]) => key);
-    const uniqueKeys = new Set(keys);
-    const contents = uniqueKeys.size === keys.length
-      ? Object.fromEntries(entries)
-      : entries;
-    return `${label} ${JSON.stringify(contents)}`;
+    const contents = formatMapContents(value);
+    return `${label} ${safeJsonStringify(contents) ?? safeString(contents)}`;
   } catch {
     return label;
   }
@@ -493,10 +485,40 @@ function formatMap(value: ReadonlyMap<unknown, unknown>): string {
 function formatSet(value: ReadonlySet<unknown>): string {
   const label = `Set(${value.size})`;
   try {
-    return `${label} ${JSON.stringify(Array.from(value))}`;
+    const contents = Array.from(value);
+    return `${label} ${safeJsonStringify(contents) ?? safeString(contents)}`;
   } catch {
     return label;
   }
+}
+
+function safeJsonStringify(value: unknown): string | undefined {
+  const seen = new WeakSet<object>();
+  return JSON.stringify(value, (_key, item: unknown) => {
+    if (typeof item === "bigint") return `${item}n`;
+    if (item instanceof RegExp) return String(item);
+    if (typeof item === "object" && item != null) {
+      if (seen.has(item)) return "[Circular]";
+      seen.add(item);
+      if (item instanceof Map) return formatMapContents(item);
+      if (item instanceof Set) return Array.from(item);
+    }
+    return item;
+  });
+}
+
+function formatMapContents(
+  value: ReadonlyMap<unknown, unknown>,
+): Readonly<Record<string, unknown>> | readonly (readonly [string, unknown])[] {
+  const entries = Array.from(
+    value,
+    ([key, entryValue]) => [safeString(key), entryValue] as const,
+  );
+  const keys = entries.map(([key]) => key);
+  const uniqueKeys = new Set(keys);
+  return uniqueKeys.size === keys.length
+    ? Object.fromEntries(entries)
+    : entries;
 }
 
 function safeString(value: unknown): string {

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -31,9 +31,9 @@ export type PropertyMatcher = (
  *
  * Object property matching is shallow: every own string key in the matcher
  * must exist on the record properties and match by value.  Most values are
- * compared with `Object.is()`, while `Date` values are compared by timestamp.
- * Use a {@link PropertyMatcher} when a test needs absence checks or deeper
- * matching.
+ * compared with `Object.is()`, `Date` values are compared by timestamp, and
+ * regular expression matcher values match string property values.  Use a
+ * {@link PropertyMatcher} when a test needs absence checks or deeper matching.
  *
  * @since 2.2.0
  */
@@ -330,6 +330,9 @@ function matchesProperties(
 function matchesPropertyValue(actual: unknown, expected: unknown): boolean {
   if (actual instanceof Date && expected instanceof Date) {
     return Object.is(actual.getTime(), expected.getTime());
+  }
+  if (typeof actual === "string" && expected instanceof RegExp) {
+    return testRegExp(expected, actual);
   }
   return Object.is(actual, expected);
 }

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -1,4 +1,15 @@
-import type { LogLevel, LogRecord, Sink } from "@logtape/logtape";
+import {
+  getTextFormatter,
+  type LogLevel,
+  type LogRecord,
+  type Sink,
+} from "@logtape/logtape";
+
+const messageFormatter = getTextFormatter({
+  format: ({ message }) => message,
+  lineEnding: "lf",
+  timestamp: "none",
+});
 
 /**
  * A predicate that matches log record properties.
@@ -45,7 +56,8 @@ export interface LogRecordMatch {
 
   /**
    * Rendered message matcher.  String and regular expression matchers are
-   * applied to the rendered message.  A predicate receives the full record.
+   * applied to the rendered message, using the same value rendering as
+   * LogTape's default text formatter.  A predicate receives the full record.
    */
   readonly message?: string | RegExp | ((record: LogRecord) => boolean);
 
@@ -144,14 +156,14 @@ export interface LogRecorder {
  *   });
  *
  *   getLogger(["my-lib"]).info("User {userId} logged in.", {
- *     userId: "u-123",
+ *     userId: 123,
  *   });
  *
  *   recorder.assertLogged({
  *     category: ["my-lib"],
  *     level: "info",
- *     message: "User u-123 logged in.",
- *     properties: { userId: "u-123" },
+ *     message: "User 123 logged in.",
+ *     properties: { userId: 123 },
  *   });
  * } finally {
  *   await reset();
@@ -232,7 +244,7 @@ function matchesLogRecord(record: LogRecord, match: LogRecordMatch): boolean {
   if (match.level != null && record.level !== match.level) return false;
   if (
     match.message != null &&
-    !matchesMessage(renderMessage(record.message), record, match.message)
+    !matchesMessage(renderMessage(record), record, match.message)
   ) {
     return false;
   }
@@ -325,35 +337,8 @@ function renderRawMessage(rawMessage: string | TemplateStringsArray): string {
   return typeof rawMessage === "string" ? rawMessage : [...rawMessage].join("");
 }
 
-function renderMessage(message: readonly unknown[]): string {
-  let rendered = "";
-  for (const part of message) {
-    rendered += renderMessagePart(part);
-  }
-  return rendered;
-}
-
-function renderMessagePart(part: unknown): string {
-  if (typeof part === "string") return part;
-  if (typeof part === "bigint") return `${part}n`;
-  if (part instanceof Error) return `${part.name}: ${part.message}`;
-  if (part instanceof RegExp) return String(part);
-  if (part instanceof Date) {
-    try {
-      return part.toISOString();
-    } catch {
-      return String(part);
-    }
-  }
-  if (part == null) return String(part);
-  if (typeof part === "object") {
-    try {
-      return JSON.stringify(part) ?? String(part);
-    } catch {
-      return String(part);
-    }
-  }
-  return String(part);
+function renderMessage(record: LogRecord): string {
+  return messageFormatter(record).slice(0, -1);
 }
 
 function formatMatcher(match: LogRecordMatch): string {
@@ -429,7 +414,7 @@ function formatRecords(records: readonly LogRecord[]): string {
 
 function formatRecord(record: LogRecord): string {
   const category = formatCategory(record.category);
-  return `  [${record.level}] ${category}: ${renderMessage(record.message)}${
+  return `  [${record.level}] ${category}: ${renderMessage(record)}${
     formatProperties(record.properties)
   }`;
 }

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -29,9 +29,10 @@ export type PropertyMatcher = (
  * A matcher for records collected by a {@link LogRecorder}.
  *
  * Object property matching is shallow: every own string key in the matcher
- * must exist on the record properties and have the same value according to
- * `Object.is()`.  Use a {@link PropertyMatcher} when a test needs absence
- * checks or deeper matching.
+ * must exist on the record properties and match by value.  Most values are
+ * compared with `Object.is()`, while `Date` values are compared by timestamp.
+ * Use a {@link PropertyMatcher} when a test needs absence checks or deeper
+ * matching.
  *
  * @since 2.2.0
  */
@@ -320,9 +321,16 @@ function matchesProperties(
   if (typeof matcher === "function") return matcher(props, record);
   for (const key of Object.keys(matcher)) {
     if (!Object.hasOwn(props, key)) return false;
-    if (!Object.is(props[key], matcher[key])) return false;
+    if (!matchesPropertyValue(props[key], matcher[key])) return false;
   }
   return true;
+}
+
+function matchesPropertyValue(actual: unknown, expected: unknown): boolean {
+  if (actual instanceof Date && expected instanceof Date) {
+    return Object.is(actual.getTime(), expected.getTime());
+  }
+  return Object.is(actual, expected);
 }
 
 function testRegExp(pattern: RegExp, text: string): boolean {

--- a/packages/testing/tsdown.config.ts
+++ b/packages/testing/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "src/mod.ts",
+  dts: {
+    sourcemap: true,
+  },
+  format: ["esm", "cjs"],
+  platform: "neutral",
+  unbundle: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@logtape/syslog':
         specifier: 'workspace:'
         version: link:../packages/syslog
+      '@logtape/testing':
+        specifier: 'workspace:'
+        version: link:../packages/testing
       '@logtape/windows-eventlog':
         specifier: 'workspace:'
         version: link:../packages/windows-eventlog
@@ -789,6 +792,22 @@ importers:
       '@std/assert':
         specifier: 'catalog:'
         version: '@jsr/std__assert@1.0.13'
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.12.7(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
+  packages/testing:
+    dependencies:
+      '@logtape/logtape':
+        specifier: workspace:^
+        version: link:../logtape
+    devDependencies:
+      '@logtape/redaction':
+        specifier: workspace:^
+        version: link:../redaction
       tsdown:
         specifier: 'catalog:'
         version: 0.12.7(typescript@5.8.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ packages:
 - packages/redaction
 - packages/sentry
 - packages/syslog
+- packages/testing
 - packages/cloudwatch-logs
 - packages/config
 - packages/windows-eventlog


### PR DESCRIPTION

Closes #173.


Summary
-------

This PR adds *packages/testing/*, a new `@logtape/testing` package for collecting LogTape records in tests. Its main API is `createLogRecorder()`, which provides a sink plus small assertion helpers for checking category, level, rendered message, raw message, and structured properties.

The recorder keeps the normal `configure()` and `reset()` lifecycle visible. It does not add test-only helpers to `@logtape/logtape` itself, so runtime users do not pull in a testing surface through the core package.


What changed
------------

 -  Added `createLogRecorder()` with `sink`, `records`, `clear()`, `take()`, `find()`, `filter()`, `assertLogged()`, and `assertNotLogged()`.
 -  Added `LogRecordMatch` and `PropertyMatcher` for category, category prefix, level, message, raw message, properties, and custom predicate matching.
 -  Added readable assertion failures that show the expected matcher, record count, and candidate records.
 -  Registered `@logtape/testing` in the Deno and pnpm workspaces and in the documentation reference navigation.
 -  Updated *docs/manual/testing.md*, *docs/manual/library.md*, *packages/logtape/README.md*, *packages/testing/README.md*, *packages/logtape/skills/logtape/SKILL.md*, and *CHANGES.md*.


Verification
------------

 -  `deno test packages/testing/src/mod.test.ts`
 -  `pnpm --filter @logtape/testing test`
 -  `pnpm --filter @logtape/testing test:bun`
 -  `mise test`
 -  `mise check`
