### PR TITLE
Fix circular structure error in OpenTelemetry sink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ Version 2.3.2
 
 To be released.
 
+### @logtape/opentelemetry
+
+ -  Fixed a `TypeError: Converting circular structure to JSON` raised while
+    rendering interpolated message values (e.g. logging a `Response` or any
+    value containing circular reference)
+
 
 Version 2.3.1
 -------------

--- a/changes.d/opentelemetry/fix-circular-error.md
+++ b/changes.d/opentelemetry/fix-circular-error.md
@@ -1,0 +1,3 @@
+ -  Fixed a `TypeError: Converting circular structure to JSON` raised while
+    rendering interpolated message values (e.g. logging a `Response` or any
+    value containing circular reference)

--- a/packages/otel/deno.json
+++ b/packages/otel/deno.json
@@ -5,8 +5,35 @@
   "exports": {
     ".": "./src/mod.ts"
   },
+  "imports": {
+    "#util": "src/util.deno.ts"
+  },
   "tasks": {
     "build": "pnpm build",
-    "test": "deno test --allow-net --allow-env"
-  }
+    "test": "deno test",
+    "test:node": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "node --experimental-transform-types --test"
+    },
+    "test:bun": {
+      "dependencies": [
+        "build"
+      ],
+      "command": "bun test"
+    },
+    "test-all": {
+      "dependencies": [
+        "test",
+        "test:node",
+        "test:bun"
+      ]
+    }
+  },
+  "exclude": [
+    "dist/",
+    "npm/",
+    "node_modules/"
+  ]
 }

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -40,6 +40,30 @@
     },
     "./package.json": "./package.json"
   },
+  "imports": {
+    "#util": {
+      "types": {
+        "import": "./dist/util.d.ts",
+        "require": "./dist/util.d.cts"
+      },
+      "browser": {
+        "import": "./dist/util.js",
+        "require": "./dist/util.cjs"
+      },
+      "node": {
+        "import": "./dist/util.node.js",
+        "require": "./dist/util.node.cjs"
+      },
+      "bun": {
+        "import": "./dist/util.node.js",
+        "require": "./dist/util.node.cjs"
+      },
+      "deno": "./dist/util.deno.js",
+      "import": "./dist/util.js",
+      "require": "./dist/util.cjs",
+      "default": "./dist/util.js"
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist/"

--- a/packages/otel/src/mod.test.ts
+++ b/packages/otel/src/mod.test.ts
@@ -468,6 +468,35 @@ test("sink handles array values in properties", () => {
   ]);
 });
 
+test("sink handles circular references in interpolated message values", () => {
+  const { provider, emittedRecords } = createMockLoggerProvider();
+  const sink = getOpenTelemetrySink({
+    loggerProvider: provider as never,
+    objectRenderer: "inspect",
+  });
+
+  // A circular value (resembling a Response with a back-reference) used as a
+  // message interpolation value.  Previously this hit JSON.stringify's circular
+  // structure error inside getParameterizedString(), which the sink swallowed,
+  // so captureMessage was never reached.  Now inspect() (util.inspect /
+  // Deno.inspect) renders it instead.
+  const circular: Record<string, unknown> = { body: "ok" };
+  circular.self = circular;
+
+  sink(createMockLogRecord({
+    level: "error",
+    message: ["Saw error: ", circular, ""],
+    rawMessage: "Saw error: {error}",
+    properties: { error: circular },
+  }));
+
+  assert.strictEqual(emittedRecords.length, 1);
+
+  const body = emittedRecords[0].body as string;
+  assert.ok(body.startsWith("Saw error: "));
+  assert.ok(body.length > "Saw error: ".length);
+});
+
 test("sink handles Date objects in properties", () => {
   const { provider, emittedRecords } = createMockLoggerProvider();
   const sink = getOpenTelemetrySink({

--- a/packages/otel/src/mod.ts
+++ b/packages/otel/src/mod.ts
@@ -25,6 +25,10 @@ import {
 } from "@opentelemetry/sdk-logs";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import metadata from "../deno.json" with { type: "json" };
+// Cross-runtime inspect: Deno.inspect / util.inspect (handles circular
+// references); falls back to JSON.stringify in browsers. Resolved via the
+// `#util` import map per runtime.
+import { inspect } from "#util";
 
 /**
  * Gets an environment variable value across different JavaScript runtimes.
@@ -606,6 +610,7 @@ function convertValueToAnyValue(
   value: unknown,
   objectRenderer: ObjectRenderer,
   exceptionMode: ExceptionAttributeMode,
+  seenObjects: Set<unknown> = new Set(),
 ): AnyValue | null {
   // Handle null/undefined
   if (value == null) return null;
@@ -617,6 +622,11 @@ function convertValueToAnyValue(
   ) {
     return value;
   }
+
+  if (seenObjects.has(value)) {
+    return null;
+  }
+  seenObjects.add(value);
 
   // Handle arrays - recursively convert elements
   if (Array.isArray(value)) {
@@ -654,6 +664,7 @@ function convertValueToAnyValue(
         item,
         objectRenderer,
         exceptionMode,
+        seenObjects,
       );
       // Skip null items but preserve the structure
       if (convertedItem !== null) {
@@ -677,6 +688,7 @@ function convertValueToAnyValue(
         val,
         objectRenderer,
         exceptionMode,
+        seenObjects,
       );
       if (convertedVal !== null) {
         converted[key] = convertedVal;
@@ -700,6 +712,7 @@ function convertValueToAnyValue(
           val,
           objectRenderer,
           exceptionMode,
+          seenObjects,
         );
         if (convertedVal !== null) {
           converted[key] = convertedVal;
@@ -868,29 +881,6 @@ function convertMessageToCustomBodyFormat(
   );
   return bodyFormatter(body);
 }
-
-/**
- * A platform-specific inspect function.  In Deno, this is {@link Deno.inspect},
- * and in Node.js/Bun it is {@link util.inspect}.  If neither is available, it
- * falls back to {@link JSON.stringify}.
- *
- * @param value The value to inspect.
- * @returns The string representation of the value.
- */
-const inspect: (value: unknown) => string =
-  // @ts-ignore: Deno global
-  "Deno" in globalThis && "inspect" in globalThis.Deno &&
-    // @ts-ignore: Deno global
-    typeof globalThis.Deno.inspect === "function"
-    // @ts-ignore: Deno global
-    ? globalThis.Deno.inspect
-    // @ts-ignore: Node.js global
-    : "util" in globalThis && "inspect" in globalThis.util &&
-        // @ts-ignore: Node.js global
-        globalThis.util.inspect === "function"
-    // @ts-ignore: Node.js global
-    ? globalThis.util.inspect
-    : JSON.stringify;
 
 class DiagLoggerAdaptor implements DiagLogger {
   logger: Logger;

--- a/packages/otel/src/util.deno.ts
+++ b/packages/otel/src/util.deno.ts
@@ -1,0 +1,19 @@
+export interface InspectOptions {
+  colors?: boolean;
+  depth?: number | null;
+  compact?: boolean;
+  [key: string]: unknown;
+}
+
+export function inspect(obj: unknown, options?: InspectOptions): string {
+  if ("Deno" in globalThis) {
+    return Deno.inspect(obj, {
+      colors: options?.colors,
+      depth: options?.depth ?? undefined,
+      compact: options?.compact ?? true,
+    });
+  } else {
+    const indent = options?.compact === true ? undefined : 2;
+    return JSON.stringify(obj, null, indent);
+  }
+}

--- a/packages/otel/src/util.node.ts
+++ b/packages/otel/src/util.node.ts
@@ -1,0 +1,12 @@
+import util from "node:util";
+
+export interface InspectOptions {
+  colors?: boolean;
+  depth?: number | null;
+  compact?: boolean;
+  [key: string]: unknown;
+}
+
+export function inspect(obj: unknown, options?: InspectOptions): string {
+  return util.inspect(obj, options);
+}

--- a/packages/otel/src/util.ts
+++ b/packages/otel/src/util.ts
@@ -1,0 +1,11 @@
+export interface InspectOptions {
+  colors?: boolean;
+  depth?: number | null;
+  compact?: boolean;
+  [key: string]: unknown;
+}
+
+export function inspect(obj: unknown, options?: InspectOptions): string {
+  const indent = options?.compact === true ? undefined : 2;
+  return JSON.stringify(obj, null, indent);
+}

--- a/packages/otel/tsdown.config.ts
+++ b/packages/otel/tsdown.config.ts
@@ -1,11 +1,24 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: "src/mod.ts",
+  entry: ["src/mod.ts", "src/util.ts", "src/util.deno.ts", "src/util.node.ts"],
   dts: {
     sourcemap: true,
   },
   format: ["esm", "cjs"],
   platform: "neutral",
   unbundle: true,
+  inputOptions: {
+    onLog(level, log, defaultHandler) {
+      if (
+        level === "warn" && log.code === "UNRESOLVED_IMPORT" &&
+        ["node:util", "#util"].includes(
+          log.exporter ?? "",
+        )
+      ) {
+        return;
+      }
+      defaultHandler(level, log);
+    },
+  },
 });


### PR DESCRIPTION
Very similar to 882144747a67f5c62bed46f85b29999e99fa17be.
In addition to fixing the inspect call, I also needed to track objects
seen in the convertValueToAnyValue recursion as it would otherwise cause
an infinite recursion in some cases.