### PR TITLE
fix: dont apply category prefix to sub meta logger

### DIFF
--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -1512,7 +1512,7 @@ export function getLogger(category: string | readonly string[] = []): Logger {
 const globalRootLoggerSymbol = Symbol.for("logtape.rootLogger");
 
 function isMetaLoggerCategory(category: readonly string[]): boolean {
-  return category.length === 2 &&
+  return category.length >= 2 &&
     category[0] === "logtape" &&
     category[1] === "meta";
 }


### PR DESCRIPTION
https://github.com/dahlia/logtape/pull/181#discussion_r3459363723

dont apply `withCategoryPrefix` to meta logger or subloggers of the meta logger.