### PR TITLE
Scoped logging configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Coding conventions
 
 ### Naming conventions
 
-1.  *Modules*: Use camelCase for filenames and import specifiers.
+1.  *Modules*: Use kebab-case for filenames and import specifiers.
 2.  *Classes/Interfaces*: Use PascalCase.
 3.  *Variables/Functions/Methods*: Use camelCase.
 4.  *Constants*: Use camelCase for constants (NOT ALL\_CAPS).
@@ -499,9 +499,20 @@ files at once.
 
  -  *Italics* (`*text*`): Use for package names (*@logtape/logtape*,
     *@logtape/otel*), emphasis, and to distinguish concepts
+
  -  *Bold* (`**text**`): Use sparingly for strong emphasis
+
  -  *Inline code* (`` `code` ``): Use for code spans, function names,
     filenames, and command-line options
+
+ -  *JSR references*: Use the syntax supported by
+    [markdown-it-jsr-ref].
+    A leading `~` is only valid for member references where the rendered text
+    should hide the owner name, such as `~ClassName.fieldName` or
+    `~ClassName.methodName()`.  Do not write standalone references like
+    `~ClassName`; use `ClassName` instead.
+
+[markdown-it-jsr-ref]: https://github.com/dahlia/markdown-it-jsr-ref#syntax
 
 ### Lists
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,21 @@ Version 2.3.0
 
 To be released.
 
+### @logtape/logtape
+
+ -  Added `withConfig()` and `withConfigSync()` functions for applying a
+    LogTape configuration only within the current execution context.  Scoped
+    configurations require `Config.contextLocalStorage`, support nesting, and
+    fully override the process-wide logger routing while active.
+    `withConfigSync()` rejects callbacks that return promises.  [[#185], [#188]]
+
+ -  Added `ScopedConfig` type for scoped configuration objects.  It has the
+    same sink, filter, and logger shape as `Config`, but excludes the
+    process-wide `reset` and `contextLocalStorage` options.  [[#185], [#188]]
+
+[#185]: https://github.com/dahlia/logtape/issues/185
+[#188]: https://github.com/dahlia/logtape/pull/188
+
 ### @logtape/file
 
  -  Added `TimeRotatingFileSinkOptions.parseFilename` option to customize how

--- a/docs/manual/config.md
+++ b/docs/manual/config.md
@@ -301,6 +301,207 @@ resetSync();
 > you should use `resetSync()`.
 
 
+Scoped configuration
+--------------------
+
+*This API is available since LogTape 2.3.0.*
+
+Most applications should call `configure()` once near the entry point and keep
+that process-wide logging policy in place.  Sometimes you need a temporary
+policy for one execution flow instead.  For example, a test helper may want to
+collect debug logs only while a test case runs, or a diagnostic block may want
+to send one request's logs to a separate sink.
+
+Use `withConfig()` for these cases:
+
+~~~~ typescript twoslash
+// @noErrors: 2307
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  configure,
+  getConsoleSink,
+  getLogger,
+  withConfig,
+} from "@logtape/logtape";
+
+await configure({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: "my-app",
+      lowestLevel: "info",
+      sinks: ["console"],
+    },
+    {
+      category: ["logtape", "meta"],
+      lowestLevel: "warning",
+      sinks: ["console"],
+    },
+  ],
+  contextLocalStorage: new AsyncLocalStorage(),
+});
+
+await withConfig({
+  sinks: {
+    debug: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: "my-app",
+      lowestLevel: "debug",
+      sinks: ["debug"],
+    },
+  ],
+}, async () => {
+  getLogger("my-app").debug("This is visible only in this async scope.");
+});
+
+getLogger("my-app").debug("This uses the process-wide configuration again.");
+~~~~
+
+`withConfig()` does not reconfigure LogTape globally.  It stores a scoped
+configuration in the current context-local storage, runs the callback, and then
+disposes the sinks and filters owned by that scoped configuration when the
+callback's return value settles.  Logs emitted by the callback, and by async
+work that the callback returns or awaits, use the scoped configuration.  Logs
+outside the callback continue to use the process-wide configuration.
+
+If the callback starts async work that continues after the callback has
+finished, LogTape does not keep using the disposed scoped configuration in that
+work.  Later logs fall back to the nearest still-active outer scoped
+configuration, or to the process-wide configuration if there is no active outer
+scope.
+
+Because scoped configuration is carried by context-local storage, LogTape must
+already be configured with the `~Config.contextLocalStorage` option.  If
+LogTape is not configured, or if the global configuration does not provide a
+context-local storage, `withConfig()` throws a `ConfigError`.  The
+context-local storage belongs to the process-wide configuration; a scoped
+configuration changes logging policy, not the mechanism used to carry scoped
+state.
+
+> [!CAUTION]
+> Scoped configuration is reliable only when the active LogTape logger
+> implementation in the current runtime also supports it.  If multiple
+> versions of LogTape are loaded into the same runtime, older versions may
+> share the global root logger but do not share scoped configuration state or
+> mutation guards.  Configure LogTape from one version, preferably the newest
+> one, and avoid calling `configure()`, `reset()`, or `dispose()` from another
+> loaded version while scoped configuration is in use.
+
+The scoped configuration is a full override while it is active.  It does not
+merge with the process-wide configuration:
+
+ -  Sinks and filters from the process-wide configuration are not inherited.
+ -  The meta logger is not automatically routed to the default console sink.
+ -  If you want meta logs inside the scope, configure a `["logtape"]` or
+    `["logtape", "meta"]` logger in the scoped configuration.
+
+Nested scopes are allowed.  An inner `withConfig()` overrides the outer scoped
+configuration for its callback, and the outer scoped configuration becomes
+active again when the inner callback finishes:
+
+~~~~ typescript twoslash
+import { getConsoleSink, getLogger, withConfig } from "@logtape/logtape";
+
+await withConfig({
+  sinks: { outer: getConsoleSink() },
+  loggers: [{ category: "my-app", lowestLevel: "info", sinks: ["outer"] }],
+}, async () => {
+  getLogger("my-app").info("Uses the outer scoped configuration.");
+
+  await withConfig({
+    sinks: { inner: getConsoleSink() },
+    loggers: [{ category: "my-app", lowestLevel: "debug", sinks: ["inner"] }],
+  }, async () => {
+    getLogger("my-app").debug("Uses the inner scoped configuration.");
+  });
+
+  getLogger("my-app").info("Uses the outer scoped configuration again.");
+});
+~~~~
+
+Scoped configuration uses the same context-local storage as
+[`withContext()`](./contexts.md) and
+[`withCategoryPrefix()`](./categories.md#category-prefix), but it uses a
+separate internal key.  That means implicit properties and category prefixes
+continue to work inside `withConfig()`:
+
+~~~~ typescript twoslash
+import {
+  getConsoleSink,
+  getLogger,
+  withCategoryPrefix,
+  withConfig,
+  withContext,
+} from "@logtape/logtape";
+
+await withContext({ requestId: "req-1" }, async () => {
+  await withCategoryPrefix("tenant-a", async () => {
+    await withConfig({
+      sinks: { console: getConsoleSink() },
+      loggers: [
+        {
+          category: ["tenant-a", "my-app"],
+          lowestLevel: "debug",
+          sinks: ["console"],
+        },
+      ],
+    }, async () => {
+      getLogger("my-app").debug("Includes the request ID and prefix.");
+    });
+  });
+});
+~~~~
+
+While a scoped configuration is active, LogTape rejects process-wide state
+changes.  Calling `configure()`, `configureSync()`, `reset()`, `resetSync()`,
+`dispose()`, or `disposeSync()` inside the callback throws `ConfigError`.
+If you need another temporary policy, use nested `withConfig()` instead.
+
+`getConfig()` always returns the process-wide configuration.  It is not an
+“effective configuration” API, and it does not return the scoped configuration
+currently active in the context.  Use it when you need to inspect the global
+configuration that was installed with `configure()`, not to discover the
+temporary policy selected by `withConfig()`.
+
+If the scoped sinks or filters implement `AsyncDisposable` or `Disposable`,
+`withConfig()` disposes them when the callback finishes.  If the callback fails
+and disposal also fails, LogTape throws an `AggregateError` that contains both
+the callback error and the disposal error.
+
+### Synchronous scoped configuration
+
+Use `withConfigSync()` when the callback and all scoped resources are
+synchronous:
+
+~~~~ typescript twoslash
+import { getConsoleSink, getLogger, withConfigSync } from "@logtape/logtape";
+
+withConfigSync({
+  sinks: {
+    console: getConsoleSink(),
+  },
+  loggers: [
+    {
+      category: "my-app",
+      lowestLevel: "debug",
+      sinks: ["console"],
+    },
+  ],
+}, () => {
+  getLogger("my-app").debug("Scoped synchronous log.");
+});
+~~~~
+
+Like `configureSync()`, `withConfigSync()` cannot use sinks or filters that
+implement `AsyncDisposable`, and the callback must not return a promise.  Use
+`withConfig()` when the callback or scoped resources need asynchronous work or
+asynchronous disposal.
+
+
 Browser and SPA environments
 ----------------------------
 

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { AsyncLocalStorage } from "node:async_hooks";
+import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
+import { withCategoryPrefix, withContext } from "./context.ts";
+import type { Filter } from "./filter.ts";
+import { getLogger, LoggerImpl } from "./logger.ts";
+import type { LogRecord } from "./record.ts";
+import type { Sink } from "./sink.ts";
 import {
   type Config,
   ConfigError,
@@ -15,11 +20,6 @@ import {
   withConfig,
   withConfigSync,
 } from "./config.ts";
-import { withCategoryPrefix, withContext } from "./context.ts";
-import type { Filter } from "./filter.ts";
-import { getLogger, LoggerImpl } from "./logger.ts";
-import type { LogRecord } from "./record.ts";
-import type { Sink } from "./sink.ts";
 
 const hasAddEventListener = typeof globalThis.addEventListener === "function";
 
@@ -635,6 +635,98 @@ test("withConfig() rejects global state mutation from sibling scopes", async () 
     await reset();
   }
 });
+
+test("withConfig() rejects scopes while global reconfiguration is pending", async () => {
+  let releaseDispose: (() => void) | undefined;
+  const disposeCanFinish = new Promise<void>((resolve) => {
+    releaseDispose = resolve;
+  });
+
+  const sink: Sink & AsyncDisposable = () => {};
+  sink[Symbol.asyncDispose] = () => disposeCanFinish;
+
+  try {
+    await configure({
+      sinks: { sink },
+      loggers: [
+        { category: "my-app", sinks: ["sink"] },
+        { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+      ],
+      contextLocalStorage: new AsyncLocalStorage(),
+      reset: true,
+    });
+
+    const resetPromise = reset();
+    await assert.rejects(
+      () => withConfig({ sinks: {}, loggers: [] }, () => {}),
+      ConfigError,
+    );
+
+    releaseDispose?.();
+    await resetPromise;
+  } finally {
+    releaseDispose?.();
+    await reset();
+  }
+});
+
+const skipUnloadDisposalTest = !("Deno" in globalThis);
+
+test(
+  "configure() unload disposal bypasses active scoped configuration guards",
+  { skip: skipUnloadDisposalTest },
+  async () => {
+    // Workaround for Bun not supporting skip option yet:
+    // https://github.com/oven-sh/bun/issues/19412
+    if (skipUnloadDisposalTest) return;
+
+    const addEventListener = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "addEventListener",
+    );
+    let unloadHandler: (() => unknown) | undefined;
+    let disposed = false;
+    const sink: Sink & AsyncDisposable = () => {};
+    sink[Symbol.asyncDispose] = () => {
+      disposed = true;
+      return Promise.resolve();
+    };
+
+    try {
+      Object.defineProperty(globalThis, "addEventListener", {
+        configurable: true,
+        value(type: string, handler: () => unknown) {
+          if (type === "unload") unloadHandler = handler;
+        },
+        writable: true,
+      });
+
+      await configure({
+        sinks: { sink },
+        loggers: [
+          { category: "my-app", sinks: ["sink"] },
+          { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+        ],
+        contextLocalStorage: new AsyncLocalStorage(),
+        reset: true,
+      });
+
+      assert.notStrictEqual(unloadHandler, undefined);
+      await withConfig({ sinks: {}, loggers: [] }, async () => {
+        await unloadHandler?.();
+      });
+
+      assert.strictEqual(disposed, true);
+    } finally {
+      if (addEventListener == null) {
+        Reflect.deleteProperty(globalThis, "addEventListener");
+      } else {
+        Object.defineProperty(globalThis, "addEventListener", addEventListener);
+      }
+      await reset();
+    }
+  },
+);
 
 test("withConfig() disposes scoped resources when the scope exits", async () => {
   const events: string[] = [];

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -1,20 +1,775 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   type Config,
   ConfigError,
   configure,
   configureSync,
+  dispose,
+  disposeSync,
   getConfig,
   reset,
   resetSync,
+  withConfig,
+  withConfigSync,
 } from "./config.ts";
+import { withCategoryPrefix, withContext } from "./context.ts";
 import type { Filter } from "./filter.ts";
 import { getLogger, LoggerImpl } from "./logger.ts";
 import type { LogRecord } from "./record.ts";
 import type { Sink } from "./sink.ts";
 
 const hasAddEventListener = typeof globalThis.addEventListener === "function";
+
+test("withConfig()", async () => {
+  const globalLogs: LogRecord[] = [];
+  const scopedLogs: LogRecord[] = [];
+
+  await configure({
+    sinks: {
+      global: globalLogs.push.bind(globalLogs),
+    },
+    loggers: [
+      { category: [], sinks: ["global"], lowestLevel: "info" },
+      { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    getLogger("app").debug("before hidden");
+    getLogger("app").info("before");
+
+    const rv = await withConfig({
+      sinks: {
+        scoped: scopedLogs.push.bind(scopedLogs),
+      },
+      loggers: [
+        { category: [], sinks: ["scoped"], lowestLevel: "debug" },
+      ],
+    }, async () => {
+      getLogger("app").debug("inside");
+      await delay(0);
+      getLogger("app").info("inside later");
+      return 123;
+    });
+
+    getLogger("app").debug("after hidden");
+    getLogger("app").info("after");
+
+    assert.strictEqual(rv, 123);
+    assert.deepStrictEqual(
+      globalLogs.map((record) => record.rawMessage),
+      ["before", "after"],
+    );
+    assert.deepStrictEqual(
+      scopedLogs.map((record) => record.rawMessage),
+      ["inside", "inside later"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() requires global context-local storage", async () => {
+  await reset();
+
+  await assert.rejects(
+    () => withConfig({ sinks: {}, loggers: [] }, () => {}),
+    ConfigError,
+  );
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    reset: true,
+  });
+
+  try {
+    await assert.rejects(
+      () => withConfig({ sinks: {}, loggers: [] }, () => {}),
+      ConfigError,
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() supports nested and concurrent scopes", async () => {
+  const globalLogs: LogRecord[] = [];
+  const outerLogs: LogRecord[] = [];
+  const innerLogs: LogRecord[] = [];
+  const concurrentA: LogRecord[] = [];
+  const concurrentB: LogRecord[] = [];
+
+  await configure({
+    sinks: {
+      global: globalLogs.push.bind(globalLogs),
+    },
+    loggers: [
+      { category: [], sinks: ["global"], lowestLevel: "trace" },
+      { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { outer: outerLogs.push.bind(outerLogs) },
+      loggers: [{ category: [], sinks: ["outer"], lowestLevel: "trace" }],
+    }, async () => {
+      getLogger("app").info("outer before");
+      await withConfig({
+        sinks: { inner: innerLogs.push.bind(innerLogs) },
+        loggers: [{ category: [], sinks: ["inner"], lowestLevel: "trace" }],
+      }, () => {
+        getLogger("app").info("inner");
+      });
+      getLogger("app").info("outer after");
+    });
+
+    await Promise.all([
+      withConfig({
+        sinks: { a: concurrentA.push.bind(concurrentA) },
+        loggers: [{ category: [], sinks: ["a"], lowestLevel: "trace" }],
+      }, async () => {
+        await delay(10);
+        getLogger("app").info("a");
+      }),
+      withConfig({
+        sinks: { b: concurrentB.push.bind(concurrentB) },
+        loggers: [{ category: [], sinks: ["b"], lowestLevel: "trace" }],
+      }, async () => {
+        await delay(0);
+        getLogger("app").info("b");
+      }),
+    ]);
+
+    assert.deepStrictEqual(
+      outerLogs.map((record) => record.rawMessage),
+      ["outer before", "outer after"],
+    );
+    assert.deepStrictEqual(
+      innerLogs.map((record) => record.rawMessage),
+      ["inner"],
+    );
+    assert.deepStrictEqual(
+      concurrentA.map((record) => record.rawMessage),
+      ["a"],
+    );
+    assert.deepStrictEqual(
+      concurrentB.map((record) => record.rawMessage),
+      ["b"],
+    );
+    assert.deepStrictEqual(globalLogs, []);
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() ignores disposed scoped configs in propagated async work", async () => {
+  const globalLogs: LogRecord[] = [];
+  const scopedLogs: LogRecord[] = [];
+  let scopedSinkDisposed = false;
+  let disposedScopedSinkCalls = 0;
+  const scopedSink: Sink & Disposable = (record) => {
+    if (scopedSinkDisposed) disposedScopedSinkCalls++;
+    scopedLogs.push(record);
+  };
+  scopedSink[Symbol.dispose] = () => {
+    scopedSinkDisposed = true;
+  };
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let spawned!: Promise<void>;
+
+  await configure({
+    sinks: {
+      global: globalLogs.push.bind(globalLogs),
+    },
+    loggers: [
+      { category: [], sinks: ["global"], lowestLevel: "info" },
+      { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { scoped: scopedSink },
+      loggers: [{ category: [], sinks: ["scoped"], lowestLevel: "info" }],
+    }, () => {
+      getLogger("app").info("inside");
+      spawned = (async () => {
+        await gate;
+        getLogger("app").info("spawned");
+      })();
+    });
+
+    release();
+    await spawned;
+
+    assert.strictEqual(disposedScopedSinkCalls, 0);
+    assert.deepStrictEqual(
+      scopedLogs.map((record) => record.rawMessage),
+      ["inside"],
+    );
+    assert.deepStrictEqual(
+      globalLogs.map((record) => record.rawMessage),
+      ["spawned"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() falls back to active parent scopes", async () => {
+  const globalLogs: LogRecord[] = [];
+  const outerLogs: LogRecord[] = [];
+  const innerLogs: LogRecord[] = [];
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let spawned!: Promise<void>;
+
+  await configure({
+    sinks: {
+      global: globalLogs.push.bind(globalLogs),
+    },
+    loggers: [
+      { category: [], sinks: ["global"], lowestLevel: "info" },
+      { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { outer: outerLogs.push.bind(outerLogs) },
+      loggers: [{ category: [], sinks: ["outer"], lowestLevel: "info" }],
+    }, async () => {
+      await withConfig({
+        sinks: { inner: innerLogs.push.bind(innerLogs) },
+        loggers: [{ category: [], sinks: ["inner"], lowestLevel: "info" }],
+      }, () => {
+        getLogger("app").info("inner");
+        spawned = (async () => {
+          await gate;
+          getLogger("app").info("spawned");
+        })();
+      });
+
+      release();
+      await spawned;
+      getLogger("app").info("outer");
+    });
+
+    assert.deepStrictEqual(globalLogs, []);
+    assert.deepStrictEqual(
+      innerLogs.map((record) => record.rawMessage),
+      ["inner"],
+    );
+    assert.deepStrictEqual(
+      outerLogs.map((record) => record.rawMessage),
+      ["spawned", "outer"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() works with implicit contexts and category prefixes", async () => {
+  const logs: LogRecord[] = [];
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withContext({ requestId: "req-1" }, async () => {
+      await withCategoryPrefix(["tenant-a"], async () => {
+        await withConfig({
+          sinks: { scoped: logs.push.bind(logs) },
+          loggers: [
+            {
+              category: ["tenant-a", "app"],
+              sinks: ["scoped"],
+              lowestLevel: "debug",
+            },
+          ],
+        }, () => {
+          getLogger("app").debug("inside", { userId: 123 });
+        });
+      });
+    });
+
+    assert.deepStrictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].category, ["tenant-a", "app"]);
+    assert.deepStrictEqual(logs[0].properties, {
+      requestId: "req-1",
+      userId: 123,
+    });
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() applies scoped filters, levels, and parent sinks", async () => {
+  const rootLogs: LogRecord[] = [];
+  const dbLogs: LogRecord[] = [];
+  const auditLogs: LogRecord[] = [];
+  const filteredMessages: string[] = [];
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: {
+        audit: auditLogs.push.bind(auditLogs),
+        db: dbLogs.push.bind(dbLogs),
+        root: rootLogs.push.bind(rootLogs),
+      },
+      filters: {
+        allowed(record: LogRecord) {
+          filteredMessages.push(String(record.rawMessage));
+          return record.rawMessage === "allowed";
+        },
+      },
+      loggers: [
+        { category: [], sinks: ["root"], lowestLevel: "info" },
+        {
+          category: ["app", "db"],
+          sinks: ["db"],
+          filters: ["allowed"],
+          lowestLevel: "debug",
+        },
+        {
+          category: ["app", "audit"],
+          sinks: ["audit"],
+          parentSinks: "override",
+          lowestLevel: "warning",
+        },
+      ],
+    }, () => {
+      getLogger(["app", "db"]).info("blocked");
+      getLogger(["app", "db"]).info("allowed");
+      getLogger(["app", "audit"]).info("audit hidden");
+      getLogger(["app", "audit"]).warning("audit shown");
+    });
+
+    assert.deepStrictEqual(filteredMessages, ["blocked", "allowed"]);
+    assert.deepStrictEqual(
+      rootLogs.map((record) => record.rawMessage),
+      ["allowed"],
+    );
+    assert.deepStrictEqual(
+      dbLogs.map((record) => record.rawMessage),
+      ["allowed"],
+    );
+    assert.deepStrictEqual(
+      auditLogs.map((record) => record.rawMessage),
+      ["audit shown"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() preserves scoped lowestLevel null", async () => {
+  const rootLogs: LogRecord[] = [];
+  const disabledLogs: LogRecord[] = [];
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: {
+        disabled: disabledLogs.push.bind(disabledLogs),
+        root: rootLogs.push.bind(rootLogs),
+      },
+      loggers: [
+        { category: [], sinks: ["root"], lowestLevel: "trace" },
+        {
+          category: "disabled",
+          sinks: ["disabled"],
+          lowestLevel: null,
+        },
+      ],
+    }, () => {
+      assert.strictEqual(getLogger("disabled").isEnabledFor("fatal"), false);
+      getLogger("disabled").fatal("hidden");
+      getLogger("enabled").info("shown");
+    });
+
+    assert.deepStrictEqual(
+      rootLogs.map((record) => record.rawMessage),
+      ["shown"],
+    );
+    assert.deepStrictEqual(disabledLogs, []);
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() skips scoped filters when the level is disabled", async () => {
+  const logs: LogRecord[] = [];
+  const filteredMessages: string[] = [];
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { scoped: logs.push.bind(logs) },
+      filters: {
+        record(record: LogRecord) {
+          filteredMessages.push(String(record.rawMessage));
+          return true;
+        },
+      },
+      loggers: [
+        {
+          category: "app",
+          sinks: ["scoped"],
+          filters: ["record"],
+          lowestLevel: "warning",
+        },
+      ],
+    }, () => {
+      getLogger("app").debug("hidden");
+      getLogger("app").warning("shown");
+    });
+
+    assert.deepStrictEqual(filteredMessages, ["shown"]);
+    assert.deepStrictEqual(
+      logs.map((record) => record.rawMessage),
+      ["shown"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() makes isEnabledFor() observe scoped routing", async () => {
+  let evaluated = false;
+  const logs: LogRecord[] = [];
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { scoped: logs.push.bind(logs) },
+      loggers: [
+        { category: ["app"], sinks: ["scoped"], lowestLevel: "warning" },
+      ],
+    }, async () => {
+      assert.strictEqual(getLogger("app").isEnabledFor("debug"), false);
+      assert.strictEqual(getLogger("app").isEnabledFor("warning"), true);
+      await getLogger("app").debug("hidden {value}", async () => {
+        await Promise.resolve();
+        evaluated = true;
+        return { value: 1 };
+      });
+      getLogger("app").warning("shown");
+    });
+
+    assert.strictEqual(evaluated, false);
+    assert.deepStrictEqual(logs.length, 1);
+    assert.deepStrictEqual(logs[0].rawMessage, "shown");
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() rejects invalid scoped configuration", async () => {
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        withConfig({
+          // deno-lint-ignore no-explicit-any
+          sinks: {} as any,
+          loggers: [{ category: "app", sinks: ["missing"] }],
+        }, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          // deno-lint-ignore no-explicit-any
+          filters: {} as any,
+          loggers: [{ category: "app", filters: ["missing"] }],
+        }, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: [{ category: "app" }, { category: ["app"] }],
+        }, () => {}),
+      ConfigError,
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() rejects global state mutation inside a scope", async () => {
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({ sinks: {}, loggers: [] }, async () => {
+      await assert.rejects(
+        () => configure({ sinks: {}, loggers: [] }),
+        ConfigError,
+      );
+      assert.throws(
+        () => configureSync({ sinks: {}, loggers: [] }),
+        ConfigError,
+      );
+      await assert.rejects(() => reset(), ConfigError);
+      assert.throws(() => resetSync(), ConfigError);
+      await assert.rejects(() => dispose(), ConfigError);
+      assert.throws(() => disposeSync(), ConfigError);
+    });
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() rejects global state mutation from sibling scopes", async () => {
+  const logs: LogRecord[] = [];
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let scoped: Promise<void> | undefined;
+
+  await configure({
+    sinks: { global: logs.push.bind(logs) },
+    loggers: [
+      { category: [], sinks: ["global"], lowestLevel: "info" },
+      { category: ["logtape", "meta"], sinks: [], lowestLevel: "fatal" },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    scoped = withConfig({
+      sinks: { scoped: logs.push.bind(logs) },
+      loggers: [{ category: [], sinks: ["scoped"], lowestLevel: "info" }],
+    }, async () => {
+      await gate;
+      getLogger("app").info("scoped");
+    });
+
+    await delay(0);
+    await assert.rejects(
+      () => configure({ sinks: {}, loggers: [], reset: true }),
+      ConfigError,
+    );
+    assert.throws(
+      () => configureSync({ sinks: {}, loggers: [], reset: true }),
+      ConfigError,
+    );
+    await assert.rejects(() => reset(), ConfigError);
+    assert.throws(() => resetSync(), ConfigError);
+    await assert.rejects(() => dispose(), ConfigError);
+    assert.throws(() => disposeSync(), ConfigError);
+
+    release();
+    await scoped;
+
+    assert.deepStrictEqual(
+      logs.map((record) => record.rawMessage),
+      ["scoped"],
+    );
+  } finally {
+    release();
+    await scoped?.catch(() => {});
+    await reset();
+  }
+});
+
+test("withConfig() disposes scoped resources when the scope exits", async () => {
+  const events: string[] = [];
+  const sink: Sink & AsyncDisposable = () => {};
+  sink[Symbol.asyncDispose] = () => {
+    events.push("sink");
+    return Promise.resolve();
+  };
+  const filter: Filter & AsyncDisposable = () => true;
+  filter[Symbol.asyncDispose] = () => {
+    events.push("filter");
+    return Promise.resolve();
+  };
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { sink },
+      filters: { filter },
+      loggers: [{ category: "app", sinks: ["sink"], filters: ["filter"] }],
+    }, () => {});
+
+    assert.deepStrictEqual(events, ["filter", "sink"]);
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() preserves callback and disposal errors", async () => {
+  const callbackError = new Error("callback failed");
+  const disposeError = new Error("dispose failed");
+  const sink: Sink & AsyncDisposable = () => {};
+  sink[Symbol.asyncDispose] = () => Promise.reject(disposeError);
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await assert.rejects(
+      withConfig({
+        sinks: { sink },
+        loggers: [{ category: "app", sinks: ["sink"] }],
+      }, () => {
+        throw callbackError;
+      }),
+      (error) => {
+        assert.ok(error instanceof AggregateError);
+        assert.deepStrictEqual(error.errors, [callbackError, disposeError]);
+        return true;
+      },
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfigSync()", async () => {
+  const logs: LogRecord[] = [];
+  const events: string[] = [];
+  const sink: Sink & Disposable = (record) => logs.push(record);
+  sink[Symbol.dispose] = () => events.push("sink");
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    const rv = withConfigSync({
+      sinks: { sink },
+      loggers: [{ category: "app", sinks: ["sink"], lowestLevel: "debug" }],
+    }, () => {
+      getLogger("app").debug("sync");
+      return 456;
+    });
+
+    assert.strictEqual(rv, 456);
+    assert.deepStrictEqual(logs.map((record) => record.rawMessage), ["sync"]);
+    assert.deepStrictEqual(events, ["sink"]);
+
+    const asyncSink: Sink & AsyncDisposable = () => {};
+    asyncSink[Symbol.asyncDispose] = () => Promise.resolve();
+    assert.throws(
+      () =>
+        withConfigSync({
+          sinks: { asyncSink },
+          loggers: [{ category: "app", sinks: ["asyncSink"] }],
+        }, () => {}),
+      ConfigError,
+    );
+
+    const asyncCallbackEvents: string[] = [];
+    const asyncCallbackSink: Sink & Disposable = () => {};
+    asyncCallbackSink[Symbol.dispose] = () => {
+      asyncCallbackEvents.push("sink");
+    };
+    assert.throws(
+      () =>
+        withConfigSync({
+          sinks: { asyncCallbackSink },
+          loggers: [{ category: "app", sinks: ["asyncCallbackSink"] }],
+          // @ts-expect-error withConfigSync() rejects async callbacks.
+        }, async () => {}),
+      ConfigError,
+    );
+    assert.deepStrictEqual(asyncCallbackEvents, ["sink"]);
+
+    assert.throws(
+      () =>
+        withConfigSync({
+          sinks: {},
+          loggers: [],
+          // @ts-expect-error withConfigSync() rejects async callbacks.
+        }, async () => {
+          await Promise.reject(new Error("async callback failed"));
+        }),
+      ConfigError,
+    );
+    await delay(0);
+  } finally {
+    await reset();
+  }
+});
 
 test("configure()", async () => {
   let disposed = 0;

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -541,6 +541,42 @@ test("withConfig() rejects invalid scoped configuration", async () => {
       ConfigError,
     );
     await assert.rejects(
+      () => withConfig(null as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          loggers: [],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: null,
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: { bad: 1 },
+          loggers: [{ category: "app", sinks: ["bad"] }],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          filters: { bad: 1 },
+          loggers: [{ category: "app", filters: ["bad"] }],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
       () =>
         withConfig({
           sinks: {},

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -586,6 +586,15 @@ test("withConfig() rejects invalid scoped configuration", async () => {
       () =>
         withConfig({
           sinks: {},
+          filters: "filter",
+          loggers: [],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
           loggers: [{ category: "app" }, { category: ["app"] }],
         }, () => {}),
       ConfigError,

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -797,6 +797,55 @@ test("withConfig() disposes scoped resources when the scope exits", async () => 
   }
 });
 
+test("withConfig() does not dispose resources still owned by parent scopes", async () => {
+  const records: LogRecord[] = [];
+  const events: string[] = [];
+  const sharedSink: Sink & Disposable = (record) => {
+    records.push(record);
+  };
+  sharedSink[Symbol.dispose] = () => events.push("sink");
+  const sharedFilter: Filter & Disposable = () => true;
+  sharedFilter[Symbol.dispose] = () => events.push("filter");
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { shared: sharedSink },
+      filters: { shared: sharedFilter },
+      loggers: [
+        { category: "app", filters: ["shared"], sinks: ["shared"] },
+      ],
+    }, async () => {
+      await withConfig({
+        sinks: { shared: sharedSink },
+        filters: { shared: sharedFilter },
+        loggers: [
+          { category: "app", filters: ["shared"], sinks: ["shared"] },
+        ],
+      }, () => {
+        getLogger("app").info("inner");
+      });
+
+      assert.deepStrictEqual(events, []);
+      getLogger("app").info("outer");
+    });
+
+    assert.deepStrictEqual(events, ["filter", "sink"]);
+    assert.deepStrictEqual(
+      records.map((record) => record.rawMessage),
+      ["inner", "outer"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
 test("withConfig() preserves callback and disposal errors", async () => {
   const callbackError = new Error("callback failed");
   const disposeError = new Error("dispose failed");

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -10,6 +10,7 @@ import {
   compileScopedConfig,
   disposeScopedConfig,
   disposeScopedConfigSync,
+  emitWithScopedConfig,
   scopedConfigHasSink,
 } from "./scoped-config.ts";
 import type { Sink } from "./sink.ts";
@@ -1255,6 +1256,52 @@ test("scoped configuration caches sink dispatch plans", () => {
   assert.strictEqual(scopedConfig.dispatchCache.size, 1);
   assert.strictEqual(scopedConfigHasSink(scopedConfig, ["app"], "info"), true);
   assert.strictEqual(scopedConfig.dispatchCache.size, 1);
+});
+
+test("scoped configuration caches filter lookup", () => {
+  const logs: LogRecord[] = [];
+  const filter: Filter = (record) => record.category[0] === "app";
+  const scopedConfig = compileScopedConfig(
+    {
+      sinks: { sink: logs.push.bind(logs) },
+      filters: { filter },
+      loggers: [
+        { category: "app", filters: ["filter"], sinks: ["sink"] },
+        { category: ["app:child"], sinks: ["sink"] },
+      ],
+    },
+    true,
+    (message) => new ConfigError(message),
+  );
+  const emit = (category: readonly string[]): void => {
+    const record: LogRecord = {
+      category,
+      level: "info",
+      message: ["cached"],
+      properties: {},
+      rawMessage: "cached",
+      timestamp: Date.now(),
+    };
+    emitWithScopedConfig(
+      scopedConfig,
+      record,
+      undefined,
+      (sink) => sink(record),
+    );
+  };
+
+  assert.strictEqual(scopedConfig.filterCache.size, 0);
+  emit(["app", "child"]);
+  assert.strictEqual(scopedConfig.filterCache.size, 1);
+  emit(["app", "child"]);
+  assert.strictEqual(scopedConfig.filterCache.size, 1);
+  emit(["app:child"]);
+
+  assert.strictEqual(scopedConfig.filterCache.size, 2);
+  assert.deepStrictEqual(
+    logs.map((record) => record.category),
+    [["app", "child"], ["app", "child"], ["app:child"]],
+  );
 });
 
 test("withConfig() preserves callback and disposal errors", async () => {

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -803,6 +803,41 @@ test("withConfig() disposes scoped resources when the scope exits", async () => 
   }
 });
 
+test("withConfig() prefers async disposal for dual disposable resources", async () => {
+  const events: string[] = [];
+  const sink: Sink & Disposable & AsyncDisposable = () => {};
+  sink[Symbol.dispose] = () => events.push("sync sink");
+  sink[Symbol.asyncDispose] = async () => {
+    await Promise.resolve();
+    events.push("async sink");
+  };
+  const filter: Filter & Disposable & AsyncDisposable = () => true;
+  filter[Symbol.dispose] = () => events.push("sync filter");
+  filter[Symbol.asyncDispose] = async () => {
+    await Promise.resolve();
+    events.push("async filter");
+  };
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { sink },
+      filters: { filter },
+      loggers: [{ category: "app", sinks: ["sink"], filters: ["filter"] }],
+    }, () => {});
+
+    assert.deepStrictEqual(events, ["async filter", "async sink"]);
+  } finally {
+    await reset();
+  }
+});
+
 test("withConfig() does not dispose resources still owned by parent scopes", async () => {
   const records: LogRecord[] = [];
   const events: string[] = [];
@@ -846,6 +881,70 @@ test("withConfig() does not dispose resources still owned by parent scopes", asy
     assert.deepStrictEqual(
       records.map((record) => record.rawMessage),
       ["inner", "outer"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() does not dispose resources still owned by sibling scopes", async () => {
+  const records: LogRecord[] = [];
+  const events: string[] = [];
+  const sharedSink: Sink & Disposable = (record) => {
+    records.push(record);
+  };
+  sharedSink[Symbol.dispose] = () => events.push("sink");
+  const sharedFilter: Filter & Disposable = () => true;
+  sharedFilter[Symbol.dispose] = () => events.push("filter");
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    let finishFirst!: () => void;
+    let markSecondEntered!: () => void;
+    const releaseFirst = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const secondEntered = new Promise<void>((resolve) => {
+      markSecondEntered = resolve;
+    });
+    const firstDone = withConfig({
+      sinks: { shared: sharedSink },
+      filters: { shared: sharedFilter },
+      loggers: [
+        { category: "app", filters: ["shared"], sinks: ["shared"] },
+      ],
+    }, async () => {
+      await secondEntered;
+      await releaseFirst;
+      getLogger("app").info("first");
+    });
+    const secondDone = withConfig({
+      sinks: { shared: sharedSink },
+      filters: { shared: sharedFilter },
+      loggers: [
+        { category: "app", filters: ["shared"], sinks: ["shared"] },
+      ],
+    }, () => {
+      markSecondEntered();
+      assert.deepStrictEqual(events, []);
+      getLogger("app").info("second");
+    });
+
+    await secondDone;
+    assert.deepStrictEqual(events, []);
+    finishFirst();
+    await firstDone;
+
+    assert.deepStrictEqual(events, ["filter", "sink"]);
+    assert.deepStrictEqual(
+      records.map((record) => record.rawMessage).sort(),
+      ["first", "second"],
     );
   } finally {
     await reset();

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -590,6 +590,46 @@ test("withConfig() rejects invalid scoped configuration", async () => {
         }, () => {}),
       ConfigError,
     );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: [null],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: [{ category: 1 }],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: [{ category: ["app", 1] }],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: [{ category: "app", sinks: "sink" }],
+        } as never, () => {}),
+      ConfigError,
+    );
+    await assert.rejects(
+      () =>
+        withConfig({
+          sinks: {},
+          loggers: [{ category: "app", filters: "filter" }],
+        } as never, () => {}),
+      ConfigError,
+    );
   } finally {
     await reset();
   }
@@ -946,6 +986,68 @@ test("withConfig() does not dispose resources still owned by sibling scopes", as
       records.map((record) => record.rawMessage).sort(),
       ["first", "second"],
     );
+  } finally {
+    await reset();
+  }
+});
+
+test("withConfig() disposes resources after overlapping scopes finish", async () => {
+  const events: string[] = [];
+  const sharedSink: Sink & AsyncDisposable = () => {};
+  sharedSink[Symbol.asyncDispose] = async () => {
+    await Promise.resolve();
+    events.push("shared sink");
+  };
+  let releaseFirstDisposal!: () => void;
+  let markFirstDisposalStarted!: () => void;
+  const firstDisposalStarted = new Promise<void>((resolve) => {
+    markFirstDisposalStarted = resolve;
+  });
+  const firstDisposalRelease = new Promise<void>((resolve) => {
+    releaseFirstDisposal = resolve;
+  });
+  const firstFilter: Filter & AsyncDisposable = () => true;
+  firstFilter[Symbol.asyncDispose] = async () => {
+    markFirstDisposalStarted();
+    await firstDisposalRelease;
+    events.push("first filter");
+  };
+
+  await configure({
+    sinks: {},
+    loggers: [{ category: ["logtape", "meta"], sinks: [] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    let finishFirst!: () => void;
+    const releaseFirst = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const firstDone = withConfig({
+      sinks: { shared: sharedSink },
+      filters: { first: firstFilter },
+      loggers: [
+        { category: "app", filters: ["first"], sinks: ["shared"] },
+      ],
+    }, async () => {
+      await releaseFirst;
+    });
+    const secondDone = withConfig({
+      sinks: { shared: sharedSink },
+      loggers: [{ category: "app", sinks: ["shared"] }],
+    }, async () => {
+      finishFirst();
+      await firstDisposalStarted;
+    });
+
+    await secondDone;
+    assert.deepStrictEqual(events, ["shared sink"]);
+    releaseFirstDisposal();
+    await firstDone;
+
+    assert.deepStrictEqual(events, ["shared sink", "first filter"]);
   } finally {
     await reset();
   }

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -6,6 +6,11 @@ import { withCategoryPrefix, withContext } from "./context.ts";
 import type { Filter } from "./filter.ts";
 import { getLogger, LoggerImpl } from "./logger.ts";
 import type { LogRecord } from "./record.ts";
+import {
+  compileScopedConfig,
+  disposeScopedConfig,
+  disposeScopedConfigSync,
+} from "./scoped-config.ts";
 import type { Sink } from "./sink.ts";
 import {
   type Config,
@@ -844,6 +849,93 @@ test("withConfig() does not dispose resources still owned by parent scopes", asy
   } finally {
     await reset();
   }
+});
+
+test("disposeScopedConfig() clears resources after disposal errors", async () => {
+  const events: string[] = [];
+  const disposeError = new Error("dispose failed");
+  const syncFilter: Filter & Disposable = () => true;
+  syncFilter[Symbol.dispose] = () => {
+    events.push("sync filter");
+    throw disposeError;
+  };
+  const asyncFilter: Filter & AsyncDisposable = () => true;
+  asyncFilter[Symbol.asyncDispose] = async () => {
+    await Promise.resolve();
+    events.push("async filter");
+  };
+  const syncSink: Sink & Disposable = () => {};
+  syncSink[Symbol.dispose] = () => events.push("sync sink");
+  const asyncSink: Sink & AsyncDisposable = () => {};
+  asyncSink[Symbol.asyncDispose] = async () => {
+    await Promise.resolve();
+    events.push("async sink");
+  };
+
+  const scopedConfig = compileScopedConfig(
+    {
+      sinks: { asyncSink, syncSink },
+      filters: { asyncFilter, syncFilter },
+      loggers: [
+        {
+          category: "app",
+          filters: ["asyncFilter", "syncFilter"],
+          sinks: ["asyncSink", "syncSink"],
+        },
+      ],
+    },
+    true,
+    (message) => new ConfigError(message),
+  );
+
+  await assert.rejects(
+    () => disposeScopedConfig(scopedConfig),
+    (error) => error === disposeError,
+  );
+  assert.strictEqual(scopedConfig.syncFilters.size, 0);
+  assert.strictEqual(scopedConfig.asyncFilters.size, 0);
+  assert.strictEqual(scopedConfig.syncSinks.size, 0);
+  assert.strictEqual(scopedConfig.asyncSinks.size, 0);
+
+  await disposeScopedConfig(scopedConfig);
+  assert.deepStrictEqual(
+    events,
+    ["sync filter", "async filter", "sync sink", "async sink"],
+  );
+});
+
+test("disposeScopedConfigSync() clears resources after disposal errors", () => {
+  const events: string[] = [];
+  const disposeError = new Error("dispose failed");
+  const filter: Filter & Disposable = () => true;
+  filter[Symbol.dispose] = () => {
+    events.push("filter");
+    throw disposeError;
+  };
+  const sink: Sink & Disposable = () => {};
+  sink[Symbol.dispose] = () => events.push("sink");
+
+  const scopedConfig = compileScopedConfig(
+    {
+      sinks: { sink },
+      filters: { filter },
+      loggers: [
+        { category: "app", filters: ["filter"], sinks: ["sink"] },
+      ],
+    },
+    false,
+    (message) => new ConfigError(message),
+  );
+
+  assert.throws(
+    () => disposeScopedConfigSync(scopedConfig),
+    (error) => error === disposeError,
+  );
+  assert.strictEqual(scopedConfig.syncFilters.size, 0);
+  assert.strictEqual(scopedConfig.syncSinks.size, 0);
+
+  disposeScopedConfigSync(scopedConfig);
+  assert.deepStrictEqual(events, ["filter", "sink"]);
 });
 
 test("withConfig() preserves callback and disposal errors", async () => {

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -852,6 +852,96 @@ test("withConfig() does not dispose resources still owned by parent scopes", asy
   }
 });
 
+test("withConfig() does not dispose resources still owned globally", async () => {
+  const records: LogRecord[] = [];
+  const events: string[] = [];
+  const sharedSink: Sink & Disposable = (record) => {
+    records.push(record);
+  };
+  sharedSink[Symbol.dispose] = () => events.push("sink");
+  const sharedFilter: Filter & Disposable = () => true;
+  sharedFilter[Symbol.dispose] = () => events.push("filter");
+
+  await configure({
+    sinks: { shared: sharedSink },
+    filters: { shared: sharedFilter },
+    loggers: [
+      { category: "app", filters: ["shared"], sinks: ["shared"] },
+      { category: ["logtape", "meta"], sinks: [] },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    await withConfig({
+      sinks: { shared: sharedSink },
+      filters: { shared: sharedFilter },
+      loggers: [
+        { category: "app", filters: ["shared"], sinks: ["shared"] },
+      ],
+    }, () => {
+      getLogger("app").info("scoped");
+    });
+
+    assert.deepStrictEqual(events, []);
+    getLogger("app").info("global");
+    assert.deepStrictEqual(
+      records.map((record) => record.rawMessage),
+      ["scoped", "global"],
+    );
+  } finally {
+    await reset();
+  }
+
+  assert.deepStrictEqual(events, ["filter", "sink"]);
+});
+
+test("withConfigSync() does not dispose resources still owned globally", () => {
+  const records: LogRecord[] = [];
+  const events: string[] = [];
+  const sharedSink: Sink & Disposable = (record) => {
+    records.push(record);
+  };
+  sharedSink[Symbol.dispose] = () => events.push("sink");
+  const sharedFilter: Filter & Disposable = () => true;
+  sharedFilter[Symbol.dispose] = () => events.push("filter");
+
+  configureSync({
+    sinks: { shared: sharedSink },
+    filters: { shared: sharedFilter },
+    loggers: [
+      { category: "app", filters: ["shared"], sinks: ["shared"] },
+      { category: ["logtape", "meta"], sinks: [] },
+    ],
+    contextLocalStorage: new AsyncLocalStorage(),
+    reset: true,
+  });
+
+  try {
+    withConfigSync({
+      sinks: { shared: sharedSink },
+      filters: { shared: sharedFilter },
+      loggers: [
+        { category: "app", filters: ["shared"], sinks: ["shared"] },
+      ],
+    }, () => {
+      getLogger("app").info("scoped");
+    });
+
+    assert.deepStrictEqual(events, []);
+    getLogger("app").info("global");
+    assert.deepStrictEqual(
+      records.map((record) => record.rawMessage),
+      ["scoped", "global"],
+    );
+  } finally {
+    resetSync();
+  }
+
+  assert.deepStrictEqual(events, ["filter", "sink"]);
+});
+
 test("disposeScopedConfig() clears resources after disposal errors", async () => {
   const events: string[] = [];
   const disposeError = new Error("dispose failed");

--- a/packages/logtape/src/config.test.ts
+++ b/packages/logtape/src/config.test.ts
@@ -10,6 +10,7 @@ import {
   compileScopedConfig,
   disposeScopedConfig,
   disposeScopedConfigSync,
+  scopedConfigHasSink,
 } from "./scoped-config.ts";
 import type { Sink } from "./sink.ts";
 import {
@@ -936,6 +937,24 @@ test("disposeScopedConfigSync() clears resources after disposal errors", () => {
 
   disposeScopedConfigSync(scopedConfig);
   assert.deepStrictEqual(events, ["filter", "sink"]);
+});
+
+test("scoped configuration caches sink dispatch plans", () => {
+  const sink: Sink = () => {};
+  const scopedConfig = compileScopedConfig(
+    {
+      sinks: { sink },
+      loggers: [{ category: "app", sinks: ["sink"] }],
+    },
+    true,
+    (message) => new ConfigError(message),
+  );
+
+  assert.strictEqual(scopedConfig.dispatchCache.size, 0);
+  assert.strictEqual(scopedConfigHasSink(scopedConfig, ["app"], "info"), true);
+  assert.strictEqual(scopedConfig.dispatchCache.size, 1);
+  assert.strictEqual(scopedConfigHasSink(scopedConfig, ["app"], "info"), true);
+  assert.strictEqual(scopedConfig.dispatchCache.size, 1);
 });
 
 test("withConfig() preserves callback and disposal errors", async () => {

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -459,7 +459,9 @@ function getRetainedDisposables(
     getGlobalDisposables(),
   );
   for (const activeScopedConfig of activeScopedConfigs) {
-    if (activeScopedConfig === scopedConfig) continue;
+    if (activeScopedConfig === scopedConfig || activeScopedConfig.disposed) {
+      continue;
+    }
     addScopedConfigDisposables(disposables, activeScopedConfig);
   }
   return disposables;

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -2,6 +2,14 @@ import type { ContextLocalStorage } from "./context.ts";
 import { type FilterLike, toFilter } from "./filter.ts";
 import type { LogLevel } from "./level.ts";
 import { LoggerImpl } from "./logger.ts";
+import {
+  compileScopedConfig,
+  disposeScopedConfig,
+  disposeScopedConfigSync,
+  runWithScopedConfig,
+  type ScopedConfigLike,
+  throwCombinedErrors,
+} from "./scoped-config.ts";
 import { getConsoleSink, type Sink } from "./sink.ts";
 
 /**
@@ -35,6 +43,22 @@ export interface Config<TSinkId extends string, TFilterId extends string> {
    */
   reset?: boolean;
 }
+
+/**
+ * A scoped configuration for the current execution context.
+ *
+ * Unlike {@link Config}, this type does not include `reset` or
+ * `contextLocalStorage`.  Scoped configuration changes only the logging policy
+ * for a callback; the context-local storage must already be initialized by the
+ * process-global configuration.
+ *
+ * @since 2.3.0
+ */
+export type ScopedConfig<TSinkId extends string, TFilterId extends string> =
+  ScopedConfigLike<TSinkId, TFilterId>;
+
+type SyncCallbackResult<TResult> = TResult extends PromiseLike<unknown> ? never
+  : TResult;
 
 /**
  * A logger configuration.
@@ -82,6 +106,7 @@ export interface LoggerConfig<
  * The current configuration, if any.  Otherwise, `null`.
  */
 let currentConfig: Config<string, string> | null = null;
+let activeScopedConfigCount = 0;
 
 /**
  * Strong references to the loggers.
@@ -199,6 +224,7 @@ export async function configure<
   TSinkId extends string,
   TFilterId extends string,
 >(config: Config<TSinkId, TFilterId>): Promise<void> {
+  assertNoScopedConfig("configure()");
   if (currentConfig != null && !config.reset) {
     throw new ConfigError(
       "Already configured; if you want to reset, turn on the reset flag.",
@@ -249,6 +275,7 @@ export async function configure<
 export function configureSync<TSinkId extends string, TFilterId extends string>(
   config: Config<TSinkId, TFilterId>,
 ): void {
+  assertNoScopedConfig("configureSync()");
   if (currentConfig != null && !config.reset) {
     throw new ConfigError(
       "Already configured; if you want to reset, turn on the reset flag.",
@@ -267,6 +294,133 @@ export function configureSync<TSinkId extends string, TFilterId extends string>(
     if (e instanceof ConfigError) resetSync();
     throw e;
   }
+}
+
+/**
+ * Runs a callback with a LogTape configuration scoped to the current execution
+ * context.
+ *
+ * The process-global configuration must already provide
+ * `contextLocalStorage`.  The scoped configuration fully overrides global
+ * logger routing while the callback and its async work run.
+ *
+ * @param config The scoped configuration.
+ * @param callback The callback to run.
+ * @returns The callback's resolved return value.
+ * @since 2.3.0
+ */
+export async function withConfig<
+  TSinkId extends string,
+  TFilterId extends string,
+  TResult,
+>(
+  config: ScopedConfig<TSinkId, TFilterId>,
+  callback: () => TResult,
+): Promise<Awaited<TResult>> {
+  const contextLocalStorage = getConfiguredContextLocalStorage("withConfig()");
+  const scopedConfig = compileScopedConfig(
+    config,
+    true,
+    (message) => new ConfigError(message),
+  );
+
+  let result: Awaited<TResult>;
+  let callbackError: unknown;
+  let callbackFailed = false;
+  activeScopedConfigCount++;
+  try {
+    result = await runWithScopedConfig(
+      contextLocalStorage,
+      scopedConfig,
+      callback,
+    );
+  } catch (error) {
+    callbackFailed = true;
+    callbackError = error;
+  }
+
+  try {
+    await disposeScopedConfig(scopedConfig);
+  } catch (disposeError) {
+    if (callbackFailed) {
+      throwCombinedErrors(callbackError, disposeError);
+    }
+    throw disposeError;
+  } finally {
+    activeScopedConfigCount--;
+  }
+
+  if (callbackFailed) throw callbackError;
+  return result!;
+}
+
+/**
+ * Runs a synchronous callback with a LogTape configuration scoped to the
+ * current execution context.
+ *
+ * The scoped configuration must not contain async disposable sinks or filters.
+ *
+ * @param config The scoped configuration.
+ * @param callback The callback to run.
+ * @returns The callback's return value.
+ * @since 2.3.0
+ */
+export function withConfigSync<
+  TSinkId extends string,
+  TFilterId extends string,
+  TResult,
+>(
+  config: ScopedConfig<TSinkId, TFilterId>,
+  callback: () => SyncCallbackResult<TResult>,
+): SyncCallbackResult<TResult> {
+  const contextLocalStorage = getConfiguredContextLocalStorage(
+    "withConfigSync()",
+  );
+  const scopedConfig = compileScopedConfig(
+    config,
+    false,
+    (message) => new ConfigError(message),
+  );
+
+  let result: SyncCallbackResult<TResult>;
+  let callbackError: unknown;
+  let callbackFailed = false;
+  activeScopedConfigCount++;
+  try {
+    result = runWithScopedConfig(contextLocalStorage, scopedConfig, callback);
+    if (isThenable(result)) {
+      void Promise.resolve(result).catch(() => {});
+      callbackFailed = true;
+      callbackError = new ConfigError(
+        "withConfigSync() callback must not return a promise. " +
+          "Use withConfig() for async callbacks.",
+      );
+    }
+  } catch (error) {
+    callbackFailed = true;
+    callbackError = error;
+  }
+
+  try {
+    disposeScopedConfigSync(scopedConfig);
+  } catch (disposeError) {
+    if (callbackFailed) {
+      throwCombinedErrors(callbackError, disposeError);
+    }
+    throw disposeError;
+  } finally {
+    activeScopedConfigCount--;
+  }
+
+  if (callbackFailed) throw callbackError;
+  return result!;
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return value != null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "then" in value &&
+    typeof value.then === "function";
 }
 
 function configureInternal<
@@ -379,6 +533,7 @@ export function getConfig(): Config<string, string> | null {
  * Reset the configuration.  Mostly for testing purposes.
  */
 export async function reset(): Promise<void> {
+  assertNoScopedConfig("reset()");
   await dispose();
   resetInternal();
 }
@@ -389,6 +544,7 @@ export async function reset(): Promise<void> {
  * @since 0.9.0
  */
 export function resetSync(): void {
+  assertNoScopedConfig("resetSync()");
   disposeSync();
   resetInternal();
 }
@@ -405,6 +561,7 @@ function resetInternal(): void {
  * Dispose of the disposables.
  */
 export async function dispose(): Promise<void> {
+  assertNoScopedConfig("dispose()");
   const errors: unknown[] = [];
   try {
     disposeSyncFilters();
@@ -435,6 +592,7 @@ export async function dispose(): Promise<void> {
  * @since 0.9.0
  */
 export function disposeSync(): void {
+  assertNoScopedConfig("disposeSync()");
   const errors: unknown[] = [];
   try {
     disposeSyncFilters();
@@ -447,6 +605,32 @@ export function disposeSync(): void {
     errors.push(error);
   }
   throwDisposeErrors(errors);
+}
+
+function getConfiguredContextLocalStorage(
+  functionName: string,
+): ContextLocalStorage<Record<string, unknown>> {
+  if (currentConfig == null) {
+    throw new ConfigError(
+      `${functionName} requires LogTape to be configured first.`,
+    );
+  }
+  const contextLocalStorage = LoggerImpl.getLogger().contextLocalStorage;
+  if (contextLocalStorage == null) {
+    throw new ConfigError(
+      `${functionName} requires Config.contextLocalStorage to be configured.`,
+    );
+  }
+  return contextLocalStorage;
+}
+
+function assertNoScopedConfig(functionName: string): void {
+  if (activeScopedConfigCount > 0) {
+    throw new ConfigError(
+      `${functionName} cannot be called while a scoped configuration is ` +
+        "active. Use nested withConfig() instead.",
+    );
+  }
 }
 
 function disposeSyncFilters(): void {

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -107,6 +107,7 @@ export interface LoggerConfig<
  */
 let currentConfig: Config<string, string> | null = null;
 let activeScopedConfigCount = 0;
+let globalConfigMutationInProgress = false;
 
 /**
  * Strong references to the loggers.
@@ -150,7 +151,7 @@ function isLoggerConfigMeta<TSinkId extends string, TFilterId extends string>(
 }
 
 function registerDisposeHook(allowAsync: boolean): void {
-  const handler = allowAsync ? dispose : disposeSync;
+  const handler = allowAsync ? disposeInternal : disposeSyncInternal;
 
   if (
     // deno-lint-ignore no-explicit-any
@@ -224,19 +225,24 @@ export async function configure<
   TSinkId extends string,
   TFilterId extends string,
 >(config: Config<TSinkId, TFilterId>): Promise<void> {
-  assertNoScopedConfig("configure()");
-  if (currentConfig != null && !config.reset) {
-    throw new ConfigError(
-      "Already configured; if you want to reset, turn on the reset flag.",
-    );
-  }
-  await reset();
-  try {
-    configureInternal(config, true);
-  } catch (e) {
-    if (e instanceof ConfigError) await reset();
-    throw e;
-  }
+  await runGlobalConfigMutation("configure()", async () => {
+    if (currentConfig != null && !config.reset) {
+      throw new ConfigError(
+        "Already configured; if you want to reset, turn on the reset flag.",
+      );
+    }
+    await disposeInternal();
+    resetInternal();
+    try {
+      configureInternal(config, true);
+    } catch (e) {
+      if (e instanceof ConfigError) {
+        await disposeInternal();
+        resetInternal();
+      }
+      throw e;
+    }
+  });
 }
 
 /**
@@ -275,25 +281,30 @@ export async function configure<
 export function configureSync<TSinkId extends string, TFilterId extends string>(
   config: Config<TSinkId, TFilterId>,
 ): void {
-  assertNoScopedConfig("configureSync()");
-  if (currentConfig != null && !config.reset) {
-    throw new ConfigError(
-      "Already configured; if you want to reset, turn on the reset flag.",
-    );
-  }
-  if (asyncFilterDisposables.size > 0 || asyncSinkDisposables.size > 0) {
-    throw new ConfigError(
-      "Previously configured async disposables are still active. " +
-        "Use configure() instead or explicitly dispose them using dispose().",
-    );
-  }
-  resetSync();
-  try {
-    configureInternal(config, false);
-  } catch (e) {
-    if (e instanceof ConfigError) resetSync();
-    throw e;
-  }
+  runGlobalConfigMutationSync("configureSync()", () => {
+    if (currentConfig != null && !config.reset) {
+      throw new ConfigError(
+        "Already configured; if you want to reset, turn on the reset flag.",
+      );
+    }
+    if (asyncFilterDisposables.size > 0 || asyncSinkDisposables.size > 0) {
+      throw new ConfigError(
+        "Previously configured async disposables are still active. " +
+          "Use configure() instead or explicitly dispose them using dispose().",
+      );
+    }
+    disposeSyncInternal();
+    resetInternal();
+    try {
+      configureInternal(config, false);
+    } catch (e) {
+      if (e instanceof ConfigError) {
+        disposeSyncInternal();
+        resetInternal();
+      }
+      throw e;
+    }
+  });
 }
 
 /**
@@ -533,9 +544,10 @@ export function getConfig(): Config<string, string> | null {
  * Reset the configuration.  Mostly for testing purposes.
  */
 export async function reset(): Promise<void> {
-  assertNoScopedConfig("reset()");
-  await dispose();
-  resetInternal();
+  await runGlobalConfigMutation("reset()", async () => {
+    await disposeInternal();
+    resetInternal();
+  });
 }
 
 /**
@@ -544,9 +556,10 @@ export async function reset(): Promise<void> {
  * @since 0.9.0
  */
 export function resetSync(): void {
-  assertNoScopedConfig("resetSync()");
-  disposeSync();
-  resetInternal();
+  runGlobalConfigMutationSync("resetSync()", () => {
+    disposeSyncInternal();
+    resetInternal();
+  });
 }
 
 function resetInternal(): void {
@@ -561,7 +574,10 @@ function resetInternal(): void {
  * Dispose of the disposables.
  */
 export async function dispose(): Promise<void> {
-  assertNoScopedConfig("dispose()");
+  await runGlobalConfigMutation("dispose()", disposeInternal);
+}
+
+async function disposeInternal(): Promise<void> {
   const errors: unknown[] = [];
   try {
     disposeSyncFilters();
@@ -592,7 +608,10 @@ export async function dispose(): Promise<void> {
  * @since 0.9.0
  */
 export function disposeSync(): void {
-  assertNoScopedConfig("disposeSync()");
+  runGlobalConfigMutationSync("disposeSync()", disposeSyncInternal);
+}
+
+function disposeSyncInternal(): void {
   const errors: unknown[] = [];
   try {
     disposeSyncFilters();
@@ -610,6 +629,11 @@ export function disposeSync(): void {
 function getConfiguredContextLocalStorage(
   functionName: string,
 ): ContextLocalStorage<Record<string, unknown>> {
+  if (globalConfigMutationInProgress) {
+    throw new ConfigError(
+      `${functionName} cannot be called while LogTape is being reconfigured.`,
+    );
+  }
   if (currentConfig == null) {
     throw new ConfigError(
       `${functionName} requires LogTape to be configured first.`,
@@ -622,6 +646,41 @@ function getConfiguredContextLocalStorage(
     );
   }
   return contextLocalStorage;
+}
+
+async function runGlobalConfigMutation<T>(
+  functionName: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  assertCanMutateGlobalConfig(functionName);
+  globalConfigMutationInProgress = true;
+  try {
+    return await callback();
+  } finally {
+    globalConfigMutationInProgress = false;
+  }
+}
+
+function runGlobalConfigMutationSync<T>(
+  functionName: string,
+  callback: () => T,
+): T {
+  assertCanMutateGlobalConfig(functionName);
+  globalConfigMutationInProgress = true;
+  try {
+    return callback();
+  } finally {
+    globalConfigMutationInProgress = false;
+  }
+}
+
+function assertCanMutateGlobalConfig(functionName: string): void {
+  if (globalConfigMutationInProgress) {
+    throw new ConfigError(
+      `${functionName} cannot be called while LogTape is being reconfigured.`,
+    );
+  }
+  assertNoScopedConfig(functionName);
 }
 
 function assertNoScopedConfig(functionName: string): void {

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -351,7 +351,7 @@ export async function withConfig<
   }
 
   try {
-    await disposeScopedConfig(scopedConfig);
+    await disposeScopedConfig(scopedConfig, getGlobalDisposables());
   } catch (disposeError) {
     if (callbackFailed) {
       throwCombinedErrors(callbackError, disposeError);
@@ -413,7 +413,7 @@ export function withConfigSync<
   }
 
   try {
-    disposeScopedConfigSync(scopedConfig);
+    disposeScopedConfigSync(scopedConfig, getGlobalDisposables());
   } catch (disposeError) {
     if (callbackFailed) {
       throwCombinedErrors(callbackError, disposeError);
@@ -432,6 +432,15 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
     (typeof value === "object" || typeof value === "function") &&
     "then" in value &&
     typeof value.then === "function";
+}
+
+function getGlobalDisposables(): ReadonlySet<Disposable | AsyncDisposable> {
+  return new Set<Disposable | AsyncDisposable>([
+    ...filterDisposables,
+    ...asyncFilterDisposables,
+    ...sinkDisposables,
+    ...asyncSinkDisposables,
+  ]);
 }
 
 function configureInternal<

--- a/packages/logtape/src/config.ts
+++ b/packages/logtape/src/config.ts
@@ -3,6 +3,7 @@ import { type FilterLike, toFilter } from "./filter.ts";
 import type { LogLevel } from "./level.ts";
 import { LoggerImpl } from "./logger.ts";
 import {
+  type CompiledScopedConfig,
   compileScopedConfig,
   disposeScopedConfig,
   disposeScopedConfigSync,
@@ -107,6 +108,7 @@ export interface LoggerConfig<
  */
 let currentConfig: Config<string, string> | null = null;
 let activeScopedConfigCount = 0;
+const activeScopedConfigs: Set<CompiledScopedConfig> = new Set();
 let globalConfigMutationInProgress = false;
 
 /**
@@ -339,6 +341,7 @@ export async function withConfig<
   let callbackError: unknown;
   let callbackFailed = false;
   activeScopedConfigCount++;
+  activeScopedConfigs.add(scopedConfig);
   try {
     result = await runWithScopedConfig(
       contextLocalStorage,
@@ -351,13 +354,17 @@ export async function withConfig<
   }
 
   try {
-    await disposeScopedConfig(scopedConfig, getGlobalDisposables());
+    await disposeScopedConfig(
+      scopedConfig,
+      getRetainedDisposables(scopedConfig),
+    );
   } catch (disposeError) {
     if (callbackFailed) {
       throwCombinedErrors(callbackError, disposeError);
     }
     throw disposeError;
   } finally {
+    activeScopedConfigs.delete(scopedConfig);
     activeScopedConfigCount--;
   }
 
@@ -397,6 +404,7 @@ export function withConfigSync<
   let callbackError: unknown;
   let callbackFailed = false;
   activeScopedConfigCount++;
+  activeScopedConfigs.add(scopedConfig);
   try {
     result = runWithScopedConfig(contextLocalStorage, scopedConfig, callback);
     if (isThenable(result)) {
@@ -413,13 +421,14 @@ export function withConfigSync<
   }
 
   try {
-    disposeScopedConfigSync(scopedConfig, getGlobalDisposables());
+    disposeScopedConfigSync(scopedConfig, getRetainedDisposables(scopedConfig));
   } catch (disposeError) {
     if (callbackFailed) {
       throwCombinedErrors(callbackError, disposeError);
     }
     throw disposeError;
   } finally {
+    activeScopedConfigs.delete(scopedConfig);
     activeScopedConfigCount--;
   }
 
@@ -441,6 +450,33 @@ function getGlobalDisposables(): ReadonlySet<Disposable | AsyncDisposable> {
     ...sinkDisposables,
     ...asyncSinkDisposables,
   ]);
+}
+
+function getRetainedDisposables(
+  scopedConfig: CompiledScopedConfig,
+): ReadonlySet<Disposable | AsyncDisposable> {
+  const disposables = new Set<Disposable | AsyncDisposable>(
+    getGlobalDisposables(),
+  );
+  for (const activeScopedConfig of activeScopedConfigs) {
+    if (activeScopedConfig === scopedConfig) continue;
+    addScopedConfigDisposables(disposables, activeScopedConfig);
+  }
+  return disposables;
+}
+
+function addScopedConfigDisposables(
+  disposables: Set<Disposable | AsyncDisposable>,
+  scopedConfig: CompiledScopedConfig,
+): void {
+  for (const disposable of scopedConfig.syncFilters) {
+    disposables.add(disposable);
+  }
+  for (const disposable of scopedConfig.asyncFilters) {
+    disposables.add(disposable);
+  }
+  for (const disposable of scopedConfig.syncSinks) disposables.add(disposable);
+  for (const disposable of scopedConfig.asyncSinks) disposables.add(disposable);
 }
 
 function configureInternal<

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -6,6 +6,11 @@ import {
 import type { Filter } from "./filter.ts";
 import { compareLogLevel, type LogLevel } from "./level.ts";
 import type { LogRecord } from "./record.ts";
+import {
+  emitWithScopedConfig,
+  getCurrentScopedConfig,
+  scopedConfigHasSink,
+} from "./scoped-config.ts";
 import type { Sink } from "./sink.ts";
 
 /**
@@ -1758,6 +1763,18 @@ export class LoggerImpl implements Logger {
         ...this.category,
       ])
       : this;
+    const scopedConfig = getCurrentScopedConfig(
+      LoggerImpl.getLogger().contextLocalStorage,
+    );
+    if (scopedConfig != null) {
+      return scopedConfigHasSink(
+        scopedConfig,
+        categoryPrefix.length > 0
+          ? [...categoryPrefix, ...this.category]
+          : this.category,
+        level,
+      );
+    }
     return dispatcher.isEnabledForResolved(level);
   }
 
@@ -1809,6 +1826,43 @@ export class LoggerImpl implements Logger {
   }
 
   private emitResolved(record: LogRecord, bypassSinks?: Set<Sink>): void {
+    const scopedConfig = getCurrentScopedConfig(
+      LoggerImpl.getLogger().contextLocalStorage,
+    );
+    if (scopedConfig != null) {
+      let snapshot: LogRecord | undefined;
+      let snapshotFailed: boolean = false;
+      emitWithScopedConfig(
+        scopedConfig,
+        record,
+        bypassSinks,
+        (sink, activeBypassSinks) => {
+          try {
+            if (shouldSnapshotForSink(sink)) {
+              try {
+                snapshot ??= snapshotLogRecordProperties(record);
+              } catch {
+                snapshotFailed = true;
+                snapshot = record;
+              }
+            }
+            sink(snapshot ?? record);
+          } catch (error) {
+            const bypassSinks2 = new Set(activeBypassSinks);
+            bypassSinks2.add(sink);
+            metaLogger.log(
+              "fatal",
+              "Failed to emit a log record to sink {sink}: {error}",
+              { sink, error, record },
+              bypassSinks2,
+            );
+          }
+          if (snapshotFailed) snapshot = record;
+        },
+      );
+      return;
+    }
+
     if (
       this.lowestLevel === null ||
       compareLogLevel(record.level, this.lowestLevel) < 0 ||

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -1831,7 +1831,7 @@ export class LoggerImpl implements Logger {
     );
     if (scopedConfig != null) {
       let snapshot: LogRecord | undefined;
-      let snapshotFailed: boolean = false;
+      let snapshotFailed = false;
       emitWithScopedConfig(
         scopedConfig,
         record,

--- a/packages/logtape/src/mod.ts
+++ b/packages/logtape/src/mod.ts
@@ -9,6 +9,9 @@ export {
   type LoggerConfig,
   reset,
   resetSync,
+  type ScopedConfig,
+  withConfig,
+  withConfigSync,
 } from "./config.ts";
 export {
   type ContextLocalStorage,

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -33,6 +33,10 @@ export interface ScopedLoggerConfigLike<
 export interface CompiledScopedConfig {
   readonly nodes: ReadonlyMap<string, CompiledScopedLogger>;
   readonly dispatchCache: Map<string, ScopedSinkDispatchPlan>;
+  readonly filterCache: Map<
+    string,
+    readonly ((record: LogRecord) => boolean)[]
+  >;
   parent: CompiledScopedConfig | undefined;
   disposed: boolean;
   readonly syncFilters: Set<Disposable>;
@@ -59,6 +63,7 @@ const defaultScopedLogger: CompiledScopedLogger = {
   parentSinks: "inherit",
   sinks: [],
 };
+const noFilters: readonly ((record: LogRecord) => boolean)[] = [];
 
 export function compileScopedConfig<
   TSinkId extends string,
@@ -199,6 +204,7 @@ export function compileScopedConfig<
     asyncSinks,
     dispatchCache: new Map(),
     disposed: false,
+    filterCache: new Map(),
     nodes,
     parent: undefined,
     syncFilters,
@@ -473,14 +479,27 @@ function filterScopedRecord(
   category: readonly string[],
   record: LogRecord,
 ): boolean {
+  const key = categoryKey(category);
+  let filters = scopedConfig.filterCache.get(key);
+  if (filters == null) {
+    filters = getScopedFilters(scopedConfig, category);
+    scopedConfig.filterCache.set(key, filters);
+  }
+  return filters.every((filter) => filter(record));
+}
+
+function getScopedFilters(
+  scopedConfig: CompiledScopedConfig,
+  category: readonly string[],
+): readonly ((record: LogRecord) => boolean)[] {
   for (let length = category.length; length >= 0; length--) {
     const logger = scopedConfig.nodes.get(
       categoryKey(category.slice(0, length)),
     );
     if (logger == null || logger.filters.length < 1) continue;
-    return logger.filters.every((filter) => filter(record));
+    return logger.filters;
   }
-  return true;
+  return noFilters;
 }
 
 function disposeSyncDisposables(

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -81,7 +81,38 @@ export function compileScopedConfig<
   const nodes = new Map<string, CompiledScopedLogger>();
   const configuredCategories = new Set<string>();
   for (const logger of config.loggers) {
-    const category = normalizeCategory(logger.category);
+    if (!isObjectLike(logger)) {
+      throw createError("Logger configuration must be an object.");
+    }
+    const loggerConfig = logger as ScopedLoggerConfigLike<TSinkId, TFilterId>;
+    const category = normalizeCategory(loggerConfig.category, createError);
+    if (
+      loggerConfig.sinks !== undefined && !Array.isArray(loggerConfig.sinks)
+    ) {
+      throw createError("Logger sinks must be an array.");
+    }
+    if (
+      loggerConfig.filters !== undefined &&
+      !Array.isArray(loggerConfig.filters)
+    ) {
+      throw createError("Logger filters must be an array.");
+    }
+    if (
+      loggerConfig.parentSinks !== undefined &&
+      loggerConfig.parentSinks !== "inherit" &&
+      loggerConfig.parentSinks !== "override"
+    ) {
+      throw createError(
+        'Logger parentSinks must be "inherit" or "override".',
+      );
+    }
+    if (
+      loggerConfig.lowestLevel !== undefined &&
+      loggerConfig.lowestLevel !== null &&
+      !isLogLevel(loggerConfig.lowestLevel)
+    ) {
+      throw createError("Logger lowestLevel must be a log level or null.");
+    }
     const key = categoryKey(category);
     if (configuredCategories.has(key)) {
       throw createError(
@@ -92,7 +123,7 @@ export function compileScopedConfig<
     configuredCategories.add(key);
 
     const sinks: Sink[] = [];
-    const sinkIds: readonly TSinkId[] = logger.sinks ?? [];
+    const sinkIds: readonly TSinkId[] = loggerConfig.sinks ?? [];
     for (const sinkId of sinkIds) {
       const sink = config.sinks[sinkId];
       if (!sink) throw createError(`Sink not found: ${sinkId}.`);
@@ -103,7 +134,7 @@ export function compileScopedConfig<
     }
 
     const filters: ((record: LogRecord) => boolean)[] = [];
-    const filterIds: readonly TFilterId[] = logger.filters ?? [];
+    const filterIds: readonly TFilterId[] = loggerConfig.filters ?? [];
     for (const filterId of filterIds) {
       const filter = config.filters?.[filterId];
       if (filter === undefined) {
@@ -119,10 +150,10 @@ export function compileScopedConfig<
 
     nodes.set(key, {
       filters,
-      lowestLevel: logger.lowestLevel === undefined
+      lowestLevel: loggerConfig.lowestLevel === undefined
         ? "trace"
-        : logger.lowestLevel,
-      parentSinks: logger.parentSinks ?? "inherit",
+        : loggerConfig.lowestLevel,
+      parentSinks: loggerConfig.parentSinks ?? "inherit",
       sinks,
     });
   }
@@ -349,8 +380,18 @@ function addScopedDisposables(
   for (const disposable of scopedConfig.asyncSinks) disposables.add(disposable);
 }
 
-function normalizeCategory(category: string | readonly string[]): string[] {
-  return typeof category === "string" ? [category] : [...category];
+function normalizeCategory(
+  category: unknown,
+  createError: (message: string) => Error,
+): string[] {
+  if (typeof category === "string") return [category];
+  if (!Array.isArray(category)) {
+    throw createError("Logger category must be a string or array of strings.");
+  }
+  if (category.some((part) => typeof part !== "string")) {
+    throw createError("Logger category must only contain strings.");
+  }
+  return [...category];
 }
 
 function categoryKey(category: readonly string[]): string {
@@ -443,17 +484,17 @@ function disposeSyncDisposables(
   disposables: Set<Disposable>,
   retainedDisposables: ReadonlySet<Disposable | AsyncDisposable>,
 ): void {
+  const disposableList = filterRetainedDisposables(
+    disposables,
+    retainedDisposables,
+  );
   const errors: unknown[] = [];
   try {
-    for (const disposable of disposables) {
+    for (const disposable of disposableList) {
       try {
-        if (!retainedDisposables.has(disposable)) {
-          disposable[Symbol.dispose]();
-        }
+        disposable[Symbol.dispose]();
       } catch (error) {
         errors.push(error);
-      } finally {
-        disposables.delete(disposable);
       }
     }
   } finally {

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -1,0 +1,411 @@
+import type { ContextLocalStorage } from "./context.ts";
+import { type FilterLike, toFilter } from "./filter.ts";
+import { compareLogLevel, type LogLevel } from "./level.ts";
+import type { LogRecord } from "./record.ts";
+import type { Sink } from "./sink.ts";
+
+export type ScopedConfigSymbol = typeof scopedConfigSymbol;
+
+export const scopedConfigSymbol: unique symbol = Symbol.for(
+  "logtape.scopedConfig",
+);
+
+export interface ScopedConfigLike<
+  TSinkId extends string,
+  TFilterId extends string,
+> {
+  readonly sinks: Record<TSinkId, Sink>;
+  readonly filters?: Record<TFilterId, FilterLike>;
+  readonly loggers: readonly ScopedLoggerConfigLike<TSinkId, TFilterId>[];
+}
+
+export interface ScopedLoggerConfigLike<
+  TSinkId extends string,
+  TFilterId extends string,
+> {
+  readonly category: string | readonly string[];
+  readonly sinks?: readonly TSinkId[];
+  readonly parentSinks?: "inherit" | "override";
+  readonly filters?: readonly TFilterId[];
+  readonly lowestLevel?: LogLevel | null;
+}
+
+export interface CompiledScopedConfig {
+  readonly nodes: ReadonlyMap<string, CompiledScopedLogger>;
+  parent: CompiledScopedConfig | undefined;
+  disposed: boolean;
+  readonly syncFilters: ReadonlySet<Disposable>;
+  readonly asyncFilters: ReadonlySet<AsyncDisposable>;
+  readonly syncSinks: ReadonlySet<Disposable>;
+  readonly asyncSinks: ReadonlySet<AsyncDisposable>;
+}
+
+interface CompiledScopedLogger {
+  readonly filters: readonly ((record: LogRecord) => boolean)[];
+  readonly lowestLevel: LogLevel | null;
+  readonly parentSinks: "inherit" | "override";
+  readonly sinks: readonly Sink[];
+}
+
+type ScopedSinkDispatchPlan =
+  | { readonly kind: "none" }
+  | { readonly kind: "one"; readonly sink: Sink }
+  | { readonly kind: "many"; readonly sinks: readonly Sink[] };
+
+const defaultScopedLogger: CompiledScopedLogger = {
+  filters: [],
+  lowestLevel: "trace",
+  parentSinks: "inherit",
+  sinks: [],
+};
+
+export function compileScopedConfig<
+  TSinkId extends string,
+  TFilterId extends string,
+>(
+  config: ScopedConfigLike<TSinkId, TFilterId>,
+  allowAsync: boolean,
+  createError: (message: string) => Error,
+): CompiledScopedConfig {
+  const nodes = new Map<string, CompiledScopedLogger>();
+  const configuredCategories = new Set<string>();
+  for (const logger of config.loggers) {
+    const category = normalizeCategory(logger.category);
+    const key = categoryKey(category);
+    if (configuredCategories.has(key)) {
+      throw createError(
+        `Duplicate logger configuration for category: ${key}. ` +
+          "Each category can only be configured once.",
+      );
+    }
+    configuredCategories.add(key);
+
+    const sinks: Sink[] = [];
+    for (const sinkId of logger.sinks ?? []) {
+      const sink = config.sinks[sinkId];
+      if (!sink) throw createError(`Sink not found: ${sinkId}.`);
+      sinks.push(sink);
+    }
+
+    const filters: ((record: LogRecord) => boolean)[] = [];
+    for (const filterId of logger.filters ?? []) {
+      const filter = config.filters?.[filterId];
+      if (filter === undefined) {
+        throw createError(`Filter not found: ${filterId}.`);
+      }
+      filters.push(toFilter(filter));
+    }
+
+    nodes.set(key, {
+      filters,
+      lowestLevel: logger.lowestLevel === undefined
+        ? "trace"
+        : logger.lowestLevel,
+      parentSinks: logger.parentSinks ?? "inherit",
+      sinks,
+    });
+  }
+
+  const syncFilters = new Set<Disposable>();
+  const asyncFilters = new Set<AsyncDisposable>();
+  const syncSinks = new Set<Disposable>();
+  const asyncSinks = new Set<AsyncDisposable>();
+
+  for (const sink of Object.values<Sink>(config.sinks)) {
+    if (Symbol.asyncDispose in sink) {
+      if (!allowAsync) {
+        throw createError(
+          "Async disposables cannot be used with withConfigSync().",
+        );
+      }
+      asyncSinks.add(sink as AsyncDisposable);
+    }
+    if (Symbol.dispose in sink) syncSinks.add(sink as Disposable);
+  }
+
+  for (const filter of Object.values<FilterLike>(config.filters ?? {})) {
+    if (filter == null || typeof filter === "string") continue;
+    if (Symbol.asyncDispose in filter) {
+      if (!allowAsync) {
+        throw createError(
+          "Async disposables cannot be used with withConfigSync().",
+        );
+      }
+      asyncFilters.add(filter as AsyncDisposable);
+      asyncSinks.delete(filter as AsyncDisposable);
+    }
+    if (Symbol.dispose in filter) {
+      syncFilters.add(filter as Disposable);
+      syncSinks.delete(filter as Disposable);
+    }
+  }
+
+  return {
+    asyncFilters,
+    asyncSinks,
+    disposed: false,
+    nodes,
+    parent: undefined,
+    syncFilters,
+    syncSinks,
+  };
+}
+
+export function getCurrentScopedConfig(
+  contextLocalStorage:
+    | ContextLocalStorage<Record<string, unknown>>
+    | undefined,
+): CompiledScopedConfig | undefined {
+  const store = contextLocalStorage?.getStore();
+  const scopedConfig = (store as Record<ScopedConfigSymbol, unknown> | null)
+    ?.[scopedConfigSymbol];
+  return isCompiledScopedConfig(scopedConfig)
+    ? getActiveScopedConfig(scopedConfig)
+    : undefined;
+}
+
+export function runWithScopedConfig<R>(
+  contextLocalStorage: ContextLocalStorage<Record<string, unknown>>,
+  scopedConfig: CompiledScopedConfig,
+  callback: () => R,
+): R {
+  const parentStore = contextLocalStorage.getStore() ?? {};
+  scopedConfig.parent = getCurrentScopedConfig(contextLocalStorage);
+  return contextLocalStorage.run({
+    ...parentStore,
+    [scopedConfigSymbol]: scopedConfig,
+  } as Record<string, unknown>, callback);
+}
+
+export function scopedConfigHasSink(
+  scopedConfig: CompiledScopedConfig,
+  category: readonly string[],
+  level: LogLevel,
+): boolean {
+  return getScopedSinkDispatchPlan(scopedConfig, category, level).kind !==
+    "none";
+}
+
+export function emitWithScopedConfig(
+  scopedConfig: CompiledScopedConfig,
+  record: LogRecord,
+  bypassSinks: Set<Sink> | undefined,
+  emitToSink: (sink: Sink, bypassSinks: Set<Sink> | undefined) => void,
+): void {
+  const plan = getScopedSinkDispatchPlan(
+    scopedConfig,
+    record.category,
+    record.level,
+  );
+  if (plan.kind === "none") return;
+  if (!filterScopedRecord(scopedConfig, record.category, record)) return;
+  if (plan.kind === "one") {
+    if (!bypassSinks?.has(plan.sink)) emitToSink(plan.sink, bypassSinks);
+    return;
+  }
+  for (const sink of plan.sinks) {
+    if (bypassSinks?.has(sink)) continue;
+    emitToSink(sink, bypassSinks);
+  }
+}
+
+export async function disposeScopedConfig(
+  scopedConfig: CompiledScopedConfig,
+): Promise<void> {
+  scopedConfig.disposed = true;
+  const errors: unknown[] = [];
+  try {
+    disposeSyncDisposables(scopedConfig.syncFilters);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await disposeAsyncDisposables(scopedConfig.asyncFilters);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    disposeSyncDisposables(scopedConfig.syncSinks);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await disposeAsyncDisposables(scopedConfig.asyncSinks);
+  } catch (error) {
+    errors.push(error);
+  }
+  throwDisposeErrors(errors);
+}
+
+export function disposeScopedConfigSync(
+  scopedConfig: CompiledScopedConfig,
+): void {
+  scopedConfig.disposed = true;
+  const errors: unknown[] = [];
+  try {
+    disposeSyncDisposables(scopedConfig.syncFilters);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    disposeSyncDisposables(scopedConfig.syncSinks);
+  } catch (error) {
+    errors.push(error);
+  }
+  throwDisposeErrors(errors);
+}
+
+export function throwCombinedErrors(
+  primary: unknown,
+  secondary: unknown,
+): never {
+  throw new AggregateError(
+    flattenErrors(primary, secondary),
+    "Multiple errors occurred while running LogTape scoped configuration.",
+  );
+}
+
+function isCompiledScopedConfig(value: unknown): value is CompiledScopedConfig {
+  return value != null && typeof value === "object" && "nodes" in value;
+}
+
+function getActiveScopedConfig(
+  scopedConfig: CompiledScopedConfig,
+): CompiledScopedConfig | undefined {
+  let activeConfig: CompiledScopedConfig | undefined = scopedConfig;
+  while (activeConfig?.disposed) activeConfig = activeConfig.parent;
+  return activeConfig;
+}
+
+function normalizeCategory(category: string | readonly string[]): string[] {
+  return typeof category === "string" ? [category] : [...category];
+}
+
+function categoryKey(category: readonly string[]): string {
+  return JSON.stringify(category);
+}
+
+function getScopedSinkDispatchPlan(
+  scopedConfig: CompiledScopedConfig,
+  category: readonly string[],
+  level: LogLevel,
+): ScopedSinkDispatchPlan {
+  return getScopedSinkDispatchPlanForPrefix(
+    scopedConfig,
+    category,
+    category.length,
+    level,
+  );
+}
+
+function getScopedSinkDispatchPlanForPrefix(
+  scopedConfig: CompiledScopedConfig,
+  category: readonly string[],
+  length: number,
+  level: LogLevel,
+): ScopedSinkDispatchPlan {
+  const prefix = category.slice(0, length);
+  const logger = scopedConfig.nodes.get(categoryKey(prefix)) ??
+    defaultScopedLogger;
+  if (
+    logger.lowestLevel === null ||
+    compareLogLevel(level, logger.lowestLevel) < 0
+  ) {
+    return { kind: "none" };
+  }
+
+  const parentPlan = length > 0 && logger.parentSinks === "inherit"
+    ? getScopedSinkDispatchPlanForPrefix(
+      scopedConfig,
+      category,
+      length - 1,
+      level,
+    )
+    : { kind: "none" } as const;
+
+  let firstSink: Sink | undefined;
+  let sinks: Sink[] | undefined;
+  const appendSink = (sink: Sink): void => {
+    if (sinks != null) {
+      sinks.push(sink);
+    } else if (firstSink == null) {
+      firstSink = sink;
+    } else {
+      sinks = [firstSink, sink];
+    }
+  };
+
+  if (parentPlan.kind === "one") appendSink(parentPlan.sink);
+  else if (parentPlan.kind === "many") {
+    for (const sink of parentPlan.sinks) appendSink(sink);
+  }
+  for (const sink of logger.sinks) appendSink(sink);
+
+  if (sinks != null) return { kind: "many", sinks };
+  if (firstSink != null) return { kind: "one", sink: firstSink };
+  return { kind: "none" };
+}
+
+function filterScopedRecord(
+  scopedConfig: CompiledScopedConfig,
+  category: readonly string[],
+  record: LogRecord,
+): boolean {
+  for (let length = category.length; length >= 0; length--) {
+    const logger = scopedConfig.nodes.get(
+      categoryKey(category.slice(0, length)),
+    );
+    if (logger == null || logger.filters.length < 1) continue;
+    return logger.filters.every((filter) => filter(record));
+  }
+  return true;
+}
+
+function disposeSyncDisposables(disposables: ReadonlySet<Disposable>): void {
+  const errors: unknown[] = [];
+  for (const disposable of disposables) {
+    try {
+      disposable[Symbol.dispose]();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  throwDisposeErrors(errors);
+}
+
+async function disposeAsyncDisposables(
+  disposables: ReadonlySet<AsyncDisposable>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    Array.from(
+      disposables,
+      (disposable) =>
+        Promise.resolve().then(() => disposable[Symbol.asyncDispose]()),
+    ),
+  );
+  throwDisposeErrors(
+    results
+      .filter((result): result is PromiseRejectedResult =>
+        result.status === "rejected"
+      )
+      .map((result) => result.reason),
+  );
+}
+
+function throwDisposeErrors(errors: readonly unknown[]): void {
+  if (errors.length < 1) return;
+  if (errors.length === 1) throw errors[0];
+  throw new AggregateError(
+    errors,
+    "Multiple errors occurred while disposing LogTape scoped resources.",
+  );
+}
+
+function flattenErrors(...errors: readonly unknown[]): unknown[] {
+  const flattened: unknown[] = [];
+  for (const error of errors) {
+    if (error instanceof AggregateError) flattened.push(...error.errors);
+    else flattened.push(error);
+  }
+  return flattened;
+}

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -1,6 +1,6 @@
 import type { ContextLocalStorage } from "./context.ts";
 import { type FilterLike, toFilter } from "./filter.ts";
-import { compareLogLevel, type LogLevel } from "./level.ts";
+import { compareLogLevel, isLogLevel, type LogLevel } from "./level.ts";
 import type { LogRecord } from "./record.ts";
 import type { Sink } from "./sink.ts";
 
@@ -67,6 +67,16 @@ export function compileScopedConfig<
   allowAsync: boolean,
   createError: (message: string) => Error,
 ): CompiledScopedConfig {
+  if (!isObjectLike(config)) {
+    throw createError("Configuration must be an object.");
+  }
+  if (!isObjectLike(config.sinks)) {
+    throw createError("Configuration must include a sinks object.");
+  }
+  if (!Array.isArray(config.loggers)) {
+    throw createError("Configuration must include a loggers array.");
+  }
+
   const nodes = new Map<string, CompiledScopedLogger>();
   const configuredCategories = new Set<string>();
   for (const logger of config.loggers) {
@@ -81,17 +91,27 @@ export function compileScopedConfig<
     configuredCategories.add(key);
 
     const sinks: Sink[] = [];
-    for (const sinkId of logger.sinks ?? []) {
+    const sinkIds: readonly TSinkId[] = logger.sinks ?? [];
+    for (const sinkId of sinkIds) {
       const sink = config.sinks[sinkId];
       if (!sink) throw createError(`Sink not found: ${sinkId}.`);
+      if (typeof sink !== "function") {
+        throw createError(`Sink must be a function: ${sinkId}.`);
+      }
       sinks.push(sink);
     }
 
     const filters: ((record: LogRecord) => boolean)[] = [];
-    for (const filterId of logger.filters ?? []) {
+    const filterIds: readonly TFilterId[] = logger.filters ?? [];
+    for (const filterId of filterIds) {
       const filter = config.filters?.[filterId];
       if (filter === undefined) {
         throw createError(`Filter not found: ${filterId}.`);
+      }
+      if (!isFilterLike(filter)) {
+        throw createError(
+          `Filter must be a function, log level, or null: ${filterId}.`,
+        );
       }
       filters.push(toFilter(filter));
     }
@@ -112,6 +132,7 @@ export function compileScopedConfig<
   const asyncSinks = new Set<AsyncDisposable>();
 
   for (const sink of Object.values<Sink>(config.sinks)) {
+    if (!isObjectLike(sink)) continue;
     if (Symbol.asyncDispose in sink) {
       if (!allowAsync) {
         throw createError(
@@ -124,7 +145,7 @@ export function compileScopedConfig<
   }
 
   for (const filter of Object.values<FilterLike>(config.filters ?? {})) {
-    if (filter == null || typeof filter === "string") continue;
+    if (!isObjectLike(filter)) continue;
     if (Symbol.asyncDispose in filter) {
       if (!allowAsync) {
         throw createError(
@@ -267,6 +288,18 @@ export function throwCombinedErrors(
 
 function isCompiledScopedConfig(value: unknown): value is CompiledScopedConfig {
   return value != null && typeof value === "object" && "nodes" in value;
+}
+
+function isObjectLike(
+  value: unknown,
+): value is object | ((...args: never[]) => unknown) {
+  return value != null &&
+    (typeof value === "object" || typeof value === "function");
+}
+
+function isFilterLike(value: unknown): value is FilterLike {
+  return value == null || typeof value === "function" ||
+    (typeof value === "string" && isLogLevel(value));
 }
 
 function getActiveScopedConfig(

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -233,25 +233,26 @@ export function emitWithScopedConfig(
 export async function disposeScopedConfig(
   scopedConfig: CompiledScopedConfig,
 ): Promise<void> {
+  const parentDisposables = getParentScopedDisposables(scopedConfig);
   scopedConfig.disposed = true;
   const errors: unknown[] = [];
   try {
-    disposeSyncDisposables(scopedConfig.syncFilters);
+    disposeSyncDisposables(scopedConfig.syncFilters, parentDisposables);
   } catch (error) {
     errors.push(error);
   }
   try {
-    await disposeAsyncDisposables(scopedConfig.asyncFilters);
+    await disposeAsyncDisposables(scopedConfig.asyncFilters, parentDisposables);
   } catch (error) {
     errors.push(error);
   }
   try {
-    disposeSyncDisposables(scopedConfig.syncSinks);
+    disposeSyncDisposables(scopedConfig.syncSinks, parentDisposables);
   } catch (error) {
     errors.push(error);
   }
   try {
-    await disposeAsyncDisposables(scopedConfig.asyncSinks);
+    await disposeAsyncDisposables(scopedConfig.asyncSinks, parentDisposables);
   } catch (error) {
     errors.push(error);
   }
@@ -261,15 +262,16 @@ export async function disposeScopedConfig(
 export function disposeScopedConfigSync(
   scopedConfig: CompiledScopedConfig,
 ): void {
+  const parentDisposables = getParentScopedDisposables(scopedConfig);
   scopedConfig.disposed = true;
   const errors: unknown[] = [];
   try {
-    disposeSyncDisposables(scopedConfig.syncFilters);
+    disposeSyncDisposables(scopedConfig.syncFilters, parentDisposables);
   } catch (error) {
     errors.push(error);
   }
   try {
-    disposeSyncDisposables(scopedConfig.syncSinks);
+    disposeSyncDisposables(scopedConfig.syncSinks, parentDisposables);
   } catch (error) {
     errors.push(error);
   }
@@ -308,6 +310,34 @@ function getActiveScopedConfig(
   let activeConfig: CompiledScopedConfig | undefined = scopedConfig;
   while (activeConfig?.disposed) activeConfig = activeConfig.parent;
   return activeConfig;
+}
+
+function getParentScopedDisposables(
+  scopedConfig: CompiledScopedConfig,
+): ReadonlySet<Disposable | AsyncDisposable> {
+  const disposables = new Set<Disposable | AsyncDisposable>();
+  let parent = scopedConfig.parent;
+  while (parent != null) {
+    const activeParent = getActiveScopedConfig(parent);
+    if (activeParent == null) break;
+    addScopedDisposables(disposables, activeParent);
+    parent = activeParent.parent;
+  }
+  return disposables;
+}
+
+function addScopedDisposables(
+  disposables: Set<Disposable | AsyncDisposable>,
+  scopedConfig: CompiledScopedConfig,
+): void {
+  for (const disposable of scopedConfig.syncFilters) {
+    disposables.add(disposable);
+  }
+  for (const disposable of scopedConfig.asyncFilters) {
+    disposables.add(disposable);
+  }
+  for (const disposable of scopedConfig.syncSinks) disposables.add(disposable);
+  for (const disposable of scopedConfig.asyncSinks) disposables.add(disposable);
 }
 
 function normalizeCategory(category: string | readonly string[]): string[] {
@@ -394,9 +424,13 @@ function filterScopedRecord(
   return true;
 }
 
-function disposeSyncDisposables(disposables: ReadonlySet<Disposable>): void {
+function disposeSyncDisposables(
+  disposables: ReadonlySet<Disposable>,
+  retainedDisposables: ReadonlySet<Disposable | AsyncDisposable>,
+): void {
   const errors: unknown[] = [];
   for (const disposable of disposables) {
+    if (retainedDisposables.has(disposable)) continue;
     try {
       disposable[Symbol.dispose]();
     } catch (error) {
@@ -408,10 +442,11 @@ function disposeSyncDisposables(disposables: ReadonlySet<Disposable>): void {
 
 async function disposeAsyncDisposables(
   disposables: ReadonlySet<AsyncDisposable>,
+  retainedDisposables: ReadonlySet<Disposable | AsyncDisposable>,
 ): Promise<void> {
   const results = await Promise.allSettled(
     Array.from(
-      disposables,
+      filterRetainedDisposables(disposables, retainedDisposables),
       (disposable) =>
         Promise.resolve().then(() => disposable[Symbol.asyncDispose]()),
     ),
@@ -423,6 +458,17 @@ async function disposeAsyncDisposables(
       )
       .map((result) => result.reason),
   );
+}
+
+function filterRetainedDisposables<
+  TDisposable extends Disposable | AsyncDisposable,
+>(
+  disposables: ReadonlySet<TDisposable>,
+  retainedDisposables: ReadonlySet<Disposable | AsyncDisposable>,
+): TDisposable[] {
+  return Array.from(
+    disposables,
+  ).filter((disposable) => !retainedDisposables.has(disposable));
 }
 
 function throwDisposeErrors(errors: readonly unknown[]): void {

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -32,6 +32,7 @@ export interface ScopedLoggerConfigLike<
 
 export interface CompiledScopedConfig {
   readonly nodes: ReadonlyMap<string, CompiledScopedLogger>;
+  readonly dispatchCache: Map<string, ScopedSinkDispatchPlan>;
   parent: CompiledScopedConfig | undefined;
   disposed: boolean;
   readonly syncFilters: Set<Disposable>;
@@ -164,6 +165,7 @@ export function compileScopedConfig<
   return {
     asyncFilters,
     asyncSinks,
+    dispatchCache: new Map(),
     disposed: false,
     nodes,
     parent: undefined,
@@ -353,12 +355,18 @@ function getScopedSinkDispatchPlan(
   category: readonly string[],
   level: LogLevel,
 ): ScopedSinkDispatchPlan {
-  return getScopedSinkDispatchPlanForPrefix(
-    scopedConfig,
-    category,
-    category.length,
-    level,
-  );
+  const cacheKey = `${categoryKey(category)}:${level}`;
+  let plan = scopedConfig.dispatchCache.get(cacheKey);
+  if (plan == null) {
+    plan = getScopedSinkDispatchPlanForPrefix(
+      scopedConfig,
+      category,
+      category.length,
+      level,
+    );
+    scopedConfig.dispatchCache.set(cacheKey, plan);
+  }
+  return plan;
 }
 
 function getScopedSinkDispatchPlanForPrefix(

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -77,6 +77,9 @@ export function compileScopedConfig<
   if (!Array.isArray(config.loggers)) {
     throw createError("Configuration must include a loggers array.");
   }
+  if (config.filters !== undefined && !isObjectLike(config.filters)) {
+    throw createError("Configuration filters must be an object.");
+  }
 
   const nodes = new Map<string, CompiledScopedLogger>();
   const configuredCategories = new Set<string>();

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -234,8 +234,12 @@ export function emitWithScopedConfig(
 
 export async function disposeScopedConfig(
   scopedConfig: CompiledScopedConfig,
+  retainedDisposables?: ReadonlySet<Disposable | AsyncDisposable>,
 ): Promise<void> {
-  const parentDisposables = getParentScopedDisposables(scopedConfig);
+  const parentDisposables = getParentScopedDisposables(
+    scopedConfig,
+    retainedDisposables,
+  );
   scopedConfig.disposed = true;
   const errors: unknown[] = [];
   try {
@@ -263,8 +267,12 @@ export async function disposeScopedConfig(
 
 export function disposeScopedConfigSync(
   scopedConfig: CompiledScopedConfig,
+  retainedDisposables?: ReadonlySet<Disposable | AsyncDisposable>,
 ): void {
-  const parentDisposables = getParentScopedDisposables(scopedConfig);
+  const parentDisposables = getParentScopedDisposables(
+    scopedConfig,
+    retainedDisposables,
+  );
   scopedConfig.disposed = true;
   const errors: unknown[] = [];
   try {
@@ -316,8 +324,9 @@ function getActiveScopedConfig(
 
 function getParentScopedDisposables(
   scopedConfig: CompiledScopedConfig,
+  extraRetained?: ReadonlySet<Disposable | AsyncDisposable>,
 ): ReadonlySet<Disposable | AsyncDisposable> {
-  const disposables = new Set<Disposable | AsyncDisposable>();
+  const disposables = new Set<Disposable | AsyncDisposable>(extraRetained);
   let parent = scopedConfig.parent;
   while (parent != null) {
     const activeParent = getActiveScopedConfig(parent);

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -141,8 +141,7 @@ export function compileScopedConfig<
         );
       }
       asyncSinks.add(sink as AsyncDisposable);
-    }
-    if (Symbol.dispose in sink) syncSinks.add(sink as Disposable);
+    } else if (Symbol.dispose in sink) syncSinks.add(sink as Disposable);
   }
 
   for (const filter of Object.values<FilterLike>(config.filters ?? {})) {
@@ -155,8 +154,7 @@ export function compileScopedConfig<
       }
       asyncFilters.add(filter as AsyncDisposable);
       asyncSinks.delete(filter as AsyncDisposable);
-    }
-    if (Symbol.dispose in filter) {
+    } else if (Symbol.dispose in filter) {
       syncFilters.add(filter as Disposable);
       syncSinks.delete(filter as Disposable);
     }

--- a/packages/logtape/src/scoped-config.ts
+++ b/packages/logtape/src/scoped-config.ts
@@ -34,10 +34,10 @@ export interface CompiledScopedConfig {
   readonly nodes: ReadonlyMap<string, CompiledScopedLogger>;
   parent: CompiledScopedConfig | undefined;
   disposed: boolean;
-  readonly syncFilters: ReadonlySet<Disposable>;
-  readonly asyncFilters: ReadonlySet<AsyncDisposable>;
-  readonly syncSinks: ReadonlySet<Disposable>;
-  readonly asyncSinks: ReadonlySet<AsyncDisposable>;
+  readonly syncFilters: Set<Disposable>;
+  readonly asyncFilters: Set<AsyncDisposable>;
+  readonly syncSinks: Set<Disposable>;
+  readonly asyncSinks: Set<AsyncDisposable>;
 }
 
 interface CompiledScopedLogger {
@@ -425,39 +425,53 @@ function filterScopedRecord(
 }
 
 function disposeSyncDisposables(
-  disposables: ReadonlySet<Disposable>,
+  disposables: Set<Disposable>,
   retainedDisposables: ReadonlySet<Disposable | AsyncDisposable>,
 ): void {
   const errors: unknown[] = [];
-  for (const disposable of disposables) {
-    if (retainedDisposables.has(disposable)) continue;
-    try {
-      disposable[Symbol.dispose]();
-    } catch (error) {
-      errors.push(error);
+  try {
+    for (const disposable of disposables) {
+      try {
+        if (!retainedDisposables.has(disposable)) {
+          disposable[Symbol.dispose]();
+        }
+      } catch (error) {
+        errors.push(error);
+      } finally {
+        disposables.delete(disposable);
+      }
     }
+  } finally {
+    disposables.clear();
   }
   throwDisposeErrors(errors);
 }
 
 async function disposeAsyncDisposables(
-  disposables: ReadonlySet<AsyncDisposable>,
+  disposables: Set<AsyncDisposable>,
   retainedDisposables: ReadonlySet<Disposable | AsyncDisposable>,
 ): Promise<void> {
-  const results = await Promise.allSettled(
-    Array.from(
-      filterRetainedDisposables(disposables, retainedDisposables),
-      (disposable) =>
-        Promise.resolve().then(() => disposable[Symbol.asyncDispose]()),
-    ),
+  const disposableList = filterRetainedDisposables(
+    disposables,
+    retainedDisposables,
   );
-  throwDisposeErrors(
-    results
-      .filter((result): result is PromiseRejectedResult =>
-        result.status === "rejected"
-      )
-      .map((result) => result.reason),
-  );
+  for (const disposable of disposableList) disposables.delete(disposable);
+  try {
+    const results = await Promise.allSettled(
+      disposableList.map((disposable) =>
+        Promise.resolve().then(() => disposable[Symbol.asyncDispose]())
+      ),
+    );
+    throwDisposeErrors(
+      results
+        .filter((result): result is PromiseRejectedResult =>
+          result.status === "rejected"
+        )
+        .map((result) => result.reason),
+    );
+  } finally {
+    disposables.clear();
+  }
 }
 
 function filterRetainedDisposables<


### PR DESCRIPTION
Closes #185.


Why
---

LogTape configuration is process-wide today, which makes short-lived logging policies awkward. Test helpers, diagnostics, and request-local capture often need a different set of sinks/filters for one execution flow without disturbing the application configuration.

This PR keeps the process-wide configuration as the source of runtime integration, especially `contextLocalStorage`, and layers a scoped logging policy on top of the current execution context. That keeps the existing global model intact while giving callers a smaller primitive for temporary routing.


How
---

The new API adds `withConfig()`, `withConfigSync()`, and `ScopedConfig` to `@logtape/logtape`. A scoped config uses the same sinks/filters/loggers shape as `Config`, but leaves out `reset` and `contextLocalStorage`. Callers configure `Config.contextLocalStorage` globally first, then use scoped configs for temporary logger routing.

The scoped implementation lives in *packages/logtape/src/scoped-config.ts*. It compiles scoped logger state separately from the global logger graph, then logger dispatch checks the current scoped config before falling back to process-wide routing. The scoped path mirrors normal logger semantics, including `lowestLevel: null`, parent sink inheritance, category prefixes, implicit context, and lazy evaluation.

Filtering also follows the global dispatch order. A scoped logger first checks whether the record's level has an eligible dispatch plan, then runs filters only for records that can actually be emitted. That preserves the usual behavior for disabled levels and avoids running expensive or side-effectful filters for rejected records.

Scoped resources are disposed when the callback settles. Because context-local storage can propagate into async work that outlives the callback, disposed scoped configs are ignored by later propagated tasks. Those logs fall back to the nearest active parent scope, or to the process-wide configuration when no parent scope remains active.

Process-wide configuration changes are blocked while any scoped config is active, even from sibling async flows. That prevents `configure()`, `reset()`, or `dispose()` from invalidating a still-running scope through shared global state.

`withConfigSync()` follows the same lifetime model, but it rejects async disposable resources and promise-returning callbacks. The runtime callback guard observes rejected promises before throwing `ConfigError`, so accidental async callbacks do not also produce unhandled promise rejections.


Documentation and tests
-----------------------

The manual in *docs/manual/config.md* explains scoped configuration after the synchronous configuration section, including lifetime rules, nesting, interaction with `withContext()` and `withCategoryPrefix()`, global-only `getConfig()` behavior, meta logger setup, and disposal errors. *CHANGES.md* records the new 2.3 API.

The regression coverage in *packages/logtape/src/config.test.ts* exercises nested and concurrent scopes, disposal, async propagation after disposal, sibling global mutations, `lowestLevel: null`, disabled-level filters, invalid scoped configs, and sync callback/resource rejection.
