### PR TITLE
Support Elysia 2 while retaining Elysia 1 compatibility

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,9 +115,19 @@ jobs:
     - run: mise run build
     - run: mise run test:bun
 
+  test-elysia-compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+    - uses: jdx/mise-action@v4
+      with: *mise_options
+    - run: pnpm install --frozen-lockfile
+    - run: mise run test:elysia-compatibility
+
   publish:
     if: github.event_name == 'push'
-    needs: [check, test-deno, test-node, test-bun]
+    needs: [check, test-deno, test-node, test-bun, test-elysia-compatibility]
     permissions:
       contents: read
       id-token: write

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,13 @@ To be released.
  -  The `parentSinks` option of logger configurations now accepts
     `"forward"`, matching *@logtape/logtape* 2.4.0.  [[#198]]
 
+### @logtape/elysia
+
+ -  Added support for Elysia 2 beta while retaining support for Elysia 1.4.
+    [[#212]]
+
+[#212]: https://github.com/dahlia/logtape/pull/212
+
 ### @logtape/lint
 
  -  Added an opt-in `no-dynamic-message` rule to *@logtape/lint* for finding

--- a/changes.d/elysia/elysia-2.md
+++ b/changes.d/elysia/elysia-2.md
@@ -1,0 +1,6 @@
+---
+links:
+  '#212': https://github.com/dahlia/logtape/pull/212
+---
+ -  Added support for Elysia 2 beta while retaining support for Elysia 1.4.
+    [[#212]]

--- a/docs/manual/integrations.md
+++ b/docs/manual/integrations.md
@@ -337,6 +337,51 @@ bun add @logtape/elysia
 
 :::
 
+Since LogTape 2.4.0, this adapter supports Elysia 1.4 and Elysia 2 starting
+with *2.0.0-beta.12*.  Elysia 2 is still in beta.  The `elysiaLogger()` options
+are the same for both versions; application routes and hooks use the native
+API of the installed Elysia version.
+
+The application and adapter must resolve the same Elysia package copy and
+module format.  Use ESM throughout or CommonJS throughout, including imported
+child plugins.  Local request context relies on Elysia 2's internal hook and
+route representation, which the compatibility tests check against the pinned
+beta version.
+
+When using `scope: "local"` with request context enabled, the adapter registers
+an internal macro in Elysia 2.  Elysia 2 rejects adding macros to the parent app
+from an async plugin function after `await`.  Register the logger before that
+`await`, or return a separate logger plugin for Elysia to merge:
+
+~~~~ typescript
+const app = new Elysia().use(async () => {
+  await initializeDatabase();
+  return elysiaLogger({ scope: "local", context: true })
+    .get("/", () => "Hello");
+});
+~~~~
+
+Do not use `return app.use(elysiaLogger(...))` after `await` inside
+`.use(async (app) => { ... })` with these options.  Returning the separate
+plugin lets Elysia merge it in its ordered async plugin queue.  This restriction
+does not affect `await` inside request handlers.
+
+For Elysia 2 on Deno, add these overrides to your *deno.json* `imports` map,
+alongside the LogTape imports.  The exact npm specifiers also redirect the
+adapter's JSR dependencies, so the application and adapter share Elysia:
+
+~~~~ json
+{
+  "imports": {
+    "elysia": "npm:elysia@2.0.0-beta.12",
+    "npm:elysia@^1.4.0": "npm:elysia@2.0.0-beta.12",
+    "npm:elysia@^1.4.0/utils": "npm:elysia@2.0.0-beta.12/utils"
+  }
+}
+~~~~
+
+Keep all three mappings on the same Elysia version when upgrading.
+
 Here's an example of using LogTape with Elysia:
 
 ~~~~ typescript twoslash
@@ -443,6 +488,7 @@ Elysia supports plugin scoping to control how lifecycle hooks propagate:
 
  -  `"global"`: Hooks apply to all routes in the application (default)
  -  `"scoped"`: Hooks apply to the parent instance where the plugin is used
+    (Elysia 2 calls this scope `"plugin"`)
  -  `"local"`: Hooks only apply within the plugin itself
 
 ~~~~ typescript twoslash
@@ -495,8 +541,10 @@ const plugin = elysiaLogger({
 ### Error logging
 
 The plugin automatically logs errors at the error level using Elysia's
-`onError` hook.  Error logs include the error message and error code
-in addition to standard request properties.
+`onError` hook in Elysia 1 or `error` hook in Elysia 2.  Error logs include
+`errorMessage` in addition to standard request properties.  `errorCode` is
+Elysia 1's context code, or Elysia 2's `error.code` when it is a string or
+number; it is omitted when Elysia 2 supplies no code.
 
 ### Structured logging output
 

--- a/mise.toml
+++ b/mise.toml
@@ -109,3 +109,7 @@ depends = ["check"]
 [tasks."hooks:pre-push"]
 description = "Run pre-push checks"
 depends = ["check", "test:deno"]
+
+[tasks."test:elysia-compatibility"]
+description = "Test Elysia 1 and 2 with packed npm artifacts and Deno source"
+run = "deno run --allow-all scripts/check_elysia_compatibility.ts"

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -29,6 +29,55 @@ bun  add     @logtape/elysia  # for Bun
 ~~~~
 
 
+Compatibility
+-------------
+
+Since LogTape 2.4.0, this adapter supports Elysia 1.4 and Elysia 2 starting
+with *2.0.0-beta.12*.  Elysia 2 is still in beta.  The `elysiaLogger()` options
+are the same for both versions; application routes and hooks use the native
+API of the installed Elysia version.
+
+The application and adapter must resolve the same Elysia package copy and
+module format.  Use ESM throughout or CommonJS throughout, including imported
+child plugins.  Local request context relies on Elysia 2's internal hook and
+route representation, which the compatibility tests check against the pinned
+beta version.
+
+When using `scope: "local"` with request context enabled, the adapter registers
+an internal macro in Elysia 2.  Elysia 2 rejects adding macros to the parent app
+from an async plugin function after `await`.  Register the logger before that
+`await`, or return a separate logger plugin for Elysia to merge:
+
+~~~~ typescript
+const app = new Elysia().use(async () => {
+  await initializeDatabase();
+  return elysiaLogger({ scope: "local", context: true })
+    .get("/", () => "Hello");
+});
+~~~~
+
+Do not use `return app.use(elysiaLogger(...))` after `await` inside
+`.use(async (app) => { ... })` with these options.  Returning the separate
+plugin lets Elysia merge it in its ordered async plugin queue.  This restriction
+does not affect `await` inside request handlers.
+
+For Elysia 2 on Deno, add these overrides to your *deno.json* `imports` map,
+alongside the LogTape imports.  The exact npm specifiers also redirect the
+adapter's JSR dependencies, so the application and adapter share Elysia:
+
+~~~~ json
+{
+  "imports": {
+    "elysia": "npm:elysia@2.0.0-beta.12",
+    "npm:elysia@^1.4.0": "npm:elysia@2.0.0-beta.12",
+    "npm:elysia@^1.4.0/utils": "npm:elysia@2.0.0-beta.12/utils"
+  }
+}
+~~~~
+
+Keep all three mappings on the same Elysia version when upgrading.
+
+
 Usage
 -----
 
@@ -122,6 +171,7 @@ Elysia supports plugin scoping to control how lifecycle hooks propagate:
 
  -  `"global"`: Hooks apply to all routes in the application (default)
  -  `"scoped"`: Hooks apply to the parent instance where the plugin is used
+    (Elysia 2 calls this scope `"plugin"`)
  -  `"local"`: Hooks only apply within the plugin itself
 
 
@@ -168,8 +218,10 @@ Error logging
 -------------
 
 The plugin automatically logs errors at the error level using Elysia's
-`onError` hook.  Error logs include the error message and error code
-in addition to standard request properties.
+`onError` hook in Elysia 1 or `error` hook in Elysia 2.  Error logs include
+`errorMessage` in addition to standard request properties.  `errorCode` is
+Elysia 1's context code, or Elysia 2's `error.code` when it is a string or
+number; it is omitted when Elysia 2 supplies no code.
 
 
 Structured logging output

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -54,7 +54,7 @@
   ],
   "peerDependencies": {
     "@logtape/logtape": "workspace:^",
-    "elysia": "catalog:"
+    "elysia": "^1.4.0 || ^2.0.0-beta.12"
   },
   "devDependencies": {
     "@alinea/suite": "catalog:",

--- a/packages/elysia/src/compat.ts
+++ b/packages/elysia/src/compat.ts
@@ -1,0 +1,389 @@
+import * as elysia from "elysia";
+import * as utils from "elysia/utils";
+import type { ElysiaContext } from "./mod.ts";
+
+type Callback = (this: unknown, ...args: unknown[]) => unknown;
+type Fields = Record<string, unknown>;
+
+export interface HookContext extends ElysiaContext {
+  store: { startTime: number };
+  error?: unknown;
+  code?: string;
+}
+
+/** The adapter only needs these lifecycle registration capabilities. */
+export function createCompatibility(instance: unknown) {
+  const plugin = instance as Fields;
+  const v2 = typeof plugin.onRequest !== "function" &&
+    typeof plugin.request === "function";
+  const register = (
+    event: "Request" | "BeforeHandle" | "AfterHandle" | "Error",
+    callback: (context: HookContext) => unknown,
+  ): void => {
+    const name = v2 ? event[0].toLowerCase() + event.slice(1) : `on${event}`;
+    const method = plugin[name];
+    if (typeof method !== "function") throw unsupported();
+    method.call(instance, (raw: HookContext) =>
+      callback(
+        v2 ? normalizeContext(raw, event === "Error") : raw,
+      ));
+  };
+  const as = (scope: "scoped" | "global"): void => {
+    (plugin.as as Callback).call(
+      instance,
+      v2 && scope === "scoped" ? "plugin" : scope,
+    );
+  };
+  return { v2, register, as };
+}
+
+function unsupported(): Error {
+  return new Error(
+    "@logtape/elysia: unsupported Elysia 2 internals for local request " +
+      "context. Use a supported Elysia version and the same Elysia copy " +
+      "and module format for the application and plugin (including utils).",
+  );
+}
+
+/** Elysia 2 shares a frozen default header map until its first write. */
+export function materializeHeaders(set: ElysiaContext["set"]): void {
+  if ((set.headers as Record<string, unknown>)["\0"] === set.headers) {
+    set.headers = Object.assign(Object.create(null), set.headers);
+  }
+}
+
+function numericStatus(value: unknown, fallback: number): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    return (elysia.StatusMap as Record<string, number>)[value] ?? fallback;
+  }
+  return fallback;
+}
+
+function normalizeContext(raw: HookContext, error: boolean): HookContext {
+  const rawSet = raw.set;
+  materializeHeaders(rawSet);
+  const response = (raw as unknown as Fields).responseValue;
+  const statusClass = (elysia as unknown as Fields).ElysiaStatus;
+  const responseStatus = !error &&
+      (response instanceof Response ||
+        (typeof statusClass === "function" && response instanceof statusClass))
+    ? (response as { status: number }).status
+    : undefined;
+  const set = Object.create(rawSet, {
+    status: {
+      enumerable: true,
+      get: () =>
+        responseStatus ?? numericStatus(rawSet.status, error ? 500 : 200),
+      set: (value: number) => {
+        rawSet.status = value;
+      },
+    },
+    headers: {
+      enumerable: true,
+      get: () => {
+        materializeHeaders(rawSet);
+        return rawSet.headers;
+      },
+      set: (value: ElysiaContext["set"]["headers"]) => {
+        rawSet.headers = value;
+      },
+    },
+  });
+  return Object.assign(Object.create(raw), { set });
+}
+
+export function nativeErrorCode(error: unknown): string | number | undefined {
+  if (error == null || typeof error !== "object") return undefined;
+  const code = (error as Fields).code;
+  return typeof code === "string" || typeof code === "number"
+    ? code
+    : undefined;
+}
+
+const hookKeys = [
+  "beforeHandle",
+  "afterHandle",
+  "parse",
+  "transform",
+  "derive",
+  "mapDerive",
+  "mapResponse",
+  "afterResponse",
+  "error",
+];
+const routeMethods = [
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+  "all",
+  "method",
+  "use",
+  "group",
+  "guard",
+  "mount",
+];
+
+/**
+ * Elysia 2 has no around-handler lifecycle. Its declared route tuples and
+ * immutable hook-chain links are private integration points, verified by the
+ * pinned compatibility matrix. Only this logger's copied rows are rewritten;
+ * an imported child must remain safe to reuse in another application.
+ */
+export function wrapV2LocalContext(
+  instance: unknown,
+  wrapCallback: (value: unknown) => unknown,
+  macroName: string,
+): () => void {
+  const plugin = instance as Fields;
+  const origins = (utils as unknown as Fields).fnOrigin;
+  if (!(origins instanceof WeakMap)) throw unsupported();
+  const probe = () => {};
+  const probeApp = new elysia.Elysia({
+    name: "@logtape/elysia/probe",
+  }) as unknown as Fields;
+  if (typeof probeApp.beforeHandle !== "function") throw unsupported();
+  probeApp.beforeHandle(probe);
+  // A different ESM/CJS copy or a bundled utils module has a different map.
+  if (!origins.has(probe)) throw unsupported();
+
+  const replacements = new WeakMap<object, object>();
+  const wrap = (value: unknown): unknown => {
+    if (Array.isArray(value)) {
+      const present = new Set(value);
+      // Early-wrapped guard errors can meet their original macro callback.
+      // Native macro dedupe would retain the existing (wrapped) slot. Remove
+      // only that mixed representation, not deliberate [fn, fn] repetitions.
+      return value.filter((item) => {
+        if (typeof item !== "function") return true;
+        const replacement = replacements.get(item);
+        return replacement == null || !present.has(replacement);
+      }).map(wrap);
+    }
+    const wrapped = wrapCallback(value);
+    if (
+      typeof value === "function" && typeof wrapped === "function" &&
+      value !== wrapped
+    ) {
+      replacements.set(value, wrapped);
+    }
+    if (
+      typeof value === "function" && typeof wrapped === "function" &&
+      origins.has(value)
+    ) origins.set(wrapped, origins.get(value));
+    return wrapped;
+  };
+  const resolveParse = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(resolveParse);
+    const parsers = (plugin["~ext"] as Fields | undefined)?.parser as
+      | Fields
+      | undefined;
+    return wrap(typeof value === "string" ? parsers?.[value] ?? value : value);
+  };
+  const hooks = (value: unknown, final = false): unknown => {
+    if (value == null) return final ? value : { [macroName]: true };
+    if (typeof value !== "object" || Array.isArray(value)) throw unsupported();
+    const source = value as Fields;
+    const copy = { ...source };
+    for (const key of hookKeys) {
+      if (final && key in source) {
+        copy[key] = key === "parse"
+          ? resolveParse(source[key])
+          : wrap(source[key]);
+      }
+    }
+    if (final && "~deriveEntries" in source) {
+      if (!Array.isArray(source["~deriveEntries"])) throw unsupported();
+      copy["~deriveEntries"] = source["~deriveEntries"].map((entry) =>
+        Array.isArray(entry) ? [wrap(entry[0]), ...entry.slice(1)] : wrap(entry)
+      );
+    }
+    // Run after the route's own macro options have expanded. Reinsert last
+    // under reentrant use/group calls to retain native expansion order.
+    delete copy[macroName];
+    if (!final) copy[macroName] = true;
+    return copy;
+  };
+  if (typeof plugin.macro !== "function") throw unsupported();
+  plugin.macro({
+    [macroName]: {
+      introspect(resolved: Fields): void {
+        // Native macro expansion is deferred until composition. Only copied
+        // local hooks carry this private option; children and unrelated parent
+        // routes stay untouched. Elysia removes the option after introspection.
+        Object.assign(resolved, hooks(resolved, true));
+      },
+    },
+  });
+  // Own links are compiler stop points: preserve even earlier snapshots.
+  const protectedNodes = new WeakSet<object>();
+  const protect = (value: unknown): void => {
+    if (value == null) return;
+    if (typeof value !== "object") throw unsupported();
+    if (protectedNodes.has(value)) return;
+    protectedNodes.add(value);
+    const node = value as Fields;
+    protect(node.parent);
+    protect(node.over);
+    // combine contains imported child links; these must still be wrapped.
+  };
+  const chain = (
+    value: unknown,
+    memo = new WeakMap<object, Fields>(),
+    final = false,
+  ): unknown => {
+    if (value == null) return value;
+    if (typeof value !== "object") throw unsupported();
+    if (protectedNodes.has(value)) return value;
+    const node = value as Fields;
+    const existing = memo.get(value);
+    if (existing != null) return existing;
+    const copy = { ...node };
+    memo.set(value, copy);
+    if ("combine" in node) {
+      copy.combine = chain(node.combine, memo, final);
+      // Nested imported chains can have child hooks on either branch.
+      // protectedNodes preserves actual logger stop points by identity.
+      copy.over = chain(node.over, memo, final);
+    } else {
+      if (!("added" in node)) throw unsupported();
+      // Preserve propagated callback identities for native deduplication,
+      // but still visit local ancestors below the propagated link.
+      copy.added = node.propagated === true
+        ? node.added
+        : hooks(node.added, final);
+      copy.parent = chain(node.parent, memo, final);
+    }
+    if ((node.owner as Fields | undefined)?.["~scopeChild"] === true) {
+      copy.owner = owner(node.owner);
+    }
+    return copy;
+  };
+  const owners = new WeakMap<object, object>();
+  const projections = new WeakSet<object>();
+  const owner = (source: unknown): unknown => {
+    if (source === instance) return source;
+    if (!(source instanceof elysia.Elysia)) throw unsupported();
+    if (projections.has(source)) return source;
+    const cached = owners.get(source);
+    if (cached != null) return cached;
+    // Error compilation reads the owner's live chain, not only route[5].
+    // Both views share callback identities so native includes() dedupes them.
+    const nativeApplyMacro = plugin["~applyMacro"];
+    if (typeof nativeApplyMacro !== "function") throw unsupported();
+    const scopeViews = new WeakMap<object, object>();
+    const scopeView = (target: object): object => {
+      const cached = scopeViews.get(target);
+      if (cached != null) return cached;
+      const view = new Proxy(target, {
+        get(target, key) {
+          const value = Reflect.get(target, key, target);
+          if (key === "~hookChain") return chain(value, new WeakMap(), true);
+          if ((source as unknown as Fields)["~scopeChild"] !== true) {
+            return value;
+          }
+          if (key === "~generation" && value != null) return scopeView(value);
+          if (key === "~ext" && value?.macro != null) {
+            // A group resolves its scope's macros before the root's macros.
+            // Hide only our terminal macro in that first phase, retaining the
+            // option until the final root expansion. User macros stay native.
+            return {
+              ...value,
+              macro: new Proxy(value.macro, {
+                has: (table, name) =>
+                  name !== macroName && Reflect.has(table, name),
+              }),
+            };
+          }
+          if (key === "~applyMacro") {
+            return (...args: unknown[]) => nativeApplyMacro.apply(view, args);
+          }
+          return value;
+        },
+      });
+      scopeViews.set(target, view);
+      return view;
+    };
+    const projection = scopeView(source);
+    owners.set(source, projection);
+    projections.add(projection);
+    return projection;
+  };
+  const rows = (): unknown[][] => {
+    const value = plugin.declaredRoutes;
+    if (value === undefined) return [];
+    if (!Array.isArray(value)) throw unsupported();
+    return value;
+  };
+  for (const name of routeMethods) {
+    const original = plugin[name];
+    if (typeof original !== "function") throw unsupported();
+    plugin[name] = function (this: unknown, ...args: unknown[]): unknown {
+      protect(plugin["~hookChain"]);
+      const start = rows().length;
+      const result = original.apply(this, args);
+      const routes = rows();
+      for (let i = start; i < routes.length; i++) {
+        const source = routes[i];
+        if (!Array.isArray(source) || source.length < 4) throw unsupported();
+        if (
+          source[0] === "WS" ||
+          (source[2] != null && (source[2] as Fields)["~mount"])
+        ) continue;
+        const copy = source.slice();
+        copy[2] = wrap(source[2]);
+        copy[3] = owner(source[3]);
+        copy[4] = hooks(source[4]);
+        copy[5] = chain(source[5]);
+        copy[6] = chain(source[6]);
+        if ((source[7] as Fields | undefined)?.["~scopeChild"] === true) {
+          copy[7] = owner(source[7]);
+        }
+        routes[i] = copy;
+      }
+      return result;
+    };
+  }
+  // Install only after internal logging hooks, which must not be rewrapped.
+  return () => {
+    protect(plugin["~hookChain"]);
+    for (const name of [...hookKeys, "guard"]) {
+      const original = plugin[name];
+      if (typeof original !== "function") throw unsupported();
+      plugin[name] = function (this: unknown, ...args: unknown[]): unknown {
+        const mapped = args.slice();
+        if (name === "guard") {
+          // Callback-form guard creates a child; the route wrapper handles it.
+          if (typeof args.at(-1) !== "function") {
+            const index = typeof args[0] === "string" ? 1 : 0;
+            const hook = hooks(args[index]) as Fields;
+            // Native error collection also reads the owner's raw guard chain.
+            // Keep that callback identical to the expanded error callback.
+            if (hook.error != null) hook.error = wrap(hook.error);
+            mapped[index] = hook;
+          }
+        } else if (name === "parse") {
+          const index = args.length > 1 && typeof args[0] === "string" ? 1 : 0;
+          mapped[index] = resolveParse(args[index]);
+        } else if (name === "error") {
+          // Error dictionaries contain constructors, not lifecycle callbacks.
+          if (args.length === 1 && typeof args[0] === "object") {
+            return original.apply(this, args);
+          }
+          const index = args.length - 1;
+          mapped[index] = wrap(args[index]);
+        } else {
+          const index = typeof args[0] === "string" ? 1 : 0;
+          mapped[index] = wrap(args[index]);
+        }
+        const result = original.apply(this, mapped);
+        protect(plugin["~hookChain"]);
+        return result;
+      };
+    }
+  };
+}

--- a/packages/elysia/src/mod.ts
+++ b/packages/elysia/src/mod.ts
@@ -1,6 +1,13 @@
 import { Elysia } from "elysia";
 import { getLogger, type LogLevel, withContext } from "@logtape/logtape";
 
+import {
+  createCompatibility,
+  materializeHeaders,
+  nativeErrorCode,
+  wrapV2LocalContext,
+} from "./compat.ts";
+
 export type { LogLevel } from "@logtape/logtape";
 
 type ElysiaRequestHeaders = Request extends {
@@ -1149,6 +1156,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     set: ElysiaContext["set"],
     requestContext: ElysiaRequestContextState | undefined,
   ): void => {
+    materializeHeaders(set);
     if (requestContext?.responseHeader != null) {
       set.headers[requestContext.responseHeader.name] =
         requestContext.responseHeader.value;
@@ -1171,17 +1179,32 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   };
 
   // deno-lint-ignore no-explicit-any
-  let plugin: Elysia<any, any, any, any, any, any, any> = new Elysia({
+  let plugin: Elysia<any> = new Elysia({
     name: "@logtape/elysia",
     seed: options,
   });
 
+  const compatibility = createCompatibility(plugin);
+  let finishLocalSetup: (() => void) | undefined;
+
   if (shouldWrapContext && scope === "local") {
-    wrapLocalRouteHandlers(
-      plugin as unknown as ElysiaRoutePlugin,
-      buildAndStoreRequestContext,
-      applyRequestContextToSet,
-    );
+    if (compatibility.v2) {
+      const wrappers = createElysiaRequestWrappers(
+        buildAndStoreRequestContext,
+        applyRequestContextToSet,
+      );
+      finishLocalSetup = wrapV2LocalContext(
+        plugin,
+        wrappers.wrapRequestCallback,
+        `@logtape/elysia/context/${generateRequestId()}`,
+      );
+    } else {
+      wrapLocalRouteHandlers(
+        plugin as unknown as ElysiaRoutePlugin,
+        buildAndStoreRequestContext,
+        applyRequestContextToSet,
+      );
+    }
   } else if (shouldWrapContext) {
     // Elysia lifecycle hooks cannot wrap downstream handlers, so use wrap()
     // to keep AsyncLocalStorage active for the whole route execution.
@@ -1196,25 +1219,24 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     });
   }
 
-  plugin = plugin
-    .state("startTime", 0)
-    .onRequest(({ request, set, store }) => {
-      const requestContext = requestContextStates.get(request);
-      if (requestContext == null && shouldWrapAllRoutes) {
-        (store as LoggerStore).startTime = performance.now();
-        return buildAndStoreRequestContext(request).then((resolvedContext) => {
-          applyRequestContextToRequest(
-            store as LoggerStore,
-            set,
-            resolvedContext,
-          );
-        });
-      }
-      applyRequestContextToRequest(store as LoggerStore, set, requestContext);
-    });
+  plugin.state("startTime", 0);
+  compatibility.register("Request", ({ request, set, store }) => {
+    const requestContext = requestContextStates.get(request);
+    if (requestContext == null && shouldWrapAllRoutes) {
+      (store as LoggerStore).startTime = performance.now();
+      return buildAndStoreRequestContext(request).then((resolvedContext) => {
+        applyRequestContextToRequest(
+          store as LoggerStore,
+          set,
+          resolvedContext,
+        );
+      });
+    }
+    applyRequestContextToRequest(store as LoggerStore, set, requestContext);
+  });
 
   if (scope === "local" && (contextOptions != null || logRequest)) {
-    plugin = plugin.onBeforeHandle(async (ctx) => {
+    compatibility.register("BeforeHandle", async (ctx) => {
       (ctx.store as LoggerStore).startTime = performance.now();
       const requestContext = await buildAndStoreRequestContext(ctx.request);
       (ctx.store as LoggerStore).startTime = requestContext?.startTime ??
@@ -1238,7 +1260,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   if (logRequest) {
     // Log immediately when request arrives
     if (scope !== "local") {
-      plugin = plugin.onRequest((ctx) => {
+      compatibility.register("Request", (ctx) => {
         if (!skip(ctx as unknown as ElysiaContext)) {
           const requestContext =
             requestContextStates.get(ctx.request)?.context ??
@@ -1257,7 +1279,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     }
   } else {
     // Log after handler completes
-    plugin = plugin.onAfterHandle((ctx) => {
+    compatibility.register("AfterHandle", (ctx) => {
       if (skip(ctx as unknown as ElysiaContext)) return;
 
       const store = ctx.store as LoggerStore;
@@ -1278,7 +1300,7 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
   }
 
   // Add error logging
-  plugin = plugin.onError((ctx) => {
+  compatibility.register("Error", (ctx) => {
     const store = ctx.store as LoggerStore;
     const responseTime = performance.now() - store.startTime;
     const elysiaCtx = ctx as unknown as ElysiaContext;
@@ -1288,7 +1310,10 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
     const props = buildProperties(elysiaCtx, responseTime);
     const requestContext = requestContextStates.get(ctx.request)?.context ?? {};
     // Get the correct HTTP status code from error context
-    const status = getErrorStatus(ctx.code, ctx.error, elysiaCtx.set.status);
+    const status = compatibility.v2
+      ? elysiaCtx.set.status
+      : getErrorStatus(ctx.code ?? "UNKNOWN", ctx.error, elysiaCtx.set.status);
+    const errorCode = compatibility.v2 ? nativeErrorCode(ctx.error) : ctx.code;
     // Extract error message safely
     const error = ctx.error as { message?: string } | undefined;
     const errorMessage = error?.message ?? "Unknown error";
@@ -1299,27 +1324,24 @@ export function elysiaLogger(options: ElysiaLogTapeOptions = {}): Elysia<any> {
         ...requestContext,
         status,
         errorMessage,
-        errorCode: ctx.code,
+        ...(errorCode === undefined ? {} : { errorCode }),
       },
     );
   });
 
   if (shouldWrapContext && scope === "local") {
-    wrapLocalLifecycleHooks(
-      plugin as unknown as ElysiaRoutePlugin,
-      buildAndStoreRequestContext,
-      applyRequestContextToSet,
-    );
+    if (finishLocalSetup != null) finishLocalSetup();
+    else {
+      wrapLocalLifecycleHooks(
+        plugin as unknown as ElysiaRoutePlugin,
+        buildAndStoreRequestContext,
+        applyRequestContextToSet,
+      );
+    }
   }
 
-  // Apply scope
-  if (scope === "global") {
-    // deno-lint-ignore no-explicit-any
-    return plugin.as("global") as unknown as Elysia<any>;
-  } else if (scope === "scoped") {
-    // deno-lint-ignore no-explicit-any
-    return plugin.as("scoped") as unknown as Elysia<any>;
-  }
+  // Apply the native scope while keeping the public v1/v2 API identical.
+  if (scope !== "local") compatibility.as(scope);
 
   // deno-lint-ignore no-explicit-any
   return plugin as unknown as Elysia<any>;

--- a/packages/elysia/tsdown.config.ts
+++ b/packages/elysia/tsdown.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   format: ["esm", "cjs"],
   platform: "node",
   unbundle: true,
+  external: [/^elysia(?:\/|$)/],
 });

--- a/scripts/check_elysia_compatibility.ts
+++ b/scripts/check_elysia_compatibility.ts
@@ -1,0 +1,270 @@
+/** Test built npm artifacts and JSR-shaped source in isolated consumers. */
+import assert from "node:assert/strict";
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const fixtures = join(root, "scripts/fixtures/elysia");
+const versions = ["1.4.0", "1.4.30", "2.0.0-beta.12"];
+const work = await mkdtemp(join(tmpdir(), "logtape-elysia-"));
+
+async function run(command: string, args: string[], cwd = root): Promise<void> {
+  console.log(`\n${command} ${args.join(" ")} (${cwd})`);
+  const status = await new Deno.Command(command, {
+    args,
+    cwd,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { npm_config_ignore_scripts: "true" },
+  }).spawn().status;
+  if (!status.success) throw new Error(`${command} exited ${status.code}`);
+}
+
+/**
+ * Reuse every baseline assertion; port only native registration syntax in the
+ * v2 fixture. Production compatibility helpers are never used by this port.
+ */
+function portV2(source: string): string {
+  source = source.replaceAll(
+    '.onBeforeHandle({ as: "local" },',
+    '.beforeHandle("local",',
+  )
+    .replaceAll(".onBeforeHandle(", ".beforeHandle(")
+    .replaceAll(".onParse(", ".parse(");
+  const tree = ts.createSourceFile(
+    "fixture.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const result = ts.transform(tree, [(context) => {
+    const visit: ts.Visitor = (node) => {
+      if (
+        ts.isCallExpression(node) && node.expression.getText() === "test" &&
+        ts.isStringLiteral(node.arguments[0]) &&
+        node.arguments[0].text ===
+          "elysiaLogger(): local scope fallback matches optional routes"
+      ) {
+        // This test deliberately pokes v1-only internals. Use an empty body
+        // as well as skip for runtimes which ignore node:test skip options.
+        return ts.factory.updateCallExpression(
+          node,
+          node.expression,
+          node.typeArguments,
+          [
+            node.arguments[0],
+            ts.factory.createObjectLiteralExpression([
+              ts.factory.createPropertyAssignment(
+                "skip",
+                ts.factory.createTrue(),
+              ),
+            ]),
+            ts.factory.createArrowFunction(
+              undefined,
+              undefined,
+              [],
+              undefined,
+              ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+              ts.factory.createBlock([]),
+            ),
+          ],
+        );
+      }
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ["get", "post", "all"].includes(node.expression.name.text) &&
+        node.arguments.length === 3
+      ) {
+        return ts.factory.updateCallExpression(
+          node,
+          node.expression,
+          node.typeArguments,
+          [node.arguments[0], node.arguments[2], node.arguments[1]].map((arg) =>
+            ts.visitNode(arg, visit) as ts.Expression
+          ),
+        );
+      }
+      return ts.visitEachChild(node, visit, context);
+    };
+    return (node) => ts.visitNode(node, visit) as ts.SourceFile;
+  }]);
+  const printed = ts.createPrinter().printFile(result.transformed[0]);
+  result.dispose();
+  return printed;
+}
+
+function javascript(source: string, commonjs: boolean): string {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: commonjs ? ts.ModuleKind.CommonJS : ts.ModuleKind.ESNext,
+      esModuleInterop: true,
+    },
+  }).outputText;
+}
+
+try {
+  // Build declarations once against the default v1 dev dependency.
+  await run("pnpm", [
+    "--filter",
+    "@logtape/logtape",
+    "--filter",
+    "@logtape/elysia",
+    "build",
+  ]);
+  for (const name of ["logtape", "elysia"]) {
+    await run(
+      "pnpm",
+      ["pack", "--out", join(work, `${name}.tgz`)],
+      join(root, "packages", name),
+    );
+  }
+  const baseline =
+    (await readFile(join(root, "packages/elysia/src/mod.test.ts"), "utf8"))
+      .replace('from "./mod.ts"', 'from "@logtape/elysia"');
+  const types = await readFile(join(fixtures, "types.ts.txt"), "utf8");
+  const v2Tests = await readFile(join(fixtures, "v2.ts.txt"), "utf8");
+  for (const version of versions) {
+    const v2 = version.startsWith("2.");
+    const consumer = join(work, version);
+    await mkdir(consumer);
+    await writeFile(
+      join(consumer, "package.json"),
+      JSON.stringify(
+        {
+          private: true,
+          type: "module",
+          dependencies: {
+            "@logtape/logtape": `file:${join(work, "logtape.tgz")}`,
+            "@logtape/elysia": `file:${join(work, "elysia.tgz")}`,
+            elysia: version,
+            typescript: "5.8.3",
+            "@types/bun": v2 ? "1.4.1" : "1.2.16",
+            "@types/node": "22.15.30",
+            ...(v2
+              ? {
+                typebox: "1.3.27",
+                "exact-mirror": "1.2.4",
+                "openapi-types": "12.1.3",
+              }
+              : { memoirist: "0.4.0" }),
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await run(
+      "npm",
+      ["install", "--ignore-scripts", "--no-audit", "--no-fund"],
+      consumer,
+    );
+    const installed = join(consumer, "node_modules/@logtape/elysia");
+    const metadata = JSON.parse(
+      await readFile(join(installed, "package.json"), "utf8"),
+    );
+    assert.equal(metadata.peerDependencies.elysia, "^1.4.0 || ^2.0.0-beta.12");
+    assert.equal(
+      metadata.peerDependencies["@logtape/logtape"].includes("workspace:"),
+      false,
+    );
+    for (const extension of ["js", "cjs"]) {
+      const output = await readFile(
+        join(installed, `dist/compat.${extension}`),
+        "utf8",
+      );
+      assert.match(
+        output,
+        extension === "js"
+          ? /from "elysia\/utils"/
+          : /require\("elysia\/utils"\)/,
+      );
+      assert.doesNotMatch(
+        output,
+        /fnOrigin\s*=\s*(?:\/\*.*?\*\/\s*)?new WeakMap/,
+      );
+    }
+    const suite = v2 ? portV2(baseline) : baseline;
+    const typing = v2 ? portV2(types) : types;
+    for (const commonjs of [false, true]) {
+      const extension = commonjs ? "cjs" : "mjs";
+      const files = [`baseline.test.${extension}`];
+      await writeFile(join(consumer, files[0]), javascript(suite, commonjs));
+      if (v2) {
+        files.push(`v2.test.${extension}`);
+        await writeFile(
+          join(consumer, files[1]),
+          javascript(v2Tests, commonjs),
+        );
+      }
+      await writeFile(
+        join(consumer, `types.${commonjs ? "cts" : "mts"}`),
+        typing,
+      );
+      await run("node", ["--test", "--test-force-exit", ...files], consumer);
+      const bunEntry = `load-${extension}.test.js`;
+      await writeFile(
+        join(consumer, bunEntry),
+        files.map((file) => `import "./${file}";`).join("\n"),
+      );
+      await run("bun", ["test", `./${bunEntry}`], consumer);
+    }
+    await cp(
+      join(fixtures, "check-types.cjs"),
+      join(consumer, "check-types.cjs"),
+    );
+    await run("node", ["check-types.cjs"], consumer);
+
+    // Simulate JSR's rewriting of dependency specifiers, not just bare aliases.
+    const deno = join(work, `deno-${version}`);
+    await mkdir(deno);
+    await cp(join(root, "packages/logtape/src"), join(deno, "core"), {
+      recursive: true,
+    });
+    for (const file of ["mod.ts", "compat.ts"]) {
+      const source =
+        (await readFile(join(root, "packages/elysia/src", file), "utf8"))
+          .replaceAll('from "elysia"', 'from "npm:elysia@^1.4.0"')
+          .replaceAll('from "elysia/utils"', 'from "npm:elysia@^1.4.0/utils"');
+      await writeFile(join(deno, file), source);
+    }
+    await writeFile(
+      join(deno, "deno.json"),
+      JSON.stringify({
+        imports: {
+          "#util": "./core/util.deno.ts",
+          "@logtape/logtape": "./core/mod.ts",
+          "@logtape/elysia": "./mod.ts",
+          elysia: `npm:elysia@${version}`,
+          "elysia/websocket": `npm:elysia@${version}/websocket`,
+          "npm:elysia@^1.4.0": `npm:elysia@${version}`,
+          "npm:elysia@^1.4.0/utils": `npm:elysia@${version}/utils`,
+        },
+      }),
+    );
+    await writeFile(join(deno, "baseline.test.ts"), suite);
+    await writeFile(join(deno, "types.ts"), typing);
+    const tests = ["baseline.test.ts"];
+    if (v2) {
+      tests.push("v2.test.ts");
+      await writeFile(join(deno, "v2.test.ts"), v2Tests);
+    }
+    await run("deno", ["check", "mod.ts", "types.ts", ...tests], deno);
+    await run("deno", [
+      "test",
+      "--allow-env",
+      "--allow-net",
+      "--allow-sys",
+      ...tests,
+    ], deno);
+  }
+  console.log("Elysia compatibility matrix passed.");
+  await rm(work, { recursive: true });
+} catch (error) {
+  console.error(`Compatibility fixtures retained at ${work}`);
+  throw error;
+}

--- a/scripts/fixtures/elysia/README.md
+++ b/scripts/fixtures/elysia/README.md
@@ -1,0 +1,28 @@
+Elysia compatibility fixtures
+=============================
+
+Run `mise run test:elysia-compatibility` after `pnpm install`.
+The runner builds the core and adapter once, packs them with pnpm, and installs
+those tarballs into temporary consumers for each pinned Elysia version.  It
+checks Node.js and Bun with both ESM and CommonJS exports, and Deno with the
+npm specifiers used by JSR source publication.
+
+The *.ts.txt* files are TypeScript templates checked inside those consumers.
+They are outside the workspace dependency graph so that the default Elysia 1
+development dependency cannot hide Elysia 2 typing failures.  The existing
+adapter test suite supplies the shared assertions.  For Elysia 2, the runner
+ports native hook names and route argument order, and skips only the test
+which deliberately replaces Elysia 1's private router lookup.
+
+*check-types.cjs* checks declarations without `skipLibCheck`.  Some Elysia
+versions have declaration errors even in a consumer that imports only Elysia.
+The checker compares against that native consumer and permits only identical
+diagnostics in external dependencies.  Any adapter or fixture diagnostic, or
+new dependency diagnostic, fails the check.  It prints the unchanged upstream
+diagnostic count so that a baseline with errors is visible.
+
+When changing the pinned beta, update the peer range and Deno documentation
+examples together.  Keep the main Elysia and `elysia/utils` resolution on the
+same package copy and module format: local hook deduplication depends on their
+shared function-origin map.  The native identity probe and packed-artifact
+checks detect accidental bundling of that map.

--- a/scripts/fixtures/elysia/check-types.cjs
+++ b/scripts/fixtures/elysia/check-types.cjs
@@ -1,0 +1,53 @@
+// Compare dependency diagnostics with a native Elysia-only consumer. Do not
+// skip declaration checking: adapter/fixture diagnostics always fail, as do
+// dependency errors which only appear when the adapter is imported.
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const ts = require("typescript");
+const options = {
+  noEmit: true,
+  strict: true,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  target: ts.ScriptTarget.ES2022,
+  types: ["bun"],
+};
+function diagnostics(files) {
+  return ts.getPreEmitDiagnostics(ts.createProgram(files, options));
+}
+function key(diagnostic) {
+  return JSON.stringify([
+    diagnostic.file?.fileName,
+    diagnostic.start,
+    diagnostic.code,
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+  ]);
+}
+fs.writeFileSync(
+  "native.mts",
+  'import { Elysia } from "elysia"; new Elysia();\n',
+);
+fs.writeFileSync(
+  "native.cts",
+  'import { Elysia } from "elysia"; new Elysia();\n',
+);
+const native = new Set(diagnostics(["native.mts", "native.cts"]).map(key));
+const actual = diagnostics(["types.mts", "types.cts"]);
+const unexpected = actual.filter((diagnostic) => {
+  const file = diagnostic.file?.fileName ?? "";
+  const dependency = file.includes(`${path.sep}node_modules${path.sep}`) &&
+    !file.includes(`${path.sep}@logtape${path.sep}`);
+  return !dependency || !native.has(key(diagnostic));
+});
+if (unexpected.length) {
+  console.error(ts.formatDiagnosticsWithColorAndContext(unexpected, {
+    getCanonicalFileName: (file) => file,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  }));
+}
+assert.equal(unexpected.length, 0, "New consumer/declaration type errors");
+console.log(
+  `Consumer types passed; ${actual.length} unchanged upstream diagnostics.`,
+);

--- a/scripts/fixtures/elysia/module-identity.mjs
+++ b/scripts/fixtures/elysia/module-identity.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { Elysia } from "elysia";
+import { elysiaLogger } from "@logtape/elysia";
+
+const require = createRequire(import.meta.url);
+const { Elysia: CommonJsElysia } = require("elysia");
+assert.notEqual(Elysia, CommonJsElysia);
+assert.throws(
+  () =>
+    elysiaLogger({ scope: "local", context: true })
+      .use(new CommonJsElysia().get("/", () => "wrong module graph")),
+  /same Elysia copy and module format/,
+);

--- a/scripts/fixtures/elysia/types.ts.txt
+++ b/scripts/fixtures/elysia/types.ts.txt
@@ -1,0 +1,37 @@
+import { Elysia, t } from "elysia";
+import {
+  type ElysiaContext,
+  elysiaLogger,
+  type ElysiaLogTapeOptions,
+} from "@logtape/elysia";
+
+const options: ElysiaLogTapeOptions = {
+  scope: "scoped",
+  context: true,
+  format(ctx: ElysiaContext) {
+    const status: number = ctx.set.status;
+    return { status };
+  },
+};
+new Elysia().use(elysiaLogger(options)).get("/users/:id", ({ params }) => {
+  const id: string = params.id;
+  // @ts-expect-error Route parameters remain strings.
+  const invalid: number = params.id;
+  return id;
+});
+elysiaLogger({ scope: "local" }).get("/local/:id", ({ params }) => {
+  const id: string = params.id;
+  // @ts-expect-error Plugin chaining preserves parameter inference.
+  const invalid: number = params.id;
+  return id;
+});
+new Elysia().use(elysiaLogger()).post("/body", ({ body }) => {
+  const name: string = body.name;
+  // @ts-expect-error Schema properties are not numbers.
+  const invalid: number = body.name;
+  return name;
+}, { body: t.Object({ name: t.String() }) });
+// @ts-expect-error No new version-dependent scope option is exposed.
+elysiaLogger({ scope: "plugin" });
+// @ts-expect-error Invalid log levels are rejected.
+elysiaLogger({ level: "verbose" });

--- a/scripts/fixtures/elysia/v2.ts.txt
+++ b/scripts/fixtures/elysia/v2.ts.txt
@@ -1,0 +1,752 @@
+import assert from "node:assert/strict";
+import { AsyncLocalStorage } from "node:async_hooks";
+import test from "node:test";
+import { configure, getLogger, type LogRecord, reset } from "@logtape/logtape";
+import { Elysia, status, t } from "elysia";
+import { websocket } from "elysia/websocket";
+import { elysiaLogger } from "@logtape/elysia";
+
+async function capture() {
+  const logs: LogRecord[] = [];
+  await configure({
+    sinks: {
+      test: (record) => {
+        if (record.category[0] !== "logtape") logs.push(record);
+      },
+    },
+    loggers: [{ category: [], sinks: ["test"] }],
+    contextLocalStorage: new AsyncLocalStorage(),
+  });
+  return logs;
+}
+const note = (name: string) => getLogger("application").info(name);
+const request = (path: string, id = "request-id") =>
+  new Request(`http://localhost${path}`, {
+    headers: { "x-request-id": id },
+  });
+
+for (
+  const [name, handler, expected] of [
+    ["default", () => "ok", 200],
+    ["status", () => status(201, "created"), 201],
+    ["response", () => new Response("accepted", { status: 202 }), 202],
+    ["plain body", () => ({ status: 404, response: "body" }), 200],
+  ] as const
+) {
+  test(`v2 logs native ${name} status in format and skip`, async () => {
+    const logs = await capture();
+    try {
+      const statuses: number[] = [];
+      const app = new Elysia().use(elysiaLogger({
+        skip(ctx) {
+          statuses.push(ctx.set.status);
+          return false;
+        },
+        format(ctx) {
+          return { status: ctx.set.status };
+        },
+      })).get("/", handler);
+      assert.equal((await app.handle(request("/"))).status, expected);
+      assert.deepEqual(statuses, [expected]);
+      assert.equal(logs[0].properties.status, expected);
+    } finally {
+      await reset();
+    }
+  });
+}
+
+test("v2 returned native statuses override set, named statuses resolve", async () => {
+  const logs = await capture();
+  try {
+    const app = new Elysia().use(elysiaLogger())
+      .get("/status", ({ set }) => {
+        set.status = 203;
+        return status(201, "ok");
+      })
+      .get("/response", ({ set }) => {
+        set.status = 203;
+        return new Response("ok", { status: 202 });
+      })
+      .get("/named", ({ set }) => {
+        set.status = "Created";
+        return "ok";
+      });
+    for (
+      const [path, expected] of [["/status", 201], ["/response", 202], [
+        "/named",
+        201,
+      ]] as const
+    ) {
+      assert.equal((await app.handle(request(path))).status, expected);
+      assert.equal(logs.at(-1)?.properties.status, expected);
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 errors retain native codes and do not replace responses", async () => {
+  const logs = await capture();
+  try {
+    const app = new Elysia().use(elysiaLogger())
+      .get("/unknown", () => {
+        throw Error("failure");
+      })
+      .get("/code", () => {
+        throw Object.assign(Error("custom"), { code: 42 });
+      })
+      .get("/status", () => {
+        throw status(409, "conflict");
+      })
+      .post(
+        "/body",
+        { body: t.Object({ name: t.String() }) },
+        ({ body }) => body,
+      );
+    for (
+      const [path, expected, code] of [
+        ["/missing", 404, "not-found"],
+        ["/unknown", 500, undefined],
+        ["/code", 500, 42],
+        ["/status", 409, undefined],
+      ] as const
+    ) {
+      const response = await app.handle(request(path));
+      assert.equal(response.status, expected);
+      const log = logs.at(-1)!;
+      assert.equal(log.level, "error");
+      assert.equal(log.properties.status, expected);
+      assert.equal(log.properties.errorCode, code);
+      if (code === undefined) {
+        assert.equal("errorCode" in log.properties, false);
+      }
+      assert.ok(await response.text());
+    }
+    for (const [body, expected] of [["{}", 422], ["{", 400]] as const) {
+      const response = await app.handle(
+        new Request("http://localhost/body", {
+          method: "POST",
+          body,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      assert.equal(response.status, expected);
+      assert.equal(logs.at(-1)?.properties.status, expected);
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 normalized headers write through and request headers never leak", async () => {
+  const logs = await capture();
+  try {
+    const app = new Elysia().headers({ "x-default": "kept" })
+      .use(elysiaLogger({
+        context: true,
+        skip(ctx) {
+          ctx.set.headers = { ...ctx.set.headers, "x-callback": "yes" };
+          return false;
+        },
+      })).get("/", () => "ok");
+    for (const id of ["first", "second"]) {
+      const response = await app.handle(request("/", id));
+      assert.equal(response.headers.get("x-request-id"), id);
+      assert.equal(response.headers.get("x-default"), "kept");
+      assert.equal(response.headers.get("x-callback"), "yes");
+      assert.equal(logs.at(-1)?.properties.requestId, id);
+    }
+    const unrelated = new Elysia().get("/", () => "ok");
+    assert.equal(
+      (await unrelated.handle(request("/"))).headers.get("x-request-id"),
+      null,
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local child hooks, derives and late errors preserve context and reuse", async () => {
+  const logs = await capture();
+  try {
+    const child = new Elysia({ name: "child" })
+      .beforeHandle("global", () => {
+        note("child-global");
+      })
+      .derive(() => {
+        note("derive");
+        return { value: "derived" };
+      })
+      .mapDerive(({ value }) => ({ value: `${value}!` }))
+      .get("/ok", ({ value }) => value)
+      .get("/error", () => {
+        throw Error("failure");
+      });
+    const plugin = elysiaLogger({ scope: "local", context: true }).use(child);
+    child.error(() => {
+      note("child-error");
+    });
+    const app = new Elysia().use(child).group("/api", (app) => app.use(plugin));
+    assert.equal(
+      await (await app.handle(request("/api/ok"))).text(),
+      "derived!",
+    );
+    logs.length = 0;
+    assert.equal((await app.handle(request("/api/error"))).status, 500);
+    for (const name of ["child-global", "derive", "child-error"]) {
+      const selected = logs.filter((log) => log.message[0] === name);
+      assert.equal(selected.length, 1, name);
+      assert.equal(selected[0].properties.requestId, "request-id", name);
+    }
+    logs.length = 0;
+    await new Elysia().use(child).handle(request("/error"));
+    assert.equal(
+      logs.find((log) => log.message[0] === "child-error")?.properties
+        .requestId,
+      undefined,
+    );
+    logs.length = 0;
+    await plugin.handle(request("/error"));
+    assert.equal(
+      logs.filter((log) => log.message[0] === "child-error").length,
+      1,
+    );
+    assert.equal(
+      logs.find((log) => log.message[0] === "child-error")?.properties
+        .requestId,
+      "request-id",
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local native method, group, guard and deferred plugin composition", async () => {
+  const logs = await capture();
+  try {
+    const plugin = elysiaLogger({ scope: "local", context: true })
+      .derive(() => ({ value: "own" }))
+      .mapDerive(({ value }) => ({ value: `${value}!` }))
+      .guard({
+        beforeHandle() {
+          note("guard");
+        },
+      })
+      .method("GET", "/method", ({ value }) => {
+        note("method");
+        return value;
+      })
+      .group("/group", (app) =>
+        app.get("/route", () => {
+          note("group");
+          return "ok";
+        }))
+      .guard(
+        { query: t.Object({ q: t.String() }) },
+        (app) =>
+          app.get("/guard", ({ query }) => {
+            note("query");
+            return query.q;
+          }),
+      )
+      .use([new Elysia().get("/array", () => {
+        note("array");
+        return "ok";
+      })])
+      .use(Promise.resolve({
+        default: new Elysia().get("/deferred", () => {
+          note("deferred");
+          return "ok";
+        }),
+      }));
+    await plugin.modules;
+    const app = new Elysia().use(plugin).get("/outside", () => {
+      note("outside");
+      return "ok";
+    });
+    await app.modules;
+    for (
+      const [path, body] of [
+        ["/method", "own!"],
+        ["/group/route", "ok"],
+        ["/guard?q=query", "query"],
+        ["/array", "ok"],
+        ["/deferred", "ok"],
+      ]
+    ) {
+      logs.length = 0;
+      const response = await app.handle(request(path));
+      assert.equal(await response.text(), body, path);
+      const application = logs.filter((log) =>
+        log.category[0] === "application"
+      );
+      assert.ok(application.length > 0, path);
+      for (const log of application) {
+        assert.equal(log.properties.requestId, "request-id", path);
+      }
+    }
+    logs.length = 0;
+    await app.handle(request("/outside"));
+    assert.equal(
+      logs.find((log) => log.message[0] === "outside")?.properties.requestId,
+      undefined,
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local typed error handlers keep constructors and native matching", async () => {
+  const logs = await capture();
+  try {
+    class Problem extends Error {}
+    const plugin = elysiaLogger({ scope: "local", context: true })
+      .error("local", Problem, () => {
+        note("typed");
+        return "handled";
+      })
+      .get("/", () => {
+        throw new Problem("failure");
+      });
+    assert.equal(await (await plugin.handle(request("/"))).text(), "handled");
+    assert.equal(logs.filter((log) => log.message[0] === "typed").length, 1);
+    assert.equal(
+      logs.find((log) => log.message[0] === "typed")?.properties.requestId,
+      "request-id",
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local asynchronous requests keep independent implicit context", async () => {
+  const logs = await capture();
+  try {
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered = 0;
+    const app = elysiaLogger({ scope: "local", context: true }).get(
+      "/:id",
+      async ({ params }) => {
+        if (++entered === 2) release();
+        await barrier;
+        note(params.id);
+        return "ok";
+      },
+    );
+    await Promise.all([
+      app.handle(request("/first", "first")),
+      app.handle(request("/second", "second")),
+    ]);
+    for (const id of ["first", "second"]) {
+      assert.equal(
+        logs.find((log) => log.message[0] === id)?.properties.requestId,
+        id,
+      );
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local mount placeholders and websocket registrations remain usable", async () => {
+  await capture();
+  try {
+    const app = elysiaLogger({ scope: "local", context: true })
+      .mount("/mounted", () => new Response("mounted"))
+      .use(websocket())
+      .ws("/ws", { message() {} })
+      .get("/", () => "ok");
+    assert.equal(
+      await (await app.handle(request("/mounted/"))).text(),
+      "mounted",
+    );
+    assert.equal(await (await app.handle(request("/"))).text(), "ok");
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local hooks on static responses receive context", async () => {
+  const logs = await capture();
+  try {
+    const app = elysiaLogger({ scope: "local", context: true })
+      .get("/", {
+        beforeHandle() {
+          note("static-hook");
+        },
+      }, "ok");
+    assert.equal(await (await app.handle(request("/"))).text(), "ok");
+    assert.equal(
+      logs.find((log) => log.message[0] === "static-hook")?.properties
+        .requestId,
+      "request-id",
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local context reaches hooks through nested imported chains", async () => {
+  const logs = await capture();
+  try {
+    const leaf = new Elysia().get("/", () => "ok");
+    const middle = new Elysia().beforeHandle(() => {
+      note("middle");
+    }).use(leaf);
+    const outer = new Elysia().beforeHandle(() => {
+      note("outer");
+    }).use(middle);
+    const app = elysiaLogger({ scope: "local", context: true }).use(outer);
+    assert.equal(await (await app.handle(request("/"))).text(), "ok");
+    for (const name of ["middle", "outer"]) {
+      const selected = logs.filter((log) => log.message[0] === name);
+      assert.equal(selected.length, 1);
+      assert.equal(selected[0].properties.requestId, "request-id", name);
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local hooks beneath propagated nodes receive context", async () => {
+  const logs = await capture();
+  try {
+    const global = new Elysia({ name: "global-hook" })
+      .beforeHandle("global", () => {
+        note("propagated");
+      });
+    const child = new Elysia().beforeHandle(() => {
+      note("child-local");
+    })
+      .use(global).get("/", () => "ok");
+    const app = new Elysia().use(global)
+      .use(elysiaLogger({ scope: "local", context: true }).use(child));
+    assert.equal(await (await app.handle(request("/"))).text(), "ok");
+    assert.equal(
+      logs.filter((log) => log.message[0] === "propagated").length,
+      1,
+    );
+    assert.equal(
+      logs.find((log) => log.message[0] === "child-local")?.properties
+        .requestId,
+      "request-id",
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local context reaches deferred child macro hooks without changing reuse", async () => {
+  const logs = await capture();
+  try {
+    const child = new Elysia().macro({
+      audited: {
+        beforeHandle() {
+          note("macro-hook");
+        },
+        derive() {
+          note("macro-derive");
+          return { value: "derived" };
+        },
+      },
+    }).get("/", { audited: true }, ({ value }) => value);
+    const app = new Elysia().use(
+      elysiaLogger({ scope: "local", context: true }).use(child),
+    );
+    assert.equal(await (await app.handle(request("/"))).text(), "derived");
+    for (const name of ["macro-hook", "macro-derive"]) {
+      assert.equal(
+        logs.find((log) => log.message[0] === name)?.properties.requestId,
+        "request-id",
+        name,
+      );
+    }
+    logs.length = 0;
+    await new Elysia().use(child).handle(request("/"));
+    for (const log of logs) assert.equal(log.properties.requestId, undefined);
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local context reaches grouped and guard macro hooks", async () => {
+  const logs = await capture();
+  try {
+    const app = elysiaLogger({ scope: "local", context: true })
+      .macro({
+        audited: (label: string) => ({
+          beforeHandle() {
+            note(label);
+          },
+        }),
+      })
+      .group(
+        "/group",
+        (app) => app.get("/", { audited: "group-macro" }, () => "ok"),
+      )
+      .guard({ audited: "guard-macro" }).get("/guard", () => "ok");
+    for (
+      const [path, name] of [["/group/", "group-macro"], [
+        "/guard",
+        "guard-macro",
+      ]]
+    ) {
+      assert.equal(await (await app.handle(request(path))).text(), "ok");
+      assert.equal(
+        logs.find((log) => log.message[0] === name)?.properties.requestId,
+        "request-id",
+        name,
+      );
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 macro and explicit hooks retain native callback deduplication", async () => {
+  const logs = await capture();
+  try {
+    const callback = () => {
+      note("shared-hook");
+    };
+    const app = elysiaLogger({ scope: "local", context: true })
+      .macro({ audited: { beforeHandle: callback } })
+      .get("/", { audited: true, beforeHandle: callback }, () => "ok");
+    await app.handle(request("/"));
+    const selected = logs.filter((log) => log.message[0] === "shared-hook");
+    assert.equal(selected.length, 1);
+    assert.equal(selected[0].properties.requestId, "request-id");
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local named parsers keep context and leave parent routes unchanged", async () => {
+  const logs = await capture();
+  try {
+    const parser = async ({ request }: { request: Request }) => {
+      note("named-parser");
+      return await request.text();
+    };
+    const plugin = elysiaLogger({ scope: "local", context: true })
+      .parser("audit", parser)
+      .post("/route", { parse: "audit" }, ({ body }) => body)
+      .parse("audit")
+      .post("/plugin", ({ body }) => body);
+    const app = new Elysia().use(plugin)
+      .post("/outside", { parse: "audit" }, ({ body }) => body);
+    for (const path of ["/route", "/plugin", "/outside"]) {
+      logs.length = 0;
+      const response = await app.handle(
+        new Request(`http://localhost${path}`, {
+          method: "POST",
+          body: "parsed",
+          headers: { "x-request-id": "request-id" },
+        }),
+      );
+      assert.equal(await response.text(), "parsed");
+      assert.equal(
+        logs.find((log) => log.message[0] === "named-parser")?.properties
+          .requestId,
+        path === "/outside" ? undefined : "request-id",
+        path,
+      );
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local group hooks include late parent macros", async () => {
+  const logs = await capture();
+  try {
+    const hook = { parentAudit: true, detail: { description: "Parent macro" } };
+    const plugin = elysiaLogger({ scope: "local", context: true })
+      .group(
+        "/group",
+        (app) => app.get("/", hook, () => "ok"),
+      );
+    const app = new Elysia().macro({
+      parentAudit: {
+        beforeHandle() {
+          note("parent-macro");
+        },
+      },
+    })
+      .use(plugin)
+      .get("/outside", { parentAudit: true }, () => "ok");
+    for (const path of ["/group/", "/outside"]) {
+      logs.length = 0;
+      assert.equal(await (await app.handle(request(path))).text(), "ok");
+      const selected = logs.filter((log) => log.message[0] === "parent-macro");
+      assert.equal(selected.length, 1);
+      assert.equal(
+        selected[0].properties.requestId,
+        path === "/outside" ? undefined : "request-id",
+      );
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 local guard error hooks run once in direct and reused loggers", async () => {
+  const logs = await capture();
+  try {
+    const onError = () => {
+      note("guard-error");
+    };
+    const plugin = elysiaLogger({ scope: "local", context: true })
+      .macro({ audited: { error: onError } })
+      .guard({ audited: true, error: onError })
+      .get("/", () => {
+        throw Error("failure");
+      });
+    for (
+      const app of [plugin, new Elysia().use(plugin), new Elysia().use(plugin)]
+    ) {
+      logs.length = 0;
+      assert.equal((await app.handle(request("/"))).status, 500);
+      const selected = logs.filter((log) => log.message[0] === "guard-error");
+      assert.equal(selected.length, 1);
+      assert.equal(selected[0].properties.requestId, "request-id");
+      assert.equal(
+        logs.filter((log) => log.category[0] === "elysia").length,
+        1,
+      );
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 typed void error handlers run once", async () => {
+  const logs = await capture();
+  try {
+    class Problem extends Error {}
+    const plugin = elysiaLogger({ scope: "local", context: true })
+      .error(Problem, () => {
+        note("typed-void");
+      })
+      .error("local", Problem, () => {
+        note("scoped-typed-void");
+      })
+      .get("/", () => {
+        throw new Problem("failure");
+      });
+    for (const app of [plugin, new Elysia().use(plugin)]) {
+      logs.length = 0;
+      await app.handle(request("/"));
+      for (const name of ["typed-void", "scoped-typed-void"]) {
+        const selected = logs.filter((log) => log.message[0] === name);
+        assert.equal(selected.length, 1, name);
+        assert.equal(selected[0].properties.requestId, "request-id");
+      }
+    }
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 direct local logger preserves native guard scope and hook order", async () => {
+  const logs = await capture();
+  try {
+    const app = elysiaLogger({ scope: "local", context: true })
+      .macro({
+        audited: {
+          beforeHandle() {
+            note("macro-order");
+          },
+        },
+      })
+      .get("/public", () => "public")
+      .guard({ audited: true })
+      .get("/private", {
+        beforeHandle() {
+          note("route-order");
+        },
+      }, () => "private");
+    await app.handle(request("/public"));
+    assert.equal(logs.some((log) => log.message[0] === "macro-order"), false);
+    logs.length = 0;
+    await app.handle(request("/private"));
+    assert.deepEqual(
+      logs.filter((log) => log.category[0] === "application").map((log) =>
+        log.message[0]
+      ),
+      ["macro-order", "route-order"],
+    );
+  } finally {
+    await reset();
+  }
+});
+
+test("v2 explicit repeated callbacks retain their native repetitions", async () => {
+  const logs = await capture();
+  try {
+    const callback = () => {
+      note("repeated");
+    };
+    const app = elysiaLogger({ scope: "local", context: true })
+      .get("/", { beforeHandle: [callback, callback] }, () => "ok");
+    await app.handle(request("/"));
+    assert.equal(logs.filter((log) => log.message[0] === "repeated").length, 2);
+  } finally {
+    await reset();
+  }
+});
+
+for (
+  const mode of ["before await", "returned plugin", "promise plugin"] as const
+) {
+  test(`v2 local context supports async registration: ${mode}`, async () => {
+    const logs = await capture();
+    try {
+      const logger = () =>
+        elysiaLogger({ scope: "local", context: true })
+          .get("/", async () => {
+            await Promise.resolve();
+            note("async-registered");
+            return "ok";
+          });
+      const app = new Elysia();
+      if (mode === "before await") {
+        app.use(async (app) => {
+          app.use(logger());
+          await Promise.resolve();
+          return app;
+        });
+      } else if (mode === "returned plugin") {
+        app.use(async () => {
+          await Promise.resolve();
+          return logger();
+        });
+      } else {
+        app.use(Promise.resolve(logger()));
+      }
+      await app.modules;
+      assert.equal(await (await app.handle(request("/"))).text(), "ok");
+      const selected = logs.filter((log) =>
+        log.message[0] === "async-registered"
+      );
+      assert.equal(selected.length, 1);
+      assert.equal(selected[0].properties.requestId, "request-id");
+    } finally {
+      await reset();
+    }
+  });
+}
+
+test("v2 retains native rejection of post-await parent macro registration", async () => {
+  const app = new Elysia().use(async (app) => {
+    await Promise.resolve();
+    return app.use(elysiaLogger({ scope: "local", context: true }));
+  });
+  await assert.rejects(app.modules, {
+    message:
+      /^Macro @logtape\/elysia\/context\/.+ can only run in sync plugin$/,
+  });
+});


### PR DESCRIPTION
A compatibility layer translates native hooks and response values so Elysia 1.4 and 2 beta can share the existing `elysiaLogger()` API in LogTape 2.4.

For local request context, the adapter copies Elysia 2 route metadata and wraps callbacks after macro expansion. This preserves request IDs in child hooks without mutating reusable plugins or changing native hook deduplication. The docs explain JSR dependency overrides and Elysia 2's restriction on registering macros after `await` in a plugin function.

The compatibility matrix tests packed ESM/CommonJS exports and JSR-shaped source on Node.js, Bun, and Deno against 1.4.0, 1.4.30, and 2.0.0-beta.12. Consumer type checks allow only dependency diagnostics also present without LogTape. The matrix, repository checks, and documentation build pass.