### PR TITLE
fix: log caught sentry sink error to meta logger

### DIFF
--- a/packages/sentry/src/mod.ts
+++ b/packages/sentry/src/mod.ts
@@ -467,11 +467,11 @@ export function getSentrySink(
           data: attributes,
         });
       }
-    } catch (err) {
-      // Never throw from a sink; keep failures silent but visible in debug
-      try {
-        console.debug("[@logtape/sentry] sink error", err);
-      } catch { /* ignore console errors */ }
+    } catch (error) {
+      getLogger(["logtape", "meta", "sentry"]).error(
+        "Failed to send log events to Sentry",
+        { error },
+      );
     }
   };
 }


### PR DESCRIPTION
whilst looking at how to write a failing test case for [this issue](https://github.com/dahlia/logtape/issues/180), I saw other sinks which used the existence of meta logger logs to prove that errors didn't happen. since this sink uses console.debug, this isn't possible. this pr fixes this