### PR TITLE
Route Sentry logs and breadcrumbs by level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -172,7 +172,16 @@ To be released.
     Sentry sink chooses `captureException()`.  The default remains
     `["error", "err"]`.  [[#189]]
 
+ -  Added `logs` and `breadcrumbs` options to `getSentrySink()` for controlling
+    which log levels are sent through Sentry's Logs API and which become Sentry
+    breadcrumbs.  `breadcrumbs: true` replaces `enableBreadcrumbs: true`, and
+    the new `SentryLogsOptions` and `SentryBreadcrumbOptions` interfaces
+    describe the corresponding option objects.  `enableBreadcrumbs` is now
+    deprecated but remains supported for compatibility.  [[#193], [#194]]
+
 [#189]: https://github.com/dahlia/logtape/issues/189
+[#193]: https://github.com/dahlia/logtape/issues/193
+[#194]: https://github.com/dahlia/logtape/pull/194
 
 
 Version 2.2.4

--- a/docs/sinks/sentry.md
+++ b/docs/sinks/sentry.md
@@ -136,7 +136,7 @@ Sentry.init({ dsn: process.env.SENTRY_DSN });
 await configure({
   sinks: {
     sentry: getSentrySink({
-      enableBreadcrumbs: true,
+      breadcrumbs: true,
     }),
   },
   loggers: [
@@ -145,9 +145,37 @@ await configure({
 });
 ~~~~
 
-When enabled, all log levels become breadcrumbs in Sentry, providing complete
-context for debugging. Use LogTape's `lowestLevel` to control which logs reach
-the sink.
+When enabled, non-error log levels become breadcrumbs in Sentry, providing
+complete context for debugging.  Use LogTape's `lowestLevel` to control which
+logs reach the sink.
+
+You can also configure which levels become breadcrumbs:
+
+~~~~ typescript twoslash
+// @noErrors: 2305 2307
+import * as Sentry from "@sentry/node";
+import { configure } from "@logtape/logtape";
+import { getSentrySink } from "@logtape/sentry";
+
+Sentry.init({ dsn: process.env.SENTRY_DSN });
+
+await configure({
+  sinks: {
+    sentry: getSentrySink({
+      breadcrumbs: {
+        level: "info",
+        maxLevel: "warning",
+      },
+    }),
+  },
+  loggers: [
+    { category: [], sinks: ["sentry"], lowestLevel: "debug" },
+  ],
+});
+~~~~
+
+The old `enableBreadcrumbs` option is still supported, but it is deprecated.
+Use `breadcrumbs: true` instead.
 
 ![LogTape records show up in the breadcrumbs of a Sentry issue.](../screenshots/sentry.png)
 
@@ -180,6 +208,71 @@ await configure({
 The sink automatically detects when the Logs API is available (SDK 9.41.0+ with
 `enableLogs: true`) and uses it for structured logging. When unavailable, logs
 are sent as events and breadcrumbs only.
+
+Use the `logs.level` option to set the minimum level sent through Sentry's Logs
+API:
+
+~~~~ typescript twoslash
+// @noErrors: 2305 2307
+import * as Sentry from "@sentry/node";
+import { configure } from "@logtape/logtape";
+import { getSentrySink } from "@logtape/sentry";
+
+Sentry.init({ dsn: process.env.SENTRY_DSN, enableLogs: true });
+
+await configure({
+  sinks: {
+    sentry: getSentrySink({
+      logs: { level: "warning" },
+      breadcrumbs: { level: "trace", maxLevel: "info" },
+    }),
+  },
+  loggers: [
+    { category: [], sinks: ["sentry"], lowestLevel: "trace" },
+  ],
+});
+~~~~
+
+This sends `warning` and higher records to Sentry's Logs API while keeping lower
+levels as breadcrumbs for later error reports.
+
+
+Routing logs and breadcrumbs by level
+-------------------------------------
+
+*This feature is available since LogTape 2.3.0.*
+
+Sometimes you may want verbose records to appear only as breadcrumbs, while
+sending higher-level records to Sentry's Logs API.  Do not use `withFilter()`
+for this case, because it filters records before they reach the Sentry sink and
+therefore prevents them from becoming breadcrumbs.
+
+Configure the sink-level `logs` and `breadcrumbs` options instead:
+
+~~~~ typescript twoslash
+// @noErrors: 2305 2307
+import * as Sentry from "@sentry/node";
+import { configure } from "@logtape/logtape";
+import { getSentrySink } from "@logtape/sentry";
+
+Sentry.init({ dsn: process.env.SENTRY_DSN, enableLogs: true });
+
+await configure({
+  sinks: {
+    sentry: getSentrySink({
+      logs: { level: "warning" },
+      breadcrumbs: { maxLevel: "info" },
+    }),
+  },
+  loggers: [
+    { category: [], sinks: ["sentry"], lowestLevel: "trace" },
+  ],
+});
+~~~~
+
+In this configuration, `trace`, `debug`, and `info` records become breadcrumbs.
+`warning`, `error`, and `fatal` records are sent through Sentry's Logs API.
+Error-level records still create Sentry issues as described below.
 
 
 Filtering and transformation
@@ -223,7 +316,9 @@ await configure({
 });
 ~~~~
 
-Returning `null` from `beforeSend` drops the log record entirely.
+Returning `null` from `beforeSend` drops the log record entirely, including
+structured logs, events, and breadcrumbs.  Use `logs.level` and `breadcrumbs`
+when you only need level-based routing between Sentry outputs.
 
 
 Event capture
@@ -277,9 +372,9 @@ await configure({
 });
 ~~~~
 
-All logs are sent to Sentry's structured logging (when `enableLogs: true`) and
-can become breadcrumbs (when `enableBreadcrumbs: true`), providing full context
-when errors occur.
+All logs are sent to Sentry's structured logging by default when
+`enableLogs: true`.  Non-error logs can become breadcrumbs when `breadcrumbs`
+is enabled, providing full context when errors occur.
 
 For more details, see the `getSentrySink()` function and `SentrySinkOptions`
 interface in the API reference.

--- a/packages/sentry/src/mod.test.ts
+++ b/packages/sentry/src/mod.test.ts
@@ -362,6 +362,121 @@ test("sink accepts enableBreadcrumbs option", () => {
   sink(createMockLogRecord({ level: "debug" }));
 });
 
+test("sink accepts breadcrumbs option", () => {
+  const breadcrumbs: unknown[] = [];
+  const sentry = createMockSentryNamespace({
+    getIsolationScope: () => ({
+      addBreadcrumb: (breadcrumb) => breadcrumbs.push(breadcrumb),
+    }),
+  });
+  const sink = getSentrySink({ sentry, breadcrumbs: true });
+
+  sink(createMockLogRecord({ level: "info" }));
+
+  assert.strictEqual(breadcrumbs.length, 1);
+});
+
+test("breadcrumbs option takes precedence over enableBreadcrumbs", () => {
+  const breadcrumbs: unknown[] = [];
+  const sentry = createMockSentryNamespace({
+    getIsolationScope: () => ({
+      addBreadcrumb: (breadcrumb) => breadcrumbs.push(breadcrumb),
+    }),
+  });
+  const sink = getSentrySink({
+    sentry,
+    enableBreadcrumbs: true,
+    breadcrumbs: false,
+  });
+
+  sink(createMockLogRecord({ level: "info" }));
+
+  assert.deepStrictEqual(breadcrumbs, []);
+});
+
+test("logs level filters records sent through Sentry Logs API", () => {
+  const logs: string[] = [];
+  const sentry = createMockSentryNamespace({
+    getClient: () => ({
+      getOptions: () => ({ enableLogs: true }),
+    }),
+    logger: {
+      info: (message) => logs.push(message.toString()),
+      warn: (message) => logs.push(message.toString()),
+    },
+  });
+  const sink = getSentrySink({ sentry, logs: { level: "warning" } });
+
+  sink(createMockLogRecord({ level: "info", message: ["Info"] }));
+  sink(createMockLogRecord({ level: "warning", message: ["Warning"] }));
+
+  assert.deepStrictEqual(logs, ["Warning"]);
+});
+
+test("breadcrumbs level filters records below the minimum level", () => {
+  const breadcrumbs: unknown[] = [];
+  const sentry = createMockSentryNamespace({
+    getIsolationScope: () => ({
+      addBreadcrumb: (breadcrumb) => breadcrumbs.push(breadcrumb),
+    }),
+  });
+  const sink = getSentrySink({
+    sentry,
+    breadcrumbs: { level: "info" },
+  });
+
+  sink(createMockLogRecord({ level: "debug" }));
+  sink(createMockLogRecord({ level: "info" }));
+
+  assert.strictEqual(breadcrumbs.length, 1);
+});
+
+test("breadcrumbs maxLevel filters records above the maximum level", () => {
+  const breadcrumbs: unknown[] = [];
+  const sentry = createMockSentryNamespace({
+    getIsolationScope: () => ({
+      addBreadcrumb: (breadcrumb) => breadcrumbs.push(breadcrumb),
+    }),
+  });
+  const sink = getSentrySink({
+    sentry,
+    breadcrumbs: { maxLevel: "info" },
+  });
+
+  sink(createMockLogRecord({ level: "info" }));
+  sink(createMockLogRecord({ level: "warning" }));
+
+  assert.strictEqual(breadcrumbs.length, 1);
+});
+
+test("logs and breadcrumbs levels can route records separately", () => {
+  const logs: string[] = [];
+  const breadcrumbs: string[] = [];
+  const sentry = createMockSentryNamespace({
+    getClient: () => ({
+      getOptions: () => ({ enableLogs: true }),
+    }),
+    getIsolationScope: () => ({
+      addBreadcrumb: (breadcrumb) => breadcrumbs.push(breadcrumb.message),
+    }),
+    logger: {
+      info: (message) => logs.push(message.toString()),
+      warn: (message) => logs.push(message.toString()),
+    },
+  });
+  const sink = getSentrySink({
+    sentry,
+    logs: { level: "warning" },
+    breadcrumbs: { level: "trace", maxLevel: "info" },
+  });
+
+  sink(createMockLogRecord({ level: "info", message: ["Info"] }));
+  sink(createMockLogRecord({ level: "warning", message: ["Warning"] }));
+
+  assert.deepStrictEqual(logs, ["Warning"]);
+  assert.deepStrictEqual(breadcrumbs, ["Info"]);
+});
+
 test("sink uses configured Sentry namespace for error messages", () => {
   const capturedMessages: string[] = [];
   const sentry = createMockSentryNamespace({

--- a/packages/sentry/src/mod.ts
+++ b/packages/sentry/src/mod.ts
@@ -76,6 +76,39 @@ function mapLevelForLogs(level: LogLevel): LogSeverityLevel {
 
 const defaultErrorPropertyNames = ["error", "err"] as const;
 
+/**
+ * Options for records sent through Sentry's Logs API.
+ *
+ * @since 2.3.0
+ */
+export interface SentryLogsOptions {
+  /**
+   * Minimum level for records sent through Sentry's Logs API.
+   *
+   * @default `"trace"`
+   */
+  level?: LogLevel;
+}
+
+/**
+ * Options for records added as Sentry breadcrumbs.
+ *
+ * @since 2.3.0
+ */
+export interface SentryBreadcrumbOptions {
+  /**
+   * Minimum level for records added as breadcrumbs.
+   *
+   * @default `"trace"`
+   */
+  level?: LogLevel;
+
+  /**
+   * Maximum level for records added as breadcrumbs.
+   */
+  maxLevel?: LogLevel;
+}
+
 function getErrorProperty(
   properties: Readonly<Record<string, unknown>>,
   propertyNames: readonly string[],
@@ -216,14 +249,39 @@ export interface SentrySinkOptions {
   /**
    * Enable automatic breadcrumb creation for log events.
    *
-   * When enabled, all logs become breadcrumbs in Sentry's isolation scope,
-   * providing a complete context trail when errors occur. Breadcrumbs are
-   * lightweight and only appear in error reports for debugging.
+   * When enabled, non-error logs become breadcrumbs in Sentry's isolation
+   * scope, providing a complete context trail when errors occur. Breadcrumbs
+   * are lightweight and only appear in error reports for debugging.
    *
    * @default false
+   * @deprecated Use `breadcrumbs` instead.
    * @since 1.3.0
    */
   enableBreadcrumbs?: boolean;
+
+  /**
+   * Enables and configures automatic breadcrumb creation for log events.
+   *
+   * Set this to `true` to use the default breadcrumb behavior, or pass an
+   * options object to control which non-error log levels become breadcrumbs.
+   *
+   * When this option is set, it takes precedence over the deprecated
+   * `enableBreadcrumbs` option.
+   *
+   * @default false
+   * @since 2.3.0
+   */
+  breadcrumbs?: boolean | SentryBreadcrumbOptions;
+
+  /**
+   * Configures records sent through Sentry's Logs API.
+   *
+   * The Sentry SDK must still have structured logging enabled with
+   * `enableLogs: true` or `_experiments.enableLogs: true`.
+   *
+   * @since 2.3.0
+   */
+  logs?: SentryLogsOptions;
 
   /**
    * Property names to inspect for an `Error` instance when deciding whether
@@ -306,7 +364,7 @@ export interface SentrySinkOptions {
  * await configure({
  *   sinks: {
  *     sentry: getSentrySink({
- *       enableBreadcrumbs: true,
+ *       breadcrumbs: true,
  *     }),
  *   },
  *   loggers: [
@@ -433,7 +491,7 @@ export function getSentrySink(
       // Send structured log if Sentry logging is enabled (v9.41.0+)
       // Uses public logger API when available (SDK 9.41.0+)
       const client = sentry.getClient();
-      if (client) {
+      if (client && shouldSendToLogs(transformed, options.logs)) {
         const { enableLogs, _experiments } = client.getOptions();
         const loggingEnabled = enableLogs ?? _experiments?.enableLogs;
 
@@ -470,7 +528,7 @@ export function getSentrySink(
           level: eventLevel,
           extra: attributes,
         });
-      } else if (options.enableBreadcrumbs) {
+      } else if (shouldAddBreadcrumb(transformed, options)) {
         // Non-error levels -> breadcrumbs only (if enabled)
         const isolationScope = sentry.getIsolationScope();
         isolationScope?.addBreadcrumb({
@@ -488,4 +546,32 @@ export function getSentrySink(
       );
     }
   };
+}
+
+function shouldSendToLogs(
+  record: LogRecord,
+  options: SentryLogsOptions | undefined,
+): boolean {
+  return options?.level == null ||
+    compareLogLevel(record.level, options.level) >= 0;
+}
+
+function shouldAddBreadcrumb(
+  record: LogRecord,
+  options: SentrySinkOptions,
+): boolean {
+  const breadcrumbOptions = options.breadcrumbs;
+  if (breadcrumbOptions === false) return false;
+  if (breadcrumbOptions === true) return true;
+  if (breadcrumbOptions == null) return options.enableBreadcrumbs === true;
+
+  if (
+    breadcrumbOptions.level != null &&
+    compareLogLevel(record.level, breadcrumbOptions.level) < 0
+  ) {
+    return false;
+  }
+
+  return breadcrumbOptions.maxLevel == null ||
+    compareLogLevel(record.level, breadcrumbOptions.maxLevel) <= 0;
 }


### PR DESCRIPTION
Fixes #193.


Why
---

The Sentry sink previously had only one filter point before all Sentry output paths.  That made `beforeSend` useful for dropping or rewriting a record globally, but it could not express a common Sentry setup: keep verbose records as breadcrumbs, then send `warning` and higher records through Sentry's Logs API.

Using `withFilter()` has the same problem from the other direction.  It removes records before they reach the Sentry sink, so the lower-level records never get a chance to become breadcrumbs.


How
---

This PR separates the two routing decisions inside the Sentry sink.  The new `logs` option applies only to records sent through Sentry's Logs API, while the new `breadcrumbs` option applies only to records added to the isolation scope as breadcrumbs.  Both options are level-based for now, which keeps the API small and covers the reported case without asking users to write custom `compareLogLevel()` hooks for basic routing.

`breadcrumbs: true` takes over the old `enableBreadcrumbs: true` behavior. `enableBreadcrumbs` still works, but it is marked as deprecated so existing configurations keep running while new code has one place for breadcrumb policy. When both options are set, `breadcrumbs` wins.

The implementation keeps `beforeSend` as the global hook.  Returning `null` from that hook still drops the record for every Sentry output path.  The new options are for level routing after a record has been accepted by the sink.


Documentation and tests
-----------------------

The Sentry sink tests cover the compatibility path, the precedence rule, each level bound, and the split routing case where `info` becomes a breadcrumb while `warning` goes to Sentry Logs.

The manual in *docs/sinks/sentry.md* now shows `breadcrumbs: true`, explains why `withFilter()` is not enough for this case, and documents the `logs`/`breadcrumbs` configuration.  *CHANGES.md* records the new `SentryLogsOptions` and `SentryBreadcrumbOptions` interfaces as part of the public API change.