### PR TITLE
Allow custom rotated file paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,10 @@ To be released.
  -  Added the `rotatedFilePath` option to `getRotatingFileSink()` to customize
     rotated log file paths, for example to keep the *.log* extension.
     [[#215], [#216]]
+ -  Changed `getRotatingFileSink()` to reject positive `maxFiles` values unless
+    they are integers from 1 to 1,000, throwing `RangeError` during sink
+    creation. Update configurations outside this range before upgrading.  Zero
+    and negative values still disable backups.  [[#216]]
 
 [#215]: https://github.com/dahlia/logtape/issues/215
 [#216]: https://github.com/dahlia/logtape/pull/216

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,15 @@ To be released.
 
 [#212]: https://github.com/dahlia/logtape/pull/212
 
+### @logtape/file
+
+ -  Added the `rotatedFilePath` option to `getRotatingFileSink()` to customize
+    rotated log file paths, for example to keep the *.log* extension.
+    [[#215], [#216]]
+
+[#215]: https://github.com/dahlia/logtape/issues/215
+[#216]: https://github.com/dahlia/logtape/pull/216
+
 ### @logtape/lint
 
  -  Added an opt-in `no-dynamic-message` rule to *@logtape/lint* for finding

--- a/changes.d/file/custom-rotated-file-paths.md
+++ b/changes.d/file/custom-rotated-file-paths.md
@@ -6,3 +6,8 @@ links:
  -  Added the `rotatedFilePath` option to `getRotatingFileSink()` to customize
     rotated log file paths, for example to keep the *.log* extension.
     [[#215], [#216]]
+
+ -  Changed `getRotatingFileSink()` to reject positive `maxFiles` values unless
+    they are integers from 1 to 1,000, throwing `RangeError` during sink
+    creation. Update configurations outside this range before upgrading.  Zero
+    and negative values still disable backups.  [[#216]]

--- a/changes.d/file/custom-rotated-file-paths.md
+++ b/changes.d/file/custom-rotated-file-paths.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#215': https://github.com/dahlia/logtape/issues/215
+  '#216': https://github.com/dahlia/logtape/pull/216
+---
+ -  Added the `rotatedFilePath` option to `getRotatingFileSink()` to customize
+    rotated log file paths, for example to keep the *.log* extension.
+    [[#215], [#216]]

--- a/docs/sinks/file.md
+++ b/docs/sinks/file.md
@@ -211,6 +211,12 @@ and so on.
 For more details, see `getRotatingFileSink()` function and
 `RotatingFileSinkOptions` interface in the API reference.
 
+Since LogTape 2.4.0, positive `~RotatingFileSinkOptions.maxFiles` values must be
+integers no greater than 1,000.  Larger values throw `RangeError` during sink
+creation, before any file is opened.  This limits the work and memory needed
+to compute and cache backup paths.  Zero or negative values still discard the
+active file on rotation without keeping backups.
+
 > [!TIP]
 > Like regular file sinks, rotating file sinks support buffering through the
 > `~FileSinkOptions.bufferSize` option (default: 8192 characters) and time-based

--- a/docs/sinks/file.md
+++ b/docs/sinks/file.md
@@ -205,7 +205,8 @@ await configure({
 });
 ~~~~
 
-Rotated log files are named with a suffix like *.1*, *.2*, *.3*, and so on.
+By default, rotated log files are named with a suffix like *.1*, *.2*, *.3*,
+and so on.
 
 For more details, see `getRotatingFileSink()` function and
 `RotatingFileSinkOptions` interface in the API reference.
@@ -222,6 +223,39 @@ For more details, see `getRotatingFileSink()` function and
 > [!NOTE]
 > On Deno, you need to have the `--allow-write` flag and the `--unstable-fs`
 > flag to use the rotating file sink.
+
+### Custom rotated file paths
+
+*This option is available since LogTape 2.4.0.*
+
+Use `~RotatingFileSinkOptions.rotatedFilePath` to choose the paths of rotated
+files.  For example, to keep the *.log* extension:
+
+~~~~ typescript twoslash
+import { getRotatingFileSink } from "@logtape/file";
+
+const sink = getRotatingFileSink("my-app.log", {
+  rotatedFilePath: (path, index) => path.replace(/(\.log)?$/, `.${index}$1`),
+});
+~~~~
+
+This produces *my-app.1.log*, *my-app.2.log*, and so on, instead of the default
+*my-app.log.1*, *my-app.log.2*.  The active file remains *my-app.log*.  This
+example also handles extensionless paths and preserves the directory.
+
+The callback receives the original path and a backup index starting at 1 for
+the newest backup.  Return a complete path; relative paths are relative to the
+current working directory, not the active file's directory.  The sink computes
+these paths when it is created, before opening the file, and reuses them for
+subsequent rotations.  A callback exception fails sink creation in both blocking
+and non-blocking modes.  The callback is not called when
+`~RotatingFileSinkOptions.maxFiles` is zero or negative.
+
+Return the same path for the same arguments, including when recreating the sink.
+Each backup must have a distinct path and must not refer to the active log file.
+Parent directories must already exist, and the filesystem must support renaming
+between the paths.  If you change the naming scheme, handle backups created
+under the previous scheme yourself; the sink does not migrate or remove them.
 
 
 Time-based rotating file sink

--- a/packages/file/src/entrypoints.test.ts
+++ b/packages/file/src/entrypoints.test.ts
@@ -45,3 +45,35 @@ function checkFileSinks(sinks: FileSinks): void {
 test("@logtape/file root exports working file sinks", async () => {
   checkFileSinks(await import("@logtape/file"));
 });
+
+test("@logtape/file root exports support custom rotation paths", async () => {
+  const { getRotatingFileSink } = await import("@logtape/file");
+  const directory = fs.mkdtempSync(join(tmpdir(), "logtape-entrypoints-"));
+  const path = join(directory, "app.log");
+  let payload = "A\n";
+  try {
+    const sink = getRotatingFileSink(path, {
+      maxSize: 2,
+      maxFiles: 1,
+      bufferSize: 0,
+      flushInterval: 0,
+      formatter: () => payload,
+      rotatedFilePath: (path, index) =>
+        path.replace(/(\.log)?$/, `.${index}$1`),
+    });
+    try {
+      sink(info);
+      payload = "B\n";
+      sink(info);
+    } finally {
+      sink[Symbol.dispose]();
+    }
+    assert.strictEqual(fs.readFileSync(path, "utf8"), "B\n");
+    assert.strictEqual(
+      fs.readFileSync(join(directory, "app.1.log"), "utf8"),
+      "A\n",
+    );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/file/src/filesink.base.ts
+++ b/packages/file/src/filesink.base.ts
@@ -665,6 +665,29 @@ export interface RotatingFileSinkOptions extends Omit<FileSinkOptions, "lazy"> {
    * The maximum number of files to keep.  5 by default.
    */
   maxFiles?: number;
+
+  /**
+   * Generates a path for a rotated log file.  By default, appends a dot and
+   * the index to the original path (e.g., `app.log.1`).
+   *
+   * Paths are computed when the sink is created, before opening the file,
+   * and reused for subsequent rotations.  If this function throws, sink
+   * creation throws the same error, including in non-blocking mode.
+   * It is not called when `maxFiles` is zero or negative.
+   *
+   * The function must return the same path for the same arguments, including
+   * when recreating the sink.  Each index must refer to a different file,
+   * distinct from the active log file.  Parent directories must already exist
+   * and the filesystem must support renaming between the paths.
+   * Changing this function does not migrate or remove previously named backups.
+   *
+   * @param path The original log file path, as passed to the sink.
+   * @param index The backup index, starting at 1 for the newest backup.
+   * @returns The complete backup path.  Relative paths are relative to the
+   *          current working directory, not the original file's directory.
+   * @since 2.4.0
+   */
+  rotatedFilePath?: (path: string, index: number) => string;
 }
 
 /**
@@ -729,9 +752,11 @@ function isFileNotFoundError(error: unknown): boolean {
  * Get a platform-independent rotating file sink.
  *
  * This sink writes log records to a file, and rotates the file when it reaches
- * the `maxSize`.  The rotated files are named with the original file name
+ * the `maxSize`.  By default, rotated files are named with the original file name
  * followed by a dot and a number, starting from 1.  The number is incremented
  * for each rotation, and the maximum number of files to keep is `maxFiles`.
+ * The {@link RotatingFileSinkOptions.rotatedFilePath} option customizes the
+ * paths of rotated files.
  *
  * @param path A path to the file to write to.
  * @param options The options for the sink and the file driver.
@@ -762,6 +787,24 @@ export function getBaseRotatingFileSink<TFile>(
   if (maxFiles <= 0 && options.unlinkSync == null) {
     throw new TypeError("maxFiles <= 0 requires unlinkSync support.");
   }
+  // Finish all user callback calls before acquiring a file handle.
+  const rotation = maxFiles <= 0 ? null : (() => {
+    const rotatedFilePath = options.rotatedFilePath ??
+      ((path: string, index: number): string => `${path}.${index}`);
+    const paths = new Map<number, string>();
+    function getPath(index: number): string {
+      const cached = paths.get(index);
+      if (cached !== undefined) return cached;
+      const result = rotatedFilePath(path, index);
+      paths.set(index, result);
+      return result;
+    }
+    const backupTuples: [string, string][] = [];
+    for (let i = maxFiles - 1; i > 0; i--) {
+      backupTuples.push([getPath(i), getPath(i + 1)]);
+    }
+    return { backupTuples, activeDestination: getPath(1) };
+  })();
   let offset: number = 0;
   try {
     const stat = options.statSync(path);
@@ -777,7 +820,7 @@ export function getBaseRotatingFileSink<TFile>(
     return offset + bytes.length > maxSize;
   }
   function performRollover(): void {
-    if (maxFiles <= 0) {
+    if (rotation == null) {
       const unlinkSync = options.unlinkSync;
       if (unlinkSync == null) return;
 
@@ -802,16 +845,14 @@ export function getBaseRotatingFileSink<TFile>(
 
     options.closeSync(fd);
 
-    for (let i = maxFiles - 1; i > 0; i--) {
-      const oldPath = `${path}.${i}`;
-      const newPath = `${path}.${i + 1}`;
+    for (const [oldPath, newPath] of rotation.backupTuples) {
       try {
         options.renameSync(oldPath, newPath);
       } catch (_) {
         // Continue if the file does not exist.
       }
     }
-    options.renameSync(path, `${path}.1`);
+    options.renameSync(path, rotation.activeDestination);
     offset = 0;
     fd = options.openSync(path);
   }

--- a/packages/file/src/filesink.base.ts
+++ b/packages/file/src/filesink.base.ts
@@ -663,8 +663,9 @@ export interface RotatingFileSinkOptions extends Omit<FileSinkOptions, "lazy"> {
 
   /**
    * The maximum number of files to keep.  5 by default.
-   * Positive values must be safe integers; otherwise a {@link RangeError}
-   * is thrown.
+   * Positive values must be integers no greater than 1000; otherwise a
+   * {@link RangeError} is thrown.  This bounds the number of backup paths
+   * computed and cached during sink creation.
    */
   maxFiles?: number;
 
@@ -784,8 +785,8 @@ export function getBaseRotatingFileSink<TFile>(
   const encoder = options.encoder ?? new TextEncoder();
   const maxSize = options.maxSize ?? 1024 * 1024;
   const maxFiles = options.maxFiles ?? 5;
-  if (maxFiles > 0 && !Number.isSafeInteger(maxFiles)) {
-    throw new RangeError("Positive maxFiles must be a safe integer.");
+  if (maxFiles > 0 && (!Number.isSafeInteger(maxFiles) || maxFiles > 1000)) {
+    throw new RangeError("Positive maxFiles must be an integer at most 1000.");
   }
   const bufferSize = options.bufferSize ?? 1024 * 8; // Default buffer size of 8192 chars
   const flushInterval = options.flushInterval ?? 5000; // Default flush interval of 5 seconds

--- a/packages/file/src/filesink.base.ts
+++ b/packages/file/src/filesink.base.ts
@@ -663,7 +663,8 @@ export interface RotatingFileSinkOptions extends Omit<FileSinkOptions, "lazy"> {
 
   /**
    * The maximum number of files to keep.  5 by default.
-   * Positive infinity is rejected with a {@link RangeError}.
+   * Positive values must be safe integers; otherwise a {@link RangeError}
+   * is thrown.
    */
   maxFiles?: number;
 
@@ -783,8 +784,8 @@ export function getBaseRotatingFileSink<TFile>(
   const encoder = options.encoder ?? new TextEncoder();
   const maxSize = options.maxSize ?? 1024 * 1024;
   const maxFiles = options.maxFiles ?? 5;
-  if (maxFiles === Infinity) {
-    throw new RangeError("maxFiles must not be positive infinity.");
+  if (maxFiles > 0 && !Number.isSafeInteger(maxFiles)) {
+    throw new RangeError("Positive maxFiles must be a safe integer.");
   }
   const bufferSize = options.bufferSize ?? 1024 * 8; // Default buffer size of 8192 chars
   const flushInterval = options.flushInterval ?? 5000; // Default flush interval of 5 seconds

--- a/packages/file/src/filesink.base.ts
+++ b/packages/file/src/filesink.base.ts
@@ -663,6 +663,7 @@ export interface RotatingFileSinkOptions extends Omit<FileSinkOptions, "lazy"> {
 
   /**
    * The maximum number of files to keep.  5 by default.
+   * Positive infinity is rejected with a {@link RangeError}.
    */
   maxFiles?: number;
 
@@ -782,6 +783,9 @@ export function getBaseRotatingFileSink<TFile>(
   const encoder = options.encoder ?? new TextEncoder();
   const maxSize = options.maxSize ?? 1024 * 1024;
   const maxFiles = options.maxFiles ?? 5;
+  if (maxFiles === Infinity) {
+    throw new RangeError("maxFiles must not be positive infinity.");
+  }
   const bufferSize = options.bufferSize ?? 1024 * 8; // Default buffer size of 8192 chars
   const flushInterval = options.flushInterval ?? 5000; // Default flush interval of 5 seconds
   if (maxFiles <= 0 && options.unlinkSync == null) {

--- a/packages/file/src/filesink.factory.deno.ts
+++ b/packages/file/src/filesink.factory.deno.ts
@@ -142,9 +142,11 @@ export function createFileSinks(
    * Get a rotating file sink.
    *
    * This sink writes log records to a file, and rotates the file when it reaches
-   * the `maxSize`.  The rotated files are named with the original file name
+   * the `maxSize`.  By default, rotated files are named with the original file name
    * followed by a dot and a number, starting from 1.  The number is incremented
    * for each rotation, and the maximum number of files to keep is `maxFiles`.
+   * The {@link RotatingFileSinkOptions.rotatedFilePath} option customizes the
+   * paths of rotated files.
    *
    * Note that this function is unavailable in the browser.
    *

--- a/packages/file/src/filesink.factory.node.ts
+++ b/packages/file/src/filesink.factory.node.ts
@@ -129,9 +129,11 @@ export function createFileSinks(
    * Get a rotating file sink.
    *
    * This sink writes log records to a file, and rotates the file when it reaches
-   * the `maxSize`.  The rotated files are named with the original file name
+   * the `maxSize`.  By default, rotated files are named with the original file name
    * followed by a dot and a number, starting from 1.  The number is incremented
    * for each rotation, and the maximum number of files to keep is `maxFiles`.
+   * The {@link RotatingFileSinkOptions.rotatedFilePath} option customizes the
+   * paths of rotated files.
    *
    * Note that this function is unavailable in the browser.
    *

--- a/packages/file/src/filesink.factory.test.ts
+++ b/packages/file/src/filesink.factory.test.ts
@@ -38,9 +38,14 @@ function checkFactory<TFile>(
   assert.deepStrictEqual(calls, []);
   for (const nonBlocking of [false, true]) {
     const options = { nonBlocking, bufferSize: 123, flushInterval: 0 };
+    const rotatingOptions = {
+      ...options,
+      rotatedFilePath: (path: string, index: number): string =>
+        `${path}-${index}`,
+    };
     assert.strictEqual(result.getFileSink("file.log", options), sink);
     assert.strictEqual(
-      result.getRotatingFileSink("rotating.log", options),
+      result.getRotatingFileSink("rotating.log", rotatingOptions),
       sink,
     );
     assert.strictEqual(
@@ -54,7 +59,7 @@ function checkFactory<TFile>(
       {
         kind: "rotating",
         path: "rotating.log",
-        options: { ...options, ...driver },
+        options: { ...rotatingOptions, ...driver },
       },
       {
         kind: "time",

--- a/packages/file/src/filesink.jsr.ts
+++ b/packages/file/src/filesink.jsr.ts
@@ -57,9 +57,11 @@ export function getFileSink(
  * Get a rotating file sink.
  *
  * This sink writes log records to a file, and rotates the file when it reaches
- * the `maxSize`.  The rotated files are named with the original file name
+ * the `maxSize`.  By default, rotated files are named with the original file name
  * followed by a dot and a number, starting from 1.  The number is incremented
  * for each rotation, and the maximum number of files to keep is `maxFiles`.
+ * The {@link RotatingFileSinkOptions.rotatedFilePath} option customizes the
+ * paths of rotated files.
  *
  * Note that this function is unavailable in the browser.
  *

--- a/packages/file/src/filesink.test.ts
+++ b/packages/file/src/filesink.test.ts
@@ -928,7 +928,7 @@ for (const nonBlocking of [false, true]) {
     }
   }
 
-  for (const maxFiles of [0, -1]) {
+  for (const maxFiles of [0, -1, -Infinity]) {
     test(`getRotatingFileSink() skips path generation with maxFiles: ${maxFiles}, nonBlocking: ${nonBlocking}`, async () => {
       const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
       const path = join(directory, "app.log");
@@ -964,23 +964,34 @@ for (const nonBlocking of [false, true]) {
     });
   }
 
-  test(`getBaseRotatingFileSink() rejects infinite maxFiles before side effects with nonBlocking: ${nonBlocking}`, () => {
-    assert.throws(() =>
-      getBaseRotatingFileSink("app.log", {
-        ...makeNodeRotatingFileDriver(),
-        maxFiles: Infinity,
-        nonBlocking,
-        rotatedFilePath(): string {
-          assert.fail("Must reject before generating backup paths.");
-        },
-        statSync(): never {
-          assert.fail("Must reject before reading file metadata.");
-        },
-        openSync(): never {
-          assert.fail("Must reject before opening a file.");
-        },
-      }), { name: "RangeError", message: /maxFiles/ });
-  });
+  for (
+    const maxFiles of [
+      Infinity,
+      2 ** 54,
+      Number.MAX_VALUE,
+      Number.MAX_SAFE_INTEGER + 1,
+      0.5,
+      1.5,
+    ]
+  ) {
+    test(`getBaseRotatingFileSink() rejects maxFiles: ${maxFiles} before side effects with nonBlocking: ${nonBlocking}`, () => {
+      assert.throws(() =>
+        getBaseRotatingFileSink("app.log", {
+          ...makeNodeRotatingFileDriver(),
+          maxFiles,
+          nonBlocking,
+          rotatedFilePath(): string {
+            assert.fail("Must reject before generating backup paths.");
+          },
+          statSync(): never {
+            assert.fail("Must reject before reading file metadata.");
+          },
+          openSync(): never {
+            assert.fail("Must reject before opening a file.");
+          },
+        }), { name: "RangeError", message: /maxFiles/ });
+    });
+  }
 
   for (const existing of [false, true]) {
     test(`getBaseRotatingFileSink() path errors precede file operations with existing: ${existing}, nonBlocking: ${nonBlocking}`, () => {

--- a/packages/file/src/filesink.test.ts
+++ b/packages/file/src/filesink.test.ts
@@ -928,6 +928,44 @@ for (const nonBlocking of [false, true]) {
     }
   }
 
+  test(`getRotatingFileSink() rotates at the maxFiles upper bound with nonBlocking: ${nonBlocking}`, async () => {
+    const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
+    const path = join(directory, "app.log");
+    try {
+      fs.writeFileSync(path, "A\n");
+      fs.writeFileSync(`${path}.999`, "B\n");
+      fs.writeFileSync(`${path}.1000`, "C\n");
+      const sink = getRotatingFileSink(path, {
+        maxFiles: 1000,
+        maxSize: 2,
+        bufferSize: 0,
+        flushInterval: 0,
+        nonBlocking,
+        formatter: () => "D\n",
+      });
+      try {
+        sink(info);
+      } finally {
+        if (nonBlocking) {
+          await (sink as unknown as Sink & AsyncDisposable)
+            [Symbol.asyncDispose]();
+        } else {
+          sink[Symbol.dispose]();
+        }
+      }
+      assert.strictEqual(fs.readFileSync(path, "utf8"), "D\n");
+      assert.strictEqual(fs.readFileSync(`${path}.1`, "utf8"), "A\n");
+      assert.strictEqual(fs.readFileSync(`${path}.1000`, "utf8"), "B\n");
+      assert.deepStrictEqual(fs.readdirSync(directory).sort(), [
+        "app.log",
+        "app.log.1",
+        "app.log.1000",
+      ]);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   for (const maxFiles of [0, -1, -Infinity]) {
     test(`getRotatingFileSink() skips path generation with maxFiles: ${maxFiles}, nonBlocking: ${nonBlocking}`, async () => {
       const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
@@ -966,6 +1004,8 @@ for (const nonBlocking of [false, true]) {
 
   for (
     const maxFiles of [
+      1001,
+      Number.MAX_SAFE_INTEGER,
       Infinity,
       2 ** 54,
       Number.MAX_VALUE,

--- a/packages/file/src/filesink.test.ts
+++ b/packages/file/src/filesink.test.ts
@@ -868,6 +868,239 @@ test("getRotatingFileSink()", () => {
   sink2[Symbol.dispose]();
 });
 
+for (const nonBlocking of [false, true]) {
+  for (const custom of [false, true]) {
+    for (const maxFiles of [1, 2]) {
+      test(`getRotatingFileSink() retains ${maxFiles} ${custom ? "custom" : "default"} backups with nonBlocking: ${nonBlocking}`, async () => {
+        const directory = fs.mkdtempSync(join(tmpdir(), "logtape.rotating-"));
+        const path = join(directory, "app.log");
+        const first = custom ? "app.1.log" : "app.log.1";
+        const second = custom ? "app.2.log" : "app.log.2";
+        try {
+          // Reuse existing backups and rotate past the retention limit.
+          fs.writeFileSync(path, "A\n");
+          fs.writeFileSync(join(directory, first), "B\n");
+          if (maxFiles === 2) fs.writeFileSync(join(directory, second), "C\n");
+          for (const payload of ["D\n", "E\n", "F\n"]) {
+            const sink = getRotatingFileSink(path, {
+              maxSize: 2,
+              maxFiles,
+              bufferSize: 0,
+              flushInterval: 0,
+              nonBlocking,
+              formatter: () => payload,
+              rotatedFilePath: custom
+                ? (path: string, index: number): string =>
+                  path.replace(/(\.log)?$/, `.${index}$1`)
+                : undefined,
+            });
+            try {
+              sink(info);
+            } finally {
+              if (nonBlocking) {
+                await (sink as unknown as Sink & AsyncDisposable)
+                  [Symbol.asyncDispose]();
+              } else {
+                sink[Symbol.dispose]();
+              }
+            }
+          }
+          assert.strictEqual(fs.readFileSync(path, "utf8"), "F\n");
+          assert.strictEqual(
+            fs.readFileSync(join(directory, first), "utf8"),
+            "E\n",
+          );
+          if (maxFiles === 2) {
+            assert.strictEqual(
+              fs.readFileSync(join(directory, second), "utf8"),
+              "D\n",
+            );
+          }
+          assert.deepStrictEqual(
+            fs.readdirSync(directory).sort(),
+            (maxFiles === 2 ? ["app.log", first, second] : ["app.log", first])
+              .sort(),
+          );
+        } finally {
+          fs.rmSync(directory, { recursive: true, force: true });
+        }
+      });
+    }
+  }
+
+  for (const maxFiles of [0, -1]) {
+    test(`getRotatingFileSink() skips path generation with maxFiles: ${maxFiles}, nonBlocking: ${nonBlocking}`, async () => {
+      const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
+      const path = join(directory, "app.log");
+      try {
+        for (const payload of ["A\n", "B\n", "C\n"]) {
+          const sink = getRotatingFileSink(path, {
+            maxSize: 2,
+            maxFiles,
+            bufferSize: 0,
+            flushInterval: 0,
+            nonBlocking,
+            formatter: () => payload,
+            rotatedFilePath: () => {
+              throw new Error("No backup path should be needed.");
+            },
+          });
+          try {
+            sink(info);
+          } finally {
+            if (nonBlocking) {
+              await (sink as unknown as Sink & AsyncDisposable)
+                [Symbol.asyncDispose]();
+            } else {
+              sink[Symbol.dispose]();
+            }
+          }
+        }
+        assert.strictEqual(fs.readFileSync(path, "utf8"), "C\n");
+        assert.deepStrictEqual(fs.readdirSync(directory), ["app.log"]);
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const existing of [false, true]) {
+    test(`getBaseRotatingFileSink() path errors precede file operations with existing: ${existing}, nonBlocking: ${nonBlocking}`, () => {
+      const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
+      const path = join(directory, "app.log");
+      const failure = new Error("Cannot generate backup path.");
+      const operations: string[] = [];
+      const original = makeNodeRotatingFileDriver();
+      const driver = {
+        ...original,
+        openSync(path: string): number {
+          operations.push("open");
+          return original.openSync(path);
+        },
+        closeSync(fd: number): void {
+          operations.push("close");
+          original.closeSync(fd);
+        },
+        renameSync(oldPath: string, newPath: string): void {
+          operations.push("rename");
+          original.renameSync(oldPath, newPath);
+        },
+        unlinkSync(path: string): void {
+          operations.push("unlink");
+          fs.unlinkSync(path);
+        },
+      };
+      try {
+        if (existing) {
+          fs.writeFileSync(path, "active\n");
+          fs.writeFileSync(join(directory, "app.1.log"), "backup\n");
+        }
+        assert.throws(() =>
+          getBaseRotatingFileSink(path, {
+            ...driver,
+            maxFiles: 2,
+            nonBlocking,
+            rotatedFilePath(path: string, index: number): string {
+              if (index === 2) throw failure;
+              return path.replace(/(\.log)?$/, `.${index}$1`);
+            },
+          }), (error: unknown) => error === failure);
+        assert.deepStrictEqual(operations, []);
+        if (existing) {
+          assert.strictEqual(fs.readFileSync(path, "utf8"), "active\n");
+          assert.strictEqual(
+            fs.readFileSync(join(directory, "app.1.log"), "utf8"),
+            "backup\n",
+          );
+          assert.deepStrictEqual(fs.readdirSync(directory).sort(), [
+            "app.1.log",
+            "app.log",
+          ]);
+        } else {
+          assert.deepStrictEqual(fs.readdirSync(directory), []);
+        }
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test(`getRotatingFileSink() caches custom paths before opening with nonBlocking: ${nonBlocking}`, async () => {
+    const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
+    const path = `${directory}/./app.log`;
+    let constructing = true;
+    let generated = false;
+    let payload = "A\n";
+    try {
+      const sink = getRotatingFileSink(path, {
+        maxSize: 2,
+        maxFiles: 1,
+        bufferSize: 0,
+        flushInterval: 0,
+        nonBlocking,
+        formatter: () => payload,
+        rotatedFilePath(originalPath: string, index: number): string {
+          assert.ok(constructing);
+          assert.strictEqual(originalPath, path);
+          assert.strictEqual(fs.existsSync(path), false);
+          generated = true;
+          return originalPath.replace(/(\.log)?$/, `.${index}$1`);
+        },
+      });
+      constructing = false;
+      try {
+        assert.ok(generated);
+        sink(info);
+        payload = "B\n";
+        sink(info);
+      } finally {
+        if (nonBlocking) {
+          await (sink as unknown as Sink & AsyncDisposable)
+            [Symbol.asyncDispose]();
+        } else {
+          sink[Symbol.dispose]();
+        }
+      }
+      assert.strictEqual(fs.readFileSync(path, "utf8"), "B\n");
+      assert.strictEqual(
+        fs.readFileSync(join(directory, "app.1.log"), "utf8"),
+        "A\n",
+      );
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+test("getBaseRotatingFileSink() passes relative backup paths to the driver verbatim", () => {
+  const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));
+  const path = join(directory, "app.log");
+  const renames: [string, string][] = [];
+  try {
+    const sink = getBaseRotatingFileSink(path, {
+      ...makeNodeRotatingFileDriver(),
+      maxSize: 2,
+      maxFiles: 1,
+      bufferSize: 0,
+      flushInterval: 0,
+      formatter: () => "A\n",
+      rotatedFilePath: () => "archive.1.log",
+      renameSync(oldPath: string, newPath: string): void {
+        renames.push([oldPath, newPath]);
+      },
+    });
+    try {
+      sink(info);
+      sink(info);
+    } finally {
+      sink[Symbol.dispose]();
+    }
+    assert.deepStrictEqual(renames, [[path, "archive.1.log"]]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("getRotatingFileSink() with maxFiles <= 0", () => {
   for (const maxFiles of [0, -1]) {
     const path = makeTempFileSync();

--- a/packages/file/src/filesink.test.ts
+++ b/packages/file/src/filesink.test.ts
@@ -964,6 +964,24 @@ for (const nonBlocking of [false, true]) {
     });
   }
 
+  test(`getBaseRotatingFileSink() rejects infinite maxFiles before side effects with nonBlocking: ${nonBlocking}`, () => {
+    assert.throws(() =>
+      getBaseRotatingFileSink("app.log", {
+        ...makeNodeRotatingFileDriver(),
+        maxFiles: Infinity,
+        nonBlocking,
+        rotatedFilePath(): string {
+          assert.fail("Must reject before generating backup paths.");
+        },
+        statSync(): never {
+          assert.fail("Must reject before reading file metadata.");
+        },
+        openSync(): never {
+          assert.fail("Must reject before opening a file.");
+        },
+      }), { name: "RangeError", message: /maxFiles/ });
+  });
+
   for (const existing of [false, true]) {
     test(`getBaseRotatingFileSink() path errors precede file operations with existing: ${existing}, nonBlocking: ${nonBlocking}`, () => {
       const directory = fs.mkdtempSync(join(tmpdir(), "logtape-"));


### PR DESCRIPTION
The `rotatedFilePath` callback lets callers name backups *app.1.log* so file selectors that match the *.log* extension include them.  The default remains *app.log.1*.

Backup paths are computed once during sink creation and reused across rotations. Callback exceptions therefore fail construction before any file is opened or renamed, in both blocking/non-blocking modes.

Closes #215.
