### PR TITLE
Add getLoggers() to list loggers in a category tree

### DIFF
--- a/changes.d/logtape/get-loggers.md
+++ b/changes.d/logtape/get-loggers.md
@@ -1,0 +1,3 @@
+ -  Added `getLoggers()` function to enumerate every logger in the category
+    tree rooted at a given logger (or the root logger by default), including
+    the given logger itself, in depth-first pre-order.  [[#62]]

--- a/changes.d/logtape/get-loggers.md
+++ b/changes.d/logtape/get-loggers.md
@@ -1,3 +1,4 @@
  -  Added `getLoggers()` function to enumerate every logger in the category
     tree rooted at a given logger (or the root logger by default), including
-    the given logger itself, in depth-first pre-order.  [[#62]]
+    the given logger itself, in depth-first pre-order.
+    [[#62], [#207] by Jepoy]

--- a/docs/manual/categories.md
+++ b/docs/manual/categories.md
@@ -198,6 +198,45 @@ const childLogger = logger.getChild(["my-module", "foo"]);
 ~~~~
 
 
+Listing loggers
+----------------
+
+*This API is available since LogTape 2.4.0.*
+
+`getLoggers()` returns every logger in the category tree rooted at a given
+logger, including that logger itself, in depth-first order.  Called with no
+arguments, it returns the whole tree from the root down:
+
+~~~~ typescript twoslash
+import { getLogger, getLoggers } from "@logtape/logtape";
+// ---cut-before---
+getLogger(["my-app"]);
+getLogger(["my-app", "my-module"]);
+
+for (const logger of getLoggers()) {
+  console.log(logger.category);
+}
+// [ ]
+// [ "my-app" ]
+// [ "my-app", "my-module" ]
+~~~~
+
+Pass a `Logger`, or a category as a string or array of strings, to scope the
+result to a subtree:
+
+~~~~ typescript twoslash
+import { getLogger, getLoggers } from "@logtape/logtape";
+// ---cut-before---
+getLoggers("my-app"); // ["my-app"] and its descendants only
+~~~~
+
+> [!NOTE]
+> `getLoggers()` only returns loggers that have actually been created by a
+> `getLogger()` call somewhere in your program.  A category that's configured
+> via `configure()` but never reached by `getLogger()`—for example, inside a
+> code path that hasn't run yet—won't appear in the result.
+
+
 Meta logger
 -----------
 

--- a/packages/logtape/src/logger.test.ts
+++ b/packages/logtape/src/logger.test.ts
@@ -12,6 +12,7 @@ import { debug, error, info, warning } from "./fixtures.ts";
 import type { LogLevel } from "./level.ts";
 import {
   getLogger,
+  getLoggers,
   isLazy,
   lazy,
   type Logger,
@@ -64,6 +65,51 @@ test("getLogger()", () => {
     getLogger(["foo", "bar"]),
     getLogger().getChild("foo").getChild("bar"),
   );
+});
+
+test("getLoggers() with a never-touched category", () => {
+  const logger = getLogger("gl-fresh");
+  assert.deepStrictEqual(getLoggers("gl-fresh"), [logger]);
+});
+
+test("getLoggers() omits descendants never reached by getLogger()", () => {
+  const parent = getLogger("gl-unmaterialized");
+  // "gl-unmaterialized.child" is deliberately never passed to getLogger(),
+  // so it must not appear in the result.
+  assert.deepStrictEqual(getLoggers("gl-unmaterialized"), [parent]);
+});
+
+test("getLoggers() returns a depth-first pre-order subtree", () => {
+  const root = getLogger("gl-tree");
+  const a = getLogger(["gl-tree", "a"]);
+  const ax = getLogger(["gl-tree", "a", "x"]);
+  const b = getLogger(["gl-tree", "b"]);
+  assert.deepStrictEqual(getLoggers("gl-tree"), [root, a, ax, b]);
+  assert.deepStrictEqual(getLoggers(root), [root, a, ax, b]);
+  assert.deepStrictEqual(getLoggers(["gl-tree"]), [root, a, ax, b]);
+});
+
+test("getLoggers() returns loggers identical to getLogger()", () => {
+  const a = getLogger("gl-identity");
+  const b = getLogger(["gl-identity", "child"]);
+  const [first, second] = getLoggers("gl-identity");
+  assert.strictEqual(first, a);
+  assert.strictEqual(second, b);
+});
+
+test("getLoggers() with no arguments includes the root and materialized loggers", () => {
+  const marker = getLogger("gl-default-marker");
+  const loggers = getLoggers();
+  assert.strictEqual(loggers[0], getLogger());
+  assert.ok(loggers.includes(marker));
+});
+
+test("getLoggers() skips dead WeakRef entries without pruning them", () => {
+  const parent = getLogger("gl-dead-ref") as LoggerImpl;
+  const deadRef = { deref: () => undefined } as WeakRef<LoggerImpl>;
+  parent.children["ghost"] = deadRef;
+  assert.deepStrictEqual(getLoggers("gl-dead-ref"), [parent]);
+  assert.strictEqual(parent.children["ghost"], deadRef);
 });
 
 test("Logger.getChild()", () => {

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -1512,6 +1512,54 @@ export function getLogger(category: string | readonly string[] = []): Logger {
 }
 
 /**
+ * Enumerate every logger in the category tree rooted at the given logger,
+ * including the given logger itself, in depth-first pre-order.
+ *
+ * ```typescript
+ * const all = getLoggers();          // the whole tree, from the root down
+ * const mine = getLoggers("my-app"); // "my-app" and its descendants only
+ * ```
+ *
+ * This only reflects loggers that have actually been *materialized* by a
+ * `getLogger()` call somewhere in the running program.  A category that has
+ * been configured via `configure()` but never reached by a `getLogger()`
+ * call (e.g. inside an unexecuted code path) will not appear.
+ *
+ * @param logger The logger (or its category, as a string or array of
+ *               strings) to start from.  Defaults to the root logger.
+ * @returns Every logger in the subtree, starting with the resolved logger
+ *          itself, in depth-first pre-order.
+ * @since 2.4.0
+ */
+export function getLoggers(
+  logger?: Logger | string | readonly string[],
+): readonly Logger[] {
+  const category = logger == null
+    ? []
+    : isCategory(logger)
+    ? logger
+    : logger.category;
+  return collectDescendants(LoggerImpl.getLogger(category));
+}
+
+function isCategory(
+  value: Logger | string | readonly string[],
+): value is string | readonly string[] {
+  return typeof value === "string" || Array.isArray(value);
+}
+
+function collectDescendants(logger: LoggerImpl): readonly LoggerImpl[] {
+  const loggers: LoggerImpl[] = [logger];
+  for (const childRef of Object.values(logger.children)) {
+    const child = childRef instanceof LoggerImpl
+      ? childRef
+      : childRef.deref();
+    if (child != null) loggers.push(...collectDescendants(child));
+  }
+  return loggers;
+}
+
+/**
  * The symbol for the global root logger.
  */
 const globalRootLoggerSymbol = Symbol.for("logtape.rootLogger");

--- a/packages/logtape/src/logger.ts
+++ b/packages/logtape/src/logger.ts
@@ -1551,9 +1551,7 @@ function isCategory(
 function collectDescendants(logger: LoggerImpl): readonly LoggerImpl[] {
   const loggers: LoggerImpl[] = [logger];
   for (const childRef of Object.values(logger.children)) {
-    const child = childRef instanceof LoggerImpl
-      ? childRef
-      : childRef.deref();
+    const child = childRef instanceof LoggerImpl ? childRef : childRef.deref();
     if (child != null) loggers.push(...collectDescendants(child));
   }
   return loggers;

--- a/packages/logtape/src/mod.ts
+++ b/packages/logtape/src/mod.ts
@@ -58,6 +58,7 @@ export {
 } from "./level.ts";
 export {
   getLogger,
+  getLoggers,
   isLazy,
   type Lazy,
   lazy,


### PR DESCRIPTION
Closes #62.

Right now there's no way to find out which loggers exist in a running program. If you're building something like a debug panel where users can toggle categories on and off, or you just want to sanity-check what logging is active, you have to already know every category name up front.

This adds `getLoggers()`, which walks the category tree from a given logger (or the root, by default) and returns every logger in that subtree, including the one you passed in, in depth-first order:

```typescript
const all = getLoggers();          // the whole tree, from the root down
const mine = getLoggers("my-app"); // "my-app" and its descendants only
```

It also accepts a `Logger`, a category string, or a category array, same as `getLogger()`.

One thing worth calling out (this came up in the discussion on #62): it only sees loggers that have actually been created via a `getLogger()` call somewhere in the program, not every category that's been set up through `configure()`. If a category is only reached lazily inside a function that hasn't run yet, it won't show up. That's documented in the docstring.

## Testing

Added tests in `logger.test.ts` covering: a fresh/never-touched category, a multi-level subtree in depth-first order, identity with `getLogger()`, the no-argument default, an untouched descendant being correctly omitted, and dead `WeakRef` entries being skipped without being pruned from the tree.

Ran the Node test suite locally (`pnpm test` in `packages/logtape`) — all passing. I wasn't able to run `deno check`/`deno lint`/`mise run check` in my environment (no `deno`/`mise` install available), so it'd be good to have CI confirm those.

---

**AI disclosure:** This PR was written with assistance from Claude Code (claude-sonnet-5) — design discussion, implementation, and tests. I reviewed and tested everything locally before submitting. See `Assisted-by` trailers in the commit.