### PR TITLE
Add opt-in `no-unrendered-properties` lint rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,8 +51,15 @@ To be released.
     TypeScript type information to distinguish properties, callbacks, and
     `Error` overloads, with local inference as a fallback.  Deno Lint users can
     enable it through the `@logtape/lint/deno/strict` entry point.  [[#199]]
+ -  Added an opt-in `no-unrendered-properties` lint rule to
+    *@logtape/lint* for finding properties that are not referenced by a
+    message template and may be omitted by sinks that output only the
+    message.  The rule is excluded from the `recommended` preset and the
+    default Deno Lint plugin, and is included in
+    `@logtape/lint/deno/strict`.  [[#214]]
 
 [#199]: https://github.com/dahlia/logtape/issues/199
+[#214]: https://github.com/dahlia/logtape/pull/214
 
 
 Version 2.3.4

--- a/changes.d/lint/no-unrendered-properties.md
+++ b/changes.d/lint/no-unrendered-properties.md
@@ -1,0 +1,10 @@
+---
+links:
+  '#214': https://github.com/dahlia/logtape/pull/214
+---
+ -  Added an opt-in `no-unrendered-properties` lint rule to
+    *@logtape/lint* for finding properties that are not referenced by a
+    message template and may be omitted by sinks that output only the
+    message.  The rule is excluded from the `recommended` preset and the
+    default Deno Lint plugin, and is included in
+    `@logtape/lint/deno/strict`.  [[#214]]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -156,6 +156,10 @@ const LINT = {
     },
     { text: "prefer-lazy-evaluation", link: "/lint/prefer-lazy-evaluation" },
     { text: "no-unawaited-log", link: "/lint/no-unawaited-log" },
+    {
+      text: "no-unrendered-properties",
+      link: "/lint/no-unrendered-properties",
+    },
     { text: "require-meta-sink", link: "/lint/require-meta-sink" },
   ],
 };

--- a/docs/lint/index.md
+++ b/docs/lint/index.md
@@ -18,12 +18,14 @@ Available rules
 | [`no-message-interpolation`] | error            | no                |
 | [`prefer-lazy-evaluation`]   | warn             | yes               |
 | [`no-unawaited-log`]         | error            | yes (conditional) |
+| [`no-unrendered-properties`] | off              | no                |
 | [`require-meta-sink`]        | warn             | no                |
 
 [`no-dynamic-message`]: /lint/no-dynamic-message
 [`no-message-interpolation`]: /lint/no-message-interpolation
 [`prefer-lazy-evaluation`]: /lint/prefer-lazy-evaluation
 [`no-unawaited-log`]: /lint/no-unawaited-log
+[`no-unrendered-properties`]: /lint/no-unrendered-properties
 [`require-meta-sink`]: /lint/require-meta-sink
 
 
@@ -72,8 +74,8 @@ export default [
 ~~~~
 
 The preset activates the four rules with a default severity of `error` or
-`warn` (see the table above).  The `no-dynamic-message` rule remains off unless
-you enable it explicitly.
+`warn` (see the table above).  The `no-dynamic-message` and
+`no-unrendered-properties` rules remain off unless you enable them explicitly.
 
 For manual configuration, import the plugin and wire rules yourself:
 
@@ -85,6 +87,7 @@ export default [
     plugins: { "@logtape": logtape },
     rules: {
       "@logtape/no-dynamic-message": "warn",
+      "@logtape/no-unrendered-properties": "warn",
       "@logtape/no-message-interpolation": "error",
       "@logtape/prefer-lazy-evaluation": "warn",
       "@logtape/no-unawaited-log": "error",
@@ -109,6 +112,7 @@ with [Oxlint]'s ESLint-compatible plugin interface.  Add the plugin to your
   ],
   "rules": {
     "@logtape/no-dynamic-message": "warn",
+      "@logtape/no-unrendered-properties": "warn",
     "@logtape/no-message-interpolation": "error",
     "@logtape/prefer-lazy-evaluation": "warn",
     "@logtape/no-unawaited-log": "error",
@@ -125,7 +129,7 @@ Deno Lint configuration
 > The Deno Lint plugin API is experimental (unstable).  This plugin requires
 > Deno 2.2.0 or later with the `"unstable": ["lint"]` option in `deno.json`.
 
-Add the plugin to your `deno.json` and list the rules you want to enable:
+Add the strict plugin to your `deno.json` to enable all LogTape rules:
 
 ~~~~ json
 {
@@ -135,6 +139,7 @@ Add the plugin to your `deno.json` and list the rules you want to enable:
     "rules": {
       "include": [
         "logtape/no-dynamic-message",
+        "logtape/no-unrendered-properties",
         "logtape/no-message-interpolation",
         "logtape/prefer-lazy-evaluation",
         "logtape/no-unawaited-log",
@@ -145,8 +150,15 @@ Add the plugin to your `deno.json` and list the rules you want to enable:
 }
 ~~~~
 
-Use the `/deno/strict` entry point only when enabling opt-in rules such as
-`no-dynamic-message`.  The default `/deno` entry point contains the four
-recommended rules and leaves `no-dynamic-message` disabled.
+Use the `/deno/strict` entry point only when enabling opt-in rules.  It enables
+both `no-dynamic-message` and `no-unrendered-properties`.  The default `/deno`
+entry point contains only the four recommended rules.
+
+An `include` list does not disable other plugin rules.  To disable either
+opt-in rule while using `/deno/strict`, put its qualified name in
+`lint.rules.exclude`.  For example,
+`"exclude": ["logtape/no-unrendered-properties"]` keeps `no-dynamic-message`
+enabled without requiring properties in messages. Deno Lint reports violations
+as failures; the warning severities in the table apply to ESLint and Oxlint.
 
 Then run `deno lint` as usual.

--- a/docs/lint/no-dynamic-message.md
+++ b/docs/lint/no-dynamic-message.md
@@ -1,6 +1,8 @@
 `no-dynamic-message`
 ====================
 
+*This rule is introduced in LogTape 2.4.0.*
+
 Disallow dynamic expressions in LogTape log message arguments.
 
 | Severity | Fixable | Category             |
@@ -112,14 +114,13 @@ Deno Lint (`deno.json`):
   "lint": {
     "plugins": ["jsr:@logtape/lint/deno/strict"],
     "rules": {
-      "include": [
-        "logtape/no-dynamic-message",
-        "logtape/no-message-interpolation"
-      ]
+      "exclude": ["logtape/no-unrendered-properties"]
     }
   }
 }
 ~~~~
 
 The default `@logtape/lint/deno` entry point excludes this opt-in rule.  Use
-the `/deno/strict` entry point in its place when enabling the rule.
+the `/deno/strict` entry point in its place when enabling the rule.  This entry
+point also includes `no-unrendered-properties`; the example excludes that rule
+so properties can remain outside the message template.

--- a/docs/lint/no-unrendered-properties.md
+++ b/docs/lint/no-unrendered-properties.md
@@ -1,0 +1,156 @@
+`no-unrendered-properties`
+==========================
+
+*This rule is introduced in LogTape 2.4.0.*
+
+Find properties that are not referenced by a log message template.
+
+| Severity | Fixable | Category                   |
+| -------- | ------- | -------------------------- |
+| off      | no      | `no-unrendered-properties` |
+
+This rule is opt-in and is not part of the `recommended` preset.  Use `warn`
+when enabling it in ESLint or Oxlint.
+
+
+Rationale
+---------
+
+Some sinks and log bridges forward only the rendered message.  A property
+passed alongside that message can then disappear from the output:
+
+~~~~ typescript
+logger.error("{operation} failed", { operation, error });
+~~~~
+
+Here, `error` is available in the log record but is not part of the message.
+If the sink only writes the message, the error details may be lost.  Include
+what you need to read in the template:
+
+~~~~ typescript
+logger.error("{operation} failed: {error.message}", { operation, error });
+~~~~
+
+Unreferenced properties are valid structured logging data.  JSON Lines,
+logfmt, and other sinks or formatters can retain them separately from the
+message.  Leave this rule disabled if that matches your project's convention.
+The rule does not inspect your sink configuration or guarantee that a value
+will be printed usefully.
+
+This rule was inspired by [cmdr's `no-unrendered-log-fields` rule], which caught
+error details omitted by a frontend log bridge.
+
+[cmdr's `no-unrendered-log-fields` rule]: https://github.com/vdavid/cmdr/commit/8e24eb2a62362287d33c640c5a820d5bbc462d1d
+
+
+Examples
+--------
+
+With this rule enabled, these calls produce a diagnostic:
+
+~~~~ typescript
+logger.info("Started", { id });
+logger.error("{operation} failed", () => ({ operation, error }));
+logger.info("{{id}}", { id }); // Escaped braces do not reference id.
+~~~~
+
+These calls reference their properties:
+
+~~~~ typescript
+logger.info("Started {id}", { id });
+logger.error("{operation} failed: {error.message}", () => ({ operation, error }));
+logger.info("First item: {items[0].name}", { items });
+logger.info("User: {user?.name}", { user });
+logger.info("Details: {*}", { id, operation });
+~~~~
+
+`{*}` references the whole properties bag unless a property named `"*"`
+overrides it.  If a wildcard placeholder contains whitespace, a key matching
+that whitespace takes precedence over `"*"`.
+
+`{error.message}` counts as a reference to `error`; it does not mean that the
+whole error, including its stack or cause, appears in the message.  Choose the
+fields your output needs.  There is no automatic fix because adding a
+placeholder or removing a property requires that judgment.
+
+
+Analysis boundaries
+-------------------
+
+The rule checks static string literals and template literals without `${}`
+interpolation.  Properties must be an object literal or an expression-bodied
+arrow function returning one, including an async arrow.  TypeScript assertions
+and `satisfies` wrappers are supported.
+
+Static string and numeric keys are checked, including computed literal keys.
+An object containing a spread or an unknown key is skipped.  Variables,
+function calls, block-bodied callbacks, and general function expressions are
+not followed.  Dynamic messages, properties-only calls, Error overloads,
+first-argument callbacks, and tagged templates are outside this rule's scope.
+
+Only fields supplied at the call site are checked.  Fields inherited from
+`logger.with()` or implicit contexts need not appear in every message.  The
+rule uses the same logger recognition as the other LogTape rules, including
+import aliases and child loggers; custom logger factories are not tracked.
+
+The analysis favors avoiding false positives.  A direct key such as
+`"error.message"` and the nested root `error` both count as referenced when
+the template uses `{error.message}`.  The rule does not evaluate which lookup
+will succeed or validate the remainder of a nested path.  A `"*"` property
+hidden in a context can also override `{*}` without this rule detecting the
+resulting omission.
+
+
+Configuration
+-------------
+
+ESLint v9 flat config:
+
+~~~~ javascript
+import logtape from "@logtape/lint/eslint";
+
+export default [
+  logtape.configs.recommended,
+  {
+    rules: {
+      "logtape/no-unrendered-properties": "warn",
+    },
+  },
+];
+~~~~
+
+Oxlint (`.oxlintrc.json`):
+
+~~~~ json
+{
+  "jsPlugins": [
+    { "name": "logtape", "specifier": "@logtape/lint/eslint" }
+  ],
+  "rules": {
+    "logtape/no-unrendered-properties": "warn"
+  }
+}
+~~~~
+
+Deno Lint (`deno.json`), enabling this rule alongside the recommended rules:
+
+~~~~ json
+{
+  "lint": {
+    "plugins": ["jsr:@logtape/lint/deno/strict"],
+    "rules": {
+      "exclude": ["logtape/no-dynamic-message"]
+    }
+  }
+}
+~~~~
+
+The default `/deno` entry point omits this rule.  `/deno/strict` enables all
+LogTape rules, including both opt-in rules.  Remove the `exclude` setting to
+use both.  To keep only `no-dynamic-message` alongside the recommended rules,
+exclude `logtape/no-unrendered-properties` instead.  An `include` list does not
+disable other plugin rules.
+
+Deno Lint does not provide ESLint-style warning severity for this rule;
+violations make `deno lint` exit unsuccessfully.  Use the host linter's ignore
+directives for intentional exceptions.

--- a/packages/lint/README.md
+++ b/packages/lint/README.md
@@ -28,11 +28,13 @@ Rules
 | `no-message-interpolation` | error            | no                |
 | `prefer-lazy-evaluation`   | warn             | yes               |
 | `no-unawaited-log`         | error            | yes (conditional) |
+| `no-unrendered-properties` | off              | no                |
 | `require-meta-sink`        | warn             | no                |
 
 For Deno Lint, the default `@logtape/lint/deno` entry point contains the four
 recommended rules.  Use `@logtape/lint/deno/strict` instead when explicitly
-enabling `no-dynamic-message`.
+enabling `no-dynamic-message` or `no-unrendered-properties`.  The strict
+entry point enables both; use `lint.rules.exclude` to disable either one.
 
 
 Installation

--- a/packages/lint/src/core/ast.ts
+++ b/packages/lint/src/core/ast.ts
@@ -19,6 +19,8 @@
 // on `any` nodes by design.
 // deno-lint-ignore-file no-explicit-any
 
+import { getUnreferencedKeys } from "./message-template.ts";
+
 /**
  * Log method names that the LogTape lint rules check.
  */
@@ -118,6 +120,67 @@ export function unwrapTypeAssertion(node: any): any {
     node = node.expression;
   }
   return node;
+}
+
+/** A call-site property and the key node to report. */
+export interface UnrenderedProperty {
+  readonly key: string;
+  readonly node: any;
+}
+
+/**
+ * Find unreferenced fields in a static message and explicit properties object.
+ * Opaque arguments and objects with unknown keys are left to the caller.
+ */
+export function findUnrenderedProperties(
+  args: readonly any[],
+): readonly UnrenderedProperty[] {
+  const template = staticMessageText(unwrapTypeAssertion(args[0]));
+  if (template === null) return [];
+  let object = unwrapTypeAssertion(args[1]);
+  if (object?.type === "ArrowFunctionExpression") {
+    object = unwrapTypeAssertion(object.body);
+  }
+  if (object?.type !== "ObjectExpression") return [];
+  const properties = new Map<string, any>();
+  for (const property of object.properties) {
+    if (property.type !== "Property") return [];
+    const keyNode = unwrapTypeAssertion(property.key);
+    let key: string | null;
+    if (!property.computed && keyNode?.type === "Identifier") {
+      key = keyNode.name;
+    } else if (
+      keyNode?.type === "Literal" && typeof keyNode.value === "number"
+    ) {
+      key = String(keyNode.value);
+    } else {
+      key = staticMessageText(keyNode);
+    }
+    if (key === null) return [];
+    if (
+      key === "__proto__" && !property.computed && !property.shorthand &&
+      !property.method && property.kind === "init"
+    ) continue;
+    properties.set(key, property.key);
+  }
+  return getUnreferencedKeys(template, [...properties.keys()]).map((key) => ({
+    key,
+    node: properties.get(key),
+  }));
+}
+
+function staticMessageText(node: any): string | null {
+  if (node?.type === "Literal" && typeof node.value === "string") {
+    return node.value;
+  }
+  if (
+    node?.type === "TemplateLiteral" && node.expressions?.length === 0 &&
+    node.quasis?.length === 1
+  ) {
+    const cooked = node.quasis[0]?.value?.cooked ?? node.quasis[0]?.cooked;
+    return typeof cooked === "string" ? cooked : null;
+  }
+  return null;
 }
 
 /**

--- a/packages/lint/src/core/message-template.test.ts
+++ b/packages/lint/src/core/message-template.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getUnreferencedKeys } from "./message-template.ts";
+
+interface TemplateCase {
+  readonly name: string;
+  readonly template: string;
+  readonly keys: readonly string[];
+  readonly unused: readonly string[];
+}
+
+const cases: readonly TemplateCase[] = [
+  { name: "plain message", template: "Started", keys: ["id"], unused: ["id"] },
+  { name: "empty message", template: "", keys: ["id"], unused: ["id"] },
+  { name: "empty bag", template: "{missing}", keys: [], unused: [] },
+  {
+    name: "multiple references",
+    template: "{a} {b} {a}",
+    keys: ["a", "b", "c"],
+    unused: ["c"],
+  },
+  {
+    name: "duplicate keys",
+    template: "{a}",
+    keys: ["c", "a", "b", "c"],
+    unused: ["c", "b"],
+  },
+  { name: "escaped braces", template: "{{a}}", keys: ["a"], unused: ["a"] },
+  { name: "unterminated brace", template: "{a", keys: ["a"], unused: ["a"] },
+  {
+    name: "opening brace in key",
+    template: "{a{b}",
+    keys: ["a{b", "b"],
+    unused: ["b"],
+  },
+  {
+    name: "first closing brace",
+    template: "{ {name} }",
+    keys: [" {name", "name"],
+    unused: ["name"],
+  },
+  {
+    name: "escaped then opening brace",
+    template: "{{{name}",
+    keys: ["name"],
+    unused: [],
+  },
+  {
+    name: "escaped closing braces",
+    template: "}}{a}",
+    keys: ["a"],
+    unused: [],
+  },
+  {
+    name: "padded key ambiguity",
+    template: "{ a }",
+    keys: [" a ", "a", "b"],
+    unused: ["b"],
+  },
+  { name: "empty key", template: "{}", keys: ["", "a"], unused: ["a"] },
+  { name: "whole bag", template: "{*}", keys: ["a", "b"], unused: [] },
+  { name: "padded whole bag", template: "{ *\t}", keys: ["a"], unused: [] },
+  { name: "literal star", template: "{*}", keys: ["*", "a"], unused: ["a"] },
+  {
+    name: "padded literal star",
+    template: "{ * }",
+    keys: [" * ", "*", "a"],
+    unused: ["*", "a"],
+  },
+  {
+    name: "trimmed literal star",
+    template: "{ * }",
+    keys: ["*", "a"],
+    unused: ["a"],
+  },
+  {
+    name: "independent wildcards",
+    template: "{*} { * }",
+    keys: ["*", " * ", "a"],
+    unused: ["a"],
+  },
+  {
+    name: "padded key does not shadow unpadded wildcard",
+    template: "{*}",
+    keys: [" * ", "a"],
+    unused: [],
+  },
+  { name: "escaped wildcard", template: "{{*}}", keys: ["a"], unused: ["a"] },
+  {
+    name: "direct dotted and nested candidates",
+    template: "{error.message}",
+    keys: ["error.message", "error", "id"],
+    unused: ["id"],
+  },
+  {
+    name: "optional root",
+    template: "{error?.cause}",
+    keys: ["error"],
+    unused: [],
+  },
+  {
+    name: "initial optional access",
+    template: "{?.error.message}",
+    keys: ["error"],
+    unused: [],
+  },
+  {
+    name: "array below root",
+    template: "{items[0].name}",
+    keys: ["items"],
+    unused: [],
+  },
+  {
+    name: "quoted leading bracket",
+    template: '{["full-name"].length}',
+    keys: ["full-name"],
+    unused: [],
+  },
+  {
+    name: "single quoted leading bracket",
+    template: "{['user'].name}",
+    keys: ["user"],
+    unused: [],
+  },
+  {
+    name: "unquoted string bracket",
+    template: "{[user].name}",
+    keys: ["user"],
+    unused: [],
+  },
+  {
+    name: "untrimmed bracket root",
+    template: "{[ foo ].x}",
+    keys: [" foo ", "foo"],
+    unused: ["foo"],
+  },
+  {
+    name: "numeric-looking dot root",
+    template: "{0.name}",
+    keys: ["0"],
+    unused: [],
+  },
+  {
+    name: "numeric-looking quoted root",
+    template: '{["0"].name}',
+    keys: ["0"],
+    unused: [],
+  },
+  {
+    name: "numeric bracket root",
+    template: "{[0].name}",
+    keys: ["0"],
+    unused: ["0"],
+  },
+  {
+    name: "padded numeric bracket root",
+    template: "{[ 1 ].name}",
+    keys: ["1"],
+    unused: ["1"],
+  },
+  {
+    name: "question mark is not nested",
+    template: "{a?b}",
+    keys: ["a?b", "a"],
+    unused: ["a"],
+  },
+  { name: "trailing dot", template: "{a.}", keys: ["a.", "a"], unused: ["a"] },
+  {
+    name: "invalid first segment",
+    template: "{.a}",
+    keys: [".a", "a"],
+    unused: ["a"],
+  },
+  {
+    name: "unterminated quoted root",
+    template: '{["a}',
+    keys: ['["a', "a"],
+    unused: ["a"],
+  },
+  {
+    name: "blocked nested root",
+    template: "{constructor.name}",
+    keys: ["constructor.name", "constructor"],
+    unused: ["constructor"],
+  },
+  {
+    name: "blocked quoted root",
+    template: '{["__proto__"].x}',
+    keys: ["__proto__"],
+    unused: ["__proto__"],
+  },
+  {
+    name: "direct prototype keys",
+    template: "{__proto__} {prototype} {constructor}",
+    keys: ["__proto__", "prototype", "constructor"],
+    unused: [],
+  },
+  {
+    name: "escaped leading quote",
+    template: String.raw`{["quo\"te"].x}`,
+    keys: ['quo"te'],
+    unused: [],
+  },
+  {
+    name: "escaped leading apostrophe",
+    template: String.raw`{['quo\'te'].x}`,
+    keys: ["quo'te"],
+    unused: [],
+  },
+  {
+    name: "escaped control characters",
+    template: String.raw`{["\n\t\r\b\f\v\0\\"].x}`,
+    keys: ["\n\t\r\b\f\v\0\\"],
+    unused: [],
+  },
+  {
+    name: "unicode escape",
+    template: String.raw`{["\u0061"].x}`,
+    keys: ["a"],
+    unused: [],
+  },
+  {
+    name: "permissive unicode escape",
+    template: String.raw`{["\u006z"].x}`,
+    keys: ["\x06"],
+    unused: [],
+  },
+  {
+    name: "invalid unicode escape",
+    template: String.raw`{["\uzzzz"].x}`,
+    keys: ["uzzzz"],
+    unused: [],
+  },
+  {
+    name: "unknown escape",
+    template: String.raw`{["\q"].x}`,
+    keys: ["q"],
+    unused: [],
+  },
+];
+
+for (const { name, template, keys, unused } of cases) {
+  test(`getUnreferencedKeys(): ${name}`, () => {
+    assert.deepStrictEqual(getUnreferencedKeys(template, keys), unused);
+  });
+}

--- a/packages/lint/src/core/message-template.ts
+++ b/packages/lint/src/core/message-template.ts
@@ -1,0 +1,137 @@
+/**
+ * Host-independent analysis of the property names a message may reference.
+ * Keep the scan and first-segment parsing aligned with parseMessageTemplate()
+ * and parseNextSegment() in the core logger.  Values are never evaluated here.
+ * @module
+ */
+
+/**
+ * Find distinct property keys not referenced by a static message template.
+ * Ambiguous direct and nested lookups both count as references: whether the
+ * direct value is undefined cannot be determined from the property names.
+ */
+export function getUnreferencedKeys(
+  template: string,
+  keys: readonly string[],
+): readonly string[] {
+  const remaining = new Set(keys);
+  const supplied = new Set(keys);
+  for (let i = 0; i < template.length; i++) {
+    if (template[i] === "{") {
+      if (template[i + 1] === "{") {
+        i++;
+        continue;
+      }
+      const closeIndex = template.indexOf("}", i + 1);
+      if (closeIndex === -1) continue;
+      const key = template.slice(i + 1, closeIndex);
+      const trimmed = key.trim();
+      if (trimmed === "*") {
+        if (supplied.has(key)) remaining.delete(key);
+        else if (supplied.has("*")) remaining.delete("*");
+        else return [];
+      } else {
+        remaining.delete(key);
+        remaining.delete(trimmed);
+        const root = nestedRoot(trimmed);
+        if (root !== null) remaining.delete(root);
+      }
+      i = closeIndex;
+    } else if (template[i] === "}" && template[i + 1] === "}") {
+      i++;
+    }
+  }
+  return [...remaining];
+}
+
+function nestedRoot(path: string): string | null {
+  if (
+    !(path.includes(".") || path.includes("[") || path.includes("?.")) ||
+    path.length === 0 || path.endsWith(".")
+  ) return null;
+  const root = firstSegment(path, path.startsWith("?.") ? 2 : 0);
+  // Unquoted numeric bracket segments index arrays, not the properties bag.
+  // Dot and quoted-bracket segments stay strings, even for a name like "0".
+  if (
+    typeof root !== "string" || root === "__proto__" ||
+    root === "prototype" || root === "constructor"
+  ) return null;
+  return root;
+}
+
+/** Parse only the first segment, with the core logger's escape semantics. */
+function firstSegment(path: string, fromIndex: number): string | number | null {
+  const len = path.length;
+  let i = fromIndex;
+  if (i >= len) return null;
+  if (path[i] !== "[") {
+    const start = i;
+    while (
+      i < len && path[i] !== "." && path[i] !== "[" && path[i] !== "?" &&
+      path[i] !== "]"
+    ) i++;
+    return i === start ? null : path.slice(start, i);
+  }
+  i++;
+  if (i >= len) return null;
+  if (path[i] !== '"' && path[i] !== "'") {
+    const start = i;
+    while (
+      i < len && path[i] !== "]" && path[i] !== "'" && path[i] !== '"'
+    ) i++;
+    if (i >= len || i === start) return null;
+    const text = path.slice(start, i);
+    const number = Number(text);
+    return Number.isNaN(number) ? text : number;
+  }
+  const quote = path[i++];
+  let segment = "";
+  while (i < len && path[i] !== quote) {
+    if (path[i] !== "\\") {
+      segment += path[i++];
+      continue;
+    }
+    i++;
+    if (i >= len) return null;
+    const escaped = path[i];
+    switch (escaped) {
+      case "n":
+        segment += "\n";
+        break;
+      case "t":
+        segment += "\t";
+        break;
+      case "r":
+        segment += "\r";
+        break;
+      case "b":
+        segment += "\b";
+        break;
+      case "f":
+        segment += "\f";
+        break;
+      case "v":
+        segment += "\v";
+        break;
+      case "0":
+        segment += "\0";
+        break;
+      case "u": {
+        // Match the runtime's permissive parseInt, including partial hex.
+        const codePoint = i + 4 < len
+          ? Number.parseInt(path.slice(i + 1, i + 5), 16)
+          : NaN;
+        if (Number.isNaN(codePoint)) segment += escaped;
+        else {
+          segment += String.fromCharCode(codePoint);
+          i += 4;
+        }
+        break;
+      }
+      default:
+        segment += escaped;
+    }
+    i++;
+  }
+  return i >= len ? null : segment;
+}

--- a/packages/lint/src/deno/plugin.test.ts
+++ b/packages/lint/src/deno/plugin.test.ts
@@ -2,6 +2,7 @@
 // configured.  They only run under Deno.
 import assert from "node:assert/strict";
 import test from "node:test";
+import defaultPlugin, { strictPlugin } from "./plugin.ts";
 
 const isDenoRuntime = typeof Deno !== "undefined";
 
@@ -20,6 +21,10 @@ interface LintOutput {
 async function lintWithPlugin(
   sourceCode: string,
   includeRules?: string[],
+  options: {
+    readonly entryPoint?: "default" | "strict";
+    readonly exclude?: readonly string[];
+  } = {},
 ): Promise<Diagnostic[]> {
   if (!isDenoRuntime) return [];
   // @ts-ignore: Deno-only API
@@ -28,17 +33,32 @@ async function lintWithPlugin(
     // Pass the plugin as a file:// URL specifier.  An OS path (e.g. from
     // fileURLToPath) is `D:\...` on Windows, which deno.json's `plugins` array
     // does not accept; a file:// URL resolves correctly on every platform.
-    const pluginFile = includeRules?.includes(
-        "logtape/no-dynamic-message",
-      )
-      ? "./strict-plugin.ts"
-      : "./plugin.ts";
+    const strict = options.entryPoint != null
+      ? options.entryPoint === "strict"
+      : includeRules?.some((rule) =>
+        rule === "logtape/no-dynamic-message" ||
+        rule === "logtape/no-unrendered-properties"
+      );
+    const pluginFile = strict ? "./strict-plugin.ts" : "./plugin.ts";
+    // Deno can silently ignore unknown include names.  Prove the selected
+    // entry point actually exposes every requested LogTape rule first.
+    for (const rule of includeRules ?? []) {
+      if (rule.startsWith("logtape/")) {
+        assert.ok(
+          Object.hasOwn(
+            (strict ? strictPlugin : defaultPlugin).rules,
+            rule.slice("logtape/".length),
+          ),
+          `Unknown LogTape rule for ${pluginFile}: ${rule}`,
+        );
+      }
+    }
     const pluginUrl = new URL(pluginFile, import.meta.url).href;
     const denoJson = {
       unstable: ["lint"],
       lint: {
         plugins: [pluginUrl],
-        rules: includeRules == null ? undefined : { include: includeRules },
+        rules: { include: includeRules, exclude: options.exclude },
       },
     };
     // @ts-ignore: Deno-only API
@@ -56,7 +76,7 @@ async function lintWithPlugin(
       stdout: "piped",
       stderr: "piped",
     });
-    const { stdout, stderr } = await cmd.output();
+    const { stdout, stderr, code } = await cmd.output();
     const text = new TextDecoder().decode(stdout);
     // `deno lint --json` always prints a JSON document to stdout, even with
     // zero diagnostics.  Empty stdout therefore means the lint run itself
@@ -67,7 +87,10 @@ async function lintWithPlugin(
       throw new Error(`deno lint produced no output. stderr:\n${err}`);
     }
     const parsed = JSON.parse(text) as LintOutput;
-    return parsed.diagnostics ?? [];
+    assert.deepStrictEqual(parsed.errors, [], new TextDecoder().decode(stderr));
+    assert.ok(Array.isArray(parsed.diagnostics), "Missing lint diagnostics");
+    assert.strictEqual(code, parsed.diagnostics.length === 0 ? 0 : 1);
+    return parsed.diagnostics;
   } finally {
     // @ts-ignore: Deno-only API
     await Deno.remove(tmpDir, { recursive: true });
@@ -116,6 +139,7 @@ async function lintAndFix(
 }
 
 const ALL_RULES = [
+  "logtape/no-unrendered-properties",
   "logtape/no-dynamic-message",
   "logtape/no-message-interpolation",
   "logtape/prefer-lazy-evaluation",
@@ -2453,5 +2477,162 @@ function scope() {
         JSON.stringify(violations)
       }`,
     );
+  },
+);
+
+const unrenderedRule = "logtape/no-unrendered-properties";
+const dynamicRule = "logtape/no-dynamic-message";
+const optionalRulesSource = `import { getLogger } from "@logtape/logtape";
+const logger = getLogger("test");
+declare const message: string;
+logger.info(message);
+logger.info("Ready", { id: 1 });`;
+
+for (
+  const [name, entryPoint, exclude, expected] of [
+    ["default excludes optional rules", "default", [], []],
+    ["strict enables both optional rules", "strict", [], [
+      dynamicRule,
+      unrenderedRule,
+    ]],
+    ["strict excludes unrendered properties", "strict", [unrenderedRule], [
+      dynamicRule,
+    ]],
+    ["strict excludes dynamic messages", "strict", [dynamicRule], [
+      unrenderedRule,
+    ]],
+  ] as const
+) {
+  test(`deno lint: ${name}`, { skip: skipIfNotDeno }, async () => {
+    if (skipIfNotDeno) return;
+    const diagnostics = await lintWithPlugin(optionalRulesSource, undefined, {
+      entryPoint,
+      exclude,
+    });
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code).sort(),
+      [...expected].sort(),
+    );
+  });
+}
+
+test("deno lint: including unrendered properties selects strict", {
+  skip: skipIfNotDeno,
+}, async () => {
+  if (skipIfNotDeno) return;
+  const diagnostics = await lintWithPlugin(optionalRulesSource, [
+    unrenderedRule,
+  ], {
+    exclude: [dynamicRule],
+  });
+  assert.deepStrictEqual(diagnostics.map((d) => d.code), [unrenderedRule]);
+});
+
+test("deno lint: rejects unknown rules instead of returning no diagnostics", {
+  skip: skipIfNotDeno,
+}, async () => {
+  if (skipIfNotDeno) return;
+  await assert.rejects(() =>
+    lintWithPlugin(optionalRulesSource, ["logtape/not-a-rule"])
+  );
+});
+
+test(
+  "deno lint: unrendered properties handles static syntax and key locations",
+  { skip: skipIfNotDeno },
+  async () => {
+    if (skipIfNotDeno) return;
+    const source =
+      `import { getLogger as get } from "jsr:@logtape/logtape@^2.0.0";
+const logger = get("test");
+const a = 1, b = 2;
+logger.info("{a}", { a, b });
+logger.warn(\`{a}\`, () => ({ a, b }));
+await logger.error(("{a}" as const)!, async () => (({ a, b }) as const));
+logger.warning("{a}", { ["a"]: a, [\`b\`]: b });
+logger.trace("{1000}", { 1e3: a, [2]: b });
+logger.fatal("{*}", { "*": undefined, b });
+logger.with({ context: 1 }).getChild("child").debug("Ready", { b });
+get("inline").info("Ready", { b });`;
+    const diagnostics = (await lintWithPlugin(source, [unrenderedRule])).filter(
+      (d) => d.code === unrenderedRule,
+    );
+    assert.deepStrictEqual(
+      diagnostics.map((d) => d.code),
+      Array(8).fill(unrenderedRule),
+    );
+    assert.strictEqual(
+      diagnostics.filter((d) => d.message.includes("Property 'b'")).length,
+      7,
+    );
+    assert.strictEqual(
+      diagnostics.filter((d) => d.message.includes("Property '2'")).length,
+      1,
+    );
+  },
+);
+
+test(
+  "deno lint: unrendered properties preserves supported templates and overloads",
+  { skip: skipIfNotDeno },
+  async () => {
+    if (skipIfNotDeno) return;
+    const source = `import { getLogger } from "@logtape/logtape";
+const logger = getLogger("test");
+const user = { name: "Ada" }, error = new Error("Oops");
+logger.info("{user?.name}", { user });
+logger.info("{[user].name}", { user });
+logger.info('{["0"].name}', { 0: user });
+logger.info("{0.name}", { 0: user });
+logger.info("{error.message}", { "error.message": undefined, error });
+logger.info("{a{b}", { "a{b": 1 });
+logger.info("{*}", { user, error });
+logger.with({ contextId: 1 }).info("Ready", {});
+logger.info("Ready", { user, ...{ error } });
+logger.info("Ready", { [user.name]: user });
+logger.info("Ready", { 1n: user });
+logger.info("Ready", () => { return { user }; });
+logger.info("Ready", function () { return { user }; });
+logger.info({ user });
+logger.error(error);
+logger.info(l => l\`Hello \${user}\`);
+logger.info\`Hello \${user}\`;
+logger.info(["Ready"], { user });
+function run(logger: { info: (...args: unknown[]) => void }) {
+  logger.info("Ready", { user });
+}
+run(console);`;
+    const diagnostics = await lintWithPlugin(source, [unrenderedRule]);
+    assert.deepStrictEqual(
+      diagnostics.filter((d) => d.code === unrenderedRule),
+      [],
+    );
+  },
+);
+
+test(
+  "deno lint: unrendered properties handles accessors, proto keys and duplicates",
+  { skip: skipIfNotDeno },
+  async () => {
+    if (skipIfNotDeno) return;
+    const diagnostics = await lintWithPlugin(
+      `import { getLogger } from "@logtape/logtape";
+const logger = getLogger("test");
+logger.info("Ready", { __proto__: null });
+logger.info("Ready", { "__proto__": null });
+logger.info("Ready", { ["__proto__"]: null });
+logger.info("Ready", { get a() { return 1; }, b() { return 2; } });
+logger.info("Ready", { id: 1, id: 2 });`,
+      [unrenderedRule],
+    );
+    const violations = diagnostics.filter((d) => d.code === unrenderedRule);
+    assert.strictEqual(violations.length, 4);
+    for (const key of ["__proto__", "a", "b", "id"]) {
+      assert.strictEqual(
+        violations.filter((d) => d.message.includes(`Property '${key}'`))
+          .length,
+        1,
+      );
+    }
   },
 );

--- a/packages/lint/src/deno/plugin.ts
+++ b/packages/lint/src/deno/plugin.ts
@@ -24,7 +24,8 @@
  * ```
  *
  * Use `jsr:@logtape/lint/deno/strict` instead to enable the opt-in
- * `logtape/no-dynamic-message` rule.
+ * `logtape/no-dynamic-message` and `logtape/no-unrendered-properties` rules.
+ * Use `lint.rules.exclude` to disable either rule individually.
  *
  * The rule detection logic is shared with the ESLint rules via `../core/ast.ts`;
  * only the scope tracking (which the Deno Lint API does not provide a manager
@@ -42,6 +43,7 @@ import {
   configNeedsMetaSink,
   containsAwaitOrYield,
   ERROR_LOG_METHODS,
+  findUnrenderedProperties,
   isAsyncFunctionExpr,
   isLogPromiseHandled,
   isLogtapeImportSource,
@@ -1092,6 +1094,29 @@ export const strictPlugin: {
   name: "logtape",
 
   rules: {
+    /** Find properties not referenced by a static message template. */
+    "no-unrendered-properties": {
+      create(ctx: any) {
+        const scope = makeLoggerScope(ctx.sourceCode?.text ?? "");
+        return {
+          ...scope.visitors,
+          CallExpression(node: any) {
+            if (!scope.isLogtapeCallee(node.callee)) return;
+            const method = logMethodName(node.callee);
+            if (!method || !LOG_METHODS.has(method)) return;
+            for (const property of findUnrenderedProperties(node.arguments)) {
+              ctx.report({
+                node: property.node,
+                message:
+                  `Property '${property.key}' is not referenced by the ` +
+                  "message template and may be omitted by sinks that output " +
+                  "only the message.",
+              });
+            }
+          },
+        };
+      },
+    },
     /** Disallow dynamic expressions in log message arguments. */
     "no-dynamic-message": {
       create(ctx: any) {

--- a/packages/lint/src/deno/strict-plugin.ts
+++ b/packages/lint/src/deno/strict-plugin.ts
@@ -2,7 +2,9 @@
  * Deno Lint plugin providing all LogTape lint rules, including opt-in rules.
  *
  * Use this entry point instead of `@logtape/lint/deno` when enabling
- * `logtape/no-dynamic-message`.
+ * `logtape/no-dynamic-message` or `logtape/no-unrendered-properties`.
+ * Both are enabled by this entry point; use `lint.rules.exclude` to disable
+ * either rule individually.
  *
  * @module
  */

--- a/packages/lint/src/eslint/plugin.test.ts
+++ b/packages/lint/src/eslint/plugin.test.ts
@@ -7,8 +7,10 @@ test("plugin: exports meta.name", () => {
   assert.strictEqual(plugin.meta.name, "@logtape/lint");
 });
 
-test("plugin: exports all five rules", () => {
+test("plugin: exports all six rules", () => {
   assert.ok("no-dynamic-message" in rules);
+  assert.ok("no-unrendered-properties" in rules);
+  assert.strictEqual(Object.keys(rules).length, 6);
   assert.ok("no-message-interpolation" in rules);
   assert.ok("prefer-lazy-evaluation" in rules);
   assert.ok("no-unawaited-log" in rules);
@@ -27,6 +29,7 @@ test("plugin: recommended config specifies all rules", () => {
   assert.strictEqual(r["logtape/no-unawaited-log"], "error");
   assert.strictEqual(r["logtape/require-meta-sink"], "warn");
   assert.strictEqual(r["logtape/no-dynamic-message"], undefined);
+  assert.strictEqual(r["logtape/no-unrendered-properties"], undefined);
 });
 
 test("plugin: configs.recommended matches exported recommended", () => {
@@ -146,4 +149,18 @@ await logger.info("Data: {data}.", async () => ({ data: await fetchData() }));`,
     [recommended],
   );
   assert.strictEqual(messages.length, 0);
+});
+
+test("plugin integration: unrendered properties are opt-in", () => {
+  const source = `import { getLogger } from "@logtape/logtape";
+const logger = getLogger("test");
+logger.info("Ready", { id: 1 });`;
+  const linter = new Linter();
+  assert.deepStrictEqual(linter.verify(source, [recommended]), []);
+  const messages = linter.verify(source, [recommended, {
+    rules: { "logtape/no-unrendered-properties": "warn" },
+  }]);
+  assert.strictEqual(messages.length, 1);
+  assert.strictEqual(messages[0].ruleId, "logtape/no-unrendered-properties");
+  assert.strictEqual(messages[0].severity, 1);
 });

--- a/packages/lint/src/eslint/plugin.ts
+++ b/packages/lint/src/eslint/plugin.ts
@@ -13,6 +13,7 @@
  *     rules: {
  *       // Opt-in; not included in the recommended preset:
  *       "logtape/no-dynamic-message": "warn",
+ *       "logtape/no-unrendered-properties": "warn",
  *       "logtape/no-message-interpolation": "error",
  *       "logtape/prefer-lazy-evaluation": "warn",
  *       "logtape/no-unawaited-log": "error",
@@ -35,12 +36,14 @@ import type { Linter, Rule } from "eslint";
 import { noDynamicMessage } from "../rules/no-dynamic-message.ts";
 import { noMessageInterpolation } from "../rules/no-message-interpolation.ts";
 import { noUnawaitedLog } from "../rules/no-unawaited-log.ts";
+import { noUnrenderedProperties } from "../rules/no-unrendered-properties.ts";
 import { preferLazyEvaluation } from "../rules/prefer-lazy-evaluation.ts";
 import { requireMetaSink } from "../rules/require-meta-sink.ts";
 
 export { noDynamicMessage } from "../rules/no-dynamic-message.ts";
 export { noMessageInterpolation } from "../rules/no-message-interpolation.ts";
 export { noUnawaitedLog } from "../rules/no-unawaited-log.ts";
+export { noUnrenderedProperties } from "../rules/no-unrendered-properties.ts";
 export { preferLazyEvaluation } from "../rules/prefer-lazy-evaluation.ts";
 export { requireMetaSink } from "../rules/require-meta-sink.ts";
 
@@ -52,6 +55,7 @@ export const rules: Record<string, Rule.RuleModule> = {
   "no-message-interpolation": noMessageInterpolation,
   "prefer-lazy-evaluation": preferLazyEvaluation,
   "no-unawaited-log": noUnawaitedLog,
+  "no-unrendered-properties": noUnrenderedProperties,
   "require-meta-sink": requireMetaSink,
 };
 

--- a/packages/lint/src/mod.ts
+++ b/packages/lint/src/mod.ts
@@ -13,6 +13,7 @@ export {
   noDynamicMessage,
   noMessageInterpolation,
   noUnawaitedLog,
+  noUnrenderedProperties,
   plugin,
   plugin as default,
   preferLazyEvaluation,

--- a/packages/lint/src/rules/no-unrendered-properties.test.ts
+++ b/packages/lint/src/rules/no-unrendered-properties.test.ts
@@ -1,0 +1,230 @@
+import * as tsParser from "@typescript-eslint/parser";
+import { Linter } from "eslint";
+import assert from "node:assert/strict";
+import test from "node:test";
+import { noUnrenderedProperties } from "./no-unrendered-properties.ts";
+
+const ruleName = "logtape/no-unrendered-properties";
+const preamble =
+  'import { getLogger } from "@logtape/logtape"; const logger = getLogger("test");\n';
+
+function lint(source: string, typescript = false): Linter.LintMessage[] {
+  return new Linter().verify(source, [{
+    plugins: {
+      logtape: {
+        rules: { "no-unrendered-properties": noUnrenderedProperties },
+      },
+    },
+    rules: { [ruleName]: "warn" },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      ...(typescript ? { parser: tsParser } : {}),
+    },
+  }]);
+}
+
+test("no-unrendered-properties: reports each omitted key at warning severity", () => {
+  const messages = lint(
+    preamble + 'logger.error("{op}: {type}", { op, type, error, id });',
+  );
+  assert.deepStrictEqual(
+    messages.map((m) => ({ id: m.messageId, severity: m.severity })),
+    [
+      { id: "unrenderedProperty", severity: 1 },
+      { id: "unrenderedProperty", severity: 1 },
+    ],
+  );
+  assert.match(messages[0].message, /Property 'error'/);
+  assert.match(messages[1].message, /Property 'id'/);
+  for (const message of messages) {
+    assert.strictEqual(message.fix, undefined);
+    assert.strictEqual(message.suggestions, undefined);
+  }
+});
+
+const cases: readonly [string, string, readonly string[]][] = [
+  ["matched fields", 'logger.info("{a} {b}", { a, b });', []],
+  [
+    "renamed value",
+    'logger.info("{reason}", { reason: e.message, error: e });',
+    ["error"],
+  ],
+  ["static backticks", "logger.info(`{a}`, { a, b });", ["b"]],
+  ["sync arrow", 'logger.info("{a}", () => ({ a, b }));', ["b"]],
+  ["async arrow", 'logger.info("{a}", async () => ({ a, b }));', ["b"]],
+  ["no fields", 'logger.info("Ready", {});', []],
+  ["literal asterisk", 'logger.info("{*}", { "*": undefined, error });', [
+    "error",
+  ]],
+  [
+    "numeric keys",
+    'logger.info("{1000} {16}", { 1e3: a, 0x10: b, 1.50: c });',
+    ["1.5"],
+  ],
+  [
+    "computed literal keys",
+    'logger.info("{a}", { ["a"]: a, [`b`]: b, [2]: c });',
+    ["b", "2"],
+  ],
+  ["duplicate field", 'logger.info("Ready", { a: 1, a: 2 });', ["a"]],
+  [
+    "accessors and methods",
+    'logger.info("Ready", { get a() { throw 1; }, set b(value) {}, c() {} });',
+    ["a", "b", "c"],
+  ],
+  ["prototype setter", 'logger.info("Ready", { __proto__: null, a });', ["a"]],
+  [
+    "quoted prototype setter",
+    'logger.info("Ready", { "__proto__": null, a });',
+    ["a"],
+  ],
+  [
+    "computed proto property",
+    'logger.info("Ready", { ["__proto__"]: null });',
+    ["__proto__"],
+  ],
+  ["shorthand proto property", 'logger.info("Ready", { __proto__ });', [
+    "__proto__",
+  ]],
+  [
+    "proto accessor",
+    'logger.info("Ready", { get __proto__() { return null; } });',
+    ["__proto__"],
+  ],
+  [
+    "context fields ignored",
+    'logger.with({ contextId }).info("{a}", { a });',
+    [],
+  ],
+  [
+    "new contextual fields",
+    'logger.with({ contextId }).getChild("child").info("Ready", { a });',
+    ["a"],
+  ],
+  ["inline getter", 'getLogger("child").info("Ready", { a });', ["a"]],
+  ["spread bag", 'logger.info("Ready", { a, ...rest });', []],
+  ["unknown computed key", 'logger.info("Ready", { a, [key]: b });', []],
+  ["bigint key", 'logger.info("Ready", { 1n: a, b });', []],
+  ["dynamic message", "logger.info(message, { a });", []],
+  ["concatenated message", 'logger.info("Ready" + suffix, { a });', []],
+  ["interpolated message", "logger.info(`Ready ${id}`, { a });", []],
+  ["referenced bag", 'logger.info("Ready", properties);', []],
+  ["block callback", 'logger.info("Ready", () => { return { a }; });', []],
+  [
+    "function callback",
+    'logger.info("Ready", function () { return { a }; });',
+    [],
+  ],
+  ["properties-only overload", "logger.info({ a });", []],
+  ["error-first overload", 'logger.error(new Error("Oops"), { a });', []],
+  ["error-second overload", 'logger.error("Oops", new Error("Oops"));', []],
+  ["callback overload", "logger.info(l => l`Ready ${id}`, { a });", []],
+  ["tagged template overload", "logger.info`Ready ${{ a }}`;", []],
+  ["array template overload", 'logger.info(["Ready"], { a });', []],
+  ["unrelated method", 'logger.getChild("child", { a });', []],
+  ["unrelated object", 'console.info("Ready", { a });', []],
+  [
+    "shadowed logger",
+    'function run(logger) { logger.info("Ready", { a }); }',
+    [],
+  ],
+];
+for (const [name, source, keys] of cases) {
+  test(`no-unrendered-properties: ${name}`, () => {
+    const messages = lint(preamble + source);
+    assert.deepStrictEqual(
+      messages.map((m) => m.ruleId),
+      keys.map(() => ruleName),
+    );
+    assert.deepStrictEqual(
+      messages.map((m) => m.message),
+      keys.map((key) =>
+        `Property '${key}' is not referenced by the message template and may be omitted by sinks that output only the message.`
+      ),
+    );
+  });
+}
+
+test("no-unrendered-properties: reports the last duplicate key location", () => {
+  const messages = lint(preamble + 'logger.info("Ready", { a: 1, a: 2 });');
+  assert.strictEqual(messages.length, 1);
+  assert.strictEqual(messages[0].line, 2);
+  assert.strictEqual(messages[0].column, 30);
+  assert.strictEqual(messages[0].endColumn, 31);
+});
+
+test("no-unrendered-properties: supports every log level and computed method", () => {
+  for (
+    const method of [
+      "trace",
+      "debug",
+      "info",
+      "warn",
+      "warning",
+      "error",
+      "fatal",
+    ]
+  ) {
+    assert.strictEqual(
+      lint(preamble + `logger.${method}("Ready", { a });`).length,
+      1,
+    );
+    assert.strictEqual(
+      lint(preamble + `logger["${method}"]("Ready", { a });`).length,
+      1,
+    );
+  }
+});
+
+test("no-unrendered-properties: recognizes aliased and versioned imports", () => {
+  for (
+    const specifier of [
+      "@logtape/logtape",
+      "jsr:@logtape/logtape@^2.0.0",
+      "npm:@logtape/logtape@^2.0.0",
+    ]
+  ) {
+    const messages = lint(
+      `import { getLogger as get } from "${specifier}"; const log = get("x"); log.info("Ready", { a });`,
+    );
+    assert.strictEqual(messages.length, 1);
+    assert.strictEqual(messages[0].ruleId, ruleName);
+  }
+});
+
+test("no-unrendered-properties: ignores custom factories and shadowed imports", () => {
+  assert.deepStrictEqual(
+    lint('const log = getAppLogger("x"); log.info("Ready", { a });'),
+    [],
+  );
+  assert.deepStrictEqual(
+    lint(
+      'import { getLogger } from "@logtape/logtape"; function run(getLogger) { const log = getLogger("x"); log.info("Ready", { a }); }',
+    ),
+    [],
+  );
+});
+
+test("no-unrendered-properties: unwraps TypeScript message, bag and arrow assertions", () => {
+  for (
+    const properties of [
+      "({ a } as const)",
+      "(() => ({ a } satisfies Record<string, unknown>))!",
+      "async () => (({ a }) as const)",
+    ]
+  ) {
+    const messages = lint(
+      preamble + `logger.info(("Ready" as const)!, ${properties});`,
+      true,
+    );
+    assert.strictEqual(messages.length, 1);
+    assert.strictEqual(messages[0].ruleId, ruleName);
+  }
+  const messages = lint(
+    preamble + 'logger.info("{a}", { ["a" as string]: 1, [2 as number]: 2 });',
+    true,
+  );
+  assert.strictEqual(messages.length, 1);
+  assert.match(messages[0].message, /Property '2'/);
+});

--- a/packages/lint/src/rules/no-unrendered-properties.ts
+++ b/packages/lint/src/rules/no-unrendered-properties.ts
@@ -1,0 +1,47 @@
+import type { Rule } from "eslint";
+import {
+  findUnrenderedProperties,
+  LOG_METHODS,
+  logMethodName,
+} from "../core/ast.ts";
+import { createLogtapeScope } from "../utils.ts";
+
+/**
+ * Find call-site properties not referenced by a static message template.
+ * This opt-in rule is intended for message-only outputs.  Structured sinks
+ * can retain these properties without including them in the message.
+ */
+export const noUnrenderedProperties: Rule.RuleModule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Find properties not referenced by a log message template",
+      recommended: false,
+      url: "https://logtape.org/lint/no-unrendered-properties",
+    },
+    schema: [],
+    messages: {
+      unrenderedProperty:
+        "Property '{{name}}' is not referenced by the message template and " +
+        "may be omitted by sinks that output only the message.",
+    },
+  },
+  create(context) {
+    const scope = createLogtapeScope(context);
+    return {
+      ImportDeclaration: scope.ImportDeclaration,
+      CallExpression(node) {
+        if (!scope.isLogtapeCall(node.callee, node)) return;
+        const method = logMethodName(node.callee);
+        if (!method || !LOG_METHODS.has(method)) return;
+        for (const property of findUnrenderedProperties(node.arguments)) {
+          context.report({
+            node: property.node,
+            messageId: "unrenderedProperty",
+            data: { name: property.key },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Sinks that forward only the rendered message can lose properties such as `error` in `logger.error("Failed", { error })`.  This rule flags those omissions but stays opt-in: keeping properties outside the message is a valid structured logging convention.  ESLint/Oxlint examples use `warn`; Deno users enable it through the existing strict plugin.

The adapters share template analysis that follows LogTape's escaped braces, nested paths, and wildcard precedence.  To avoid false positives, it checks only static messages with explicit property objects, including lazy arrow returns, and skips spreads or unknown keys.  Context properties are left alone. There is no autofix because choosing what to render requires judgment.
